### PR TITLE
Render emptySearch with an autoCompleteList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-#Unreleased
+# Unreleased
 Breaking changes:
 - [Autocomplete] Render empty search with an autocomplete list
 - [Autocomplete] Replace the props `loadingItemIndex` and `valid` by a new selectedItemStatus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-# Unreleased
-- [...]
+#Unreleased
+- [Autocomplete] Render empty search with an autocomplete list
 
 # v0.2.2 (07/06/2018)
 - [Autocomplete] Pass down the `bodyClassName` to the AutoCompleteList

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 #Unreleased
+Breaking changes:
 - [Autocomplete] Render empty search with an autocomplete list
+- [Autocomplete] Replace the props `loadingItemIndex` and `valid` by a new selectedItemStatus
 
 # v0.2.2 (07/06/2018)
 - [Autocomplete] Pass down the `bodyClassName` to the AutoCompleteList

--- a/src/autoComplete/autoCompleteList.unit.tsx
+++ b/src/autoComplete/autoCompleteList.unit.tsx
@@ -90,35 +90,21 @@ describe('AutoCompleteList', () => {
     })
   })
 
-  describe('#loadingItemIndex', () => {
-    it('Can display an AutoCompleteListItem in loading state', () => {
-      const wrapper = shallow(<AutoCompleteList {...defaultProps} loadingItemIndex={0} />)
-      expect(wrapper.find('AutoCompleteListItem').first().prop('status'))
-        .toBe(AutoCompleteListItem.STATUS.LOADING)
-      expect(wrapper.find('AutoCompleteListItem').last().prop('status'))
-        .toBe(AutoCompleteListItem.STATUS.DEFAULT)
-    })
-
-    it('Can display an AutoCompleteListItem in valid state', () => {
-      const wrapper = shallow(<AutoCompleteList {...defaultProps} loadingItemIndex={0} valid />)
-      expect(wrapper.find('AutoCompleteListItem').first().prop('status'))
-        .toBe(AutoCompleteListItem.STATUS.CHECKED)
-      expect(wrapper.find('AutoCompleteListItem').last().prop('status'))
-        .toBe(AutoCompleteListItem.STATUS.DEFAULT)
-    })
-
-    it('Can trigger onDoneAnimationEnd callback', () => {
-      const event = jest.fn()
-      const wrapper = mount(<AutoCompleteList
+  describe('#selectedItemStatus', () => {
+    it('displays an AutoCompleteListItem in loading state', () => {
+      const onSelectSpy = jest.fn()
+      const wrapper = shallow(
+      <AutoCompleteList
         {...defaultProps}
-        loadingItemIndex={0}
-        onDoneAnimationEnd={event}
-      />)
-
-      wrapper.setProps({ valid: true })
-      expect(event).not.toBeCalled()
-      jest.advanceTimersByTime(1500)
-      expect(event).toBeCalled()
+        onSelect={onSelectSpy}
+        selectedItemStatus={AutoCompleteListItem.STATUS.LOADING}
+      />,
+    )
+      
+      wrapper.instance().handleKeydown(fakeKeyboardEventArrowDown())
+      wrapper.instance().handleKeydown(fakeKeyboardEventArrowEnter())
+      
+      expect(wrapper.state().selectedIndex).toBe(0)
     })
   })
 })

--- a/src/autoComplete/index.tsx
+++ b/src/autoComplete/index.tsx
@@ -31,7 +31,7 @@ interface AutoCompleteProps {
   readonly renderBusy?: ({ query }: { query: query}) => React.ReactElement<any>,
   readonly renderNoResults?: ({ query }: { query: query}) => React.ReactElement<any>,
   readonly renderQuery?: (item:AutocompleteItem) => string,
-  readonly renderEmptySearch?: JSX.Element[],
+  readonly renderEmptySearch?: AutocompleteItem[],
   readonly getItemValue?: (item:AutocompleteItem) => string,
   readonly inputAddon?: React.ReactElement<any>,
   readonly placeholder?: string,
@@ -209,10 +209,12 @@ export default class AutoComplete extends Component<AutoCompleteProps, AutoCompl
 
   render() {
     const shouldDisplayEmptyState = !this.hasMinCharsForSearch() && this.props.showList
-      && this.props.renderEmptySearch.length > 0
+    && this.props.renderEmptySearch.length > 0
     const shouldDisplayBusyState = this.state.busy && this.props.showList
-    const shouldDisplayNoResults = !this.state.busy && this.state.noResults && this.props.showList
-    const shouldDisplayAutoCompleteList = this.state.items.length > 0 && !this.state.busy
+    const shouldDisplayNoResults = this.hasMinCharsForSearch() 
+      && !this.state.busy && this.state.noResults && this.props.showList
+    const shouldDisplayAutoCompleteList = this.hasMinCharsForSearch() 
+      && this.state.items.length > 0 && !this.state.busy
       && this.props.showList
 
     return (
@@ -249,25 +251,14 @@ export default class AutoComplete extends Component<AutoCompleteProps, AutoCompl
             { this.props.renderNoResults({ query: this.state.query }) }
           </div>
         )}
-        { shouldDisplayEmptyState && (
-          <ul>
-            { this.props.renderEmptySearch.map((item, index) => {
-              if (isValidElement(item)) {
-                const props:Partial<ItemChoiceProps> = { key: index }
-                return cloneElement(item as React.ReactElement<ItemChoiceProps>, props)
-              }
-              return null
-            })}
-          </ul>
-        )}
         <AutoCompleteList
           className={this.props.bodyClassName}
           name={`${this.props.name}-list`}
-          items={this.state.items}
+          items={shouldDisplayAutoCompleteList ? this.state.items : this.props.renderEmptySearch}
           maxItems={this.props.maxItems}
           renderItem={this.props.renderItem}
           onSelect={this.onSelectItem}
-          visible={shouldDisplayAutoCompleteList}
+          visible={shouldDisplayAutoCompleteList || shouldDisplayEmptyState}
           loadingItemIndex={this.props.loadingItemIndex}
           itemClassName={this.props.itemClassName}
           valid={this.props.valid}

--- a/src/autoComplete/index.tsx
+++ b/src/autoComplete/index.tsx
@@ -4,7 +4,7 @@ import cc from 'classcat'
 import debounce from 'lodash.debounce'
 import prefix from '_utils'
 import TextField from 'textField'
-import ItemChoice, { ItemChoiceProps } from 'itemChoice'
+import { ItemChoiceStatus } from 'itemChoice'
 import AutoCompleteList from './autoCompleteList'
 import AutoCompleteListItemDefault from './autoCompleteListItemDefault'
 import style from './style'
@@ -39,16 +39,15 @@ interface AutoCompleteProps {
   readonly debounceTimeout?: number,
   readonly autoFocus?: boolean,
   readonly focus?: boolean,
-  readonly loadingItemIndex?: number,
   readonly buttonTitle?: string,
   readonly showList?: boolean,
-  readonly valid?: boolean,
   readonly onDoneAnimationEnd?: () => void,
   readonly autoCorrect?: 'on' | 'off',
   readonly disabled?: boolean,
   readonly readOnly?: boolean,
   readonly required?: boolean,
   readonly error?: string | JSX.Element,
+  readonly selectedItemStatus?: ItemChoiceStatus,
 }
 
 interface AutoCompleteState {
@@ -91,10 +90,8 @@ export default class AutoComplete extends Component<AutoCompleteProps, AutoCompl
     autoFocus: false,
     focus: false,
     buttonTitle: null,
-    loadingItemIndex: -1,
     defaultValue: '',
     showList: true,
-    valid: false,
     autoCorrect: 'off',
     disabled: false,
     readOnly: false,
@@ -216,7 +213,9 @@ export default class AutoComplete extends Component<AutoCompleteProps, AutoCompl
     const shouldDisplayAutoCompleteList = this.hasMinCharsForSearch() 
       && this.state.items.length > 0 && !this.state.busy
       && this.props.showList
-
+    const listItems = shouldDisplayAutoCompleteList ? (
+      this.state.items
+     ) : this.props.renderEmptySearch
     return (
       <div role="search" className={cc([prefix({ autoComplete: true }), this.props.className])}>
         <TextField
@@ -254,14 +253,13 @@ export default class AutoComplete extends Component<AutoCompleteProps, AutoCompl
         <AutoCompleteList
           className={this.props.bodyClassName}
           name={`${this.props.name}-list`}
-          items={shouldDisplayAutoCompleteList ? this.state.items : this.props.renderEmptySearch}
+          items={listItems}
           maxItems={this.props.maxItems}
           renderItem={this.props.renderItem}
           onSelect={this.onSelectItem}
           visible={shouldDisplayAutoCompleteList || shouldDisplayEmptyState}
-          loadingItemIndex={this.props.loadingItemIndex}
+          selectedItemStatus={this.props.selectedItemStatus}
           itemClassName={this.props.itemClassName}
-          valid={this.props.valid}
           onDoneAnimationEnd={this.props.onDoneAnimationEnd}
         />
         <style jsx>{style}</style>

--- a/src/autoComplete/index.unit.tsx
+++ b/src/autoComplete/index.unit.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import AutoComplete from 'autoComplete'
+import AutoCompleteListItem from './AutoCompleteListItem'
 
 const initialFakeItems = [
   { id: '1', title: 'title1', description: 'description1' },
@@ -65,14 +66,15 @@ describe('AutoComplete', () => {
     const event = jest.fn()
     const wrapper = mount(<AutoComplete
       {...defaultProps}
-      loadingItemIndex={0}
       onDoneAnimationEnd={event}
+      selectedItemStatus={AutoCompleteListItem.STATUS.CHECKED}
     />)
     wrapper.instance().onInputChange({ value: 'title' })
 
+    const items = fakeSearchForItems()
     wrapper.setProps({ isSearching: true })
-    wrapper.setProps({ items: fakeSearchForItems(), isSearching: false })
-    wrapper.setProps({ valid: true })
+    wrapper.setProps({ items, isSearching: false })
+    wrapper.find('li').first().simulate('mousedown')
 
     expect(event).not.toBeCalled()
     jest.advanceTimersByTime(1500)

--- a/src/autoComplete/index.unit.tsx
+++ b/src/autoComplete/index.unit.tsx
@@ -68,6 +68,7 @@ describe('AutoComplete', () => {
       loadingItemIndex={0}
       onDoneAnimationEnd={event}
     />)
+    wrapper.instance().onInputChange({ value: 'title' })
 
     wrapper.setProps({ isSearching: true })
     wrapper.setProps({ items: fakeSearchForItems(), isSearching: false })
@@ -83,7 +84,9 @@ describe('AutoComplete', () => {
       const wrapper = mount(<AutoComplete
         {...defaultProps}
         renderItem={item => <div className="custom-item">{item.title}</div>}
-      />)
+      />)     
+      wrapper.instance().onInputChange({ value: 'title' })
+
       wrapper.setProps({ isSearching: true })
       wrapper.setProps({ items: fakeSearchForItems(), isSearching: false })
       expect(wrapper.find('.custom-item')).toHaveLength(2)
@@ -96,6 +99,8 @@ describe('AutoComplete', () => {
         {...defaultProps}
         maxItems={1}
       />)
+      wrapper.instance().onInputChange({ value: 'title' })
+
       wrapper.setProps({ isSearching: true })
       wrapper.setProps({ items: fakeSearchForItems(), isSearching: false })
       expect(wrapper.find('li')).toHaveLength(1)
@@ -201,6 +206,36 @@ describe('AutoComplete', () => {
     })
   })
 
+  describe('renderEmptySearch', () => {
+    const emptySearch = [
+      { id: '1', title: 'title1', description: 'description1' },
+      { id: '2', title: 'title1', description: 'description1' },
+      { id: '3', title: 'title1', description: 'description1' },
+    ]
+    it('renders empty search when query is lower than minChar', () => {
+      const wrapper = mount(<AutoComplete
+        {...defaultProps}
+        renderEmptySearch={emptySearch}
+        renderBusy={() => <div className="busy" />}
+      />)
+
+      expect(wrapper.find('li')).toHaveLength(emptySearch.length)
+    })
+
+    it('renders the result list when query is greater than minChar', () => {
+      const wrapper = mount(<AutoComplete
+        {...defaultProps}
+        renderEmptySearch={emptySearch}
+        renderBusy={() => <div className="busy" />}
+      />)
+      wrapper.instance().onInputChange({ value: 'Lyon' })
+      wrapper.setProps({ isSearching: true })
+      wrapper.setProps({ items: fakeSearchForItems(), isSearching: false })
+
+      expect(wrapper.find('li')).toHaveLength(initialFakeItems.length)
+    })
+  })
+
   describe('#onInputChange', () => {
     it('Invokes `onInputChange` when typing text in TextField', () => {
       const onInputChange = jest.fn()
@@ -221,6 +256,7 @@ describe('AutoComplete', () => {
         {...defaultProps}
         onSelect={onSelectSpy}
       />)
+      wrapper.instance().onInputChange({ value: 'title' })
 
       const items = fakeSearchForItems()
       wrapper.setProps({ isSearching: true })
@@ -254,6 +290,7 @@ describe('AutoComplete', () => {
         onSelect={onSelectSpy}
         getItemValue={item => item.id}
       />)
+      wrapper.instance().onInputChange({ value: 'title' })
 
       const items = fakeSearchForItems()
       wrapper.setProps({ isSearching: true })
@@ -273,6 +310,7 @@ describe('AutoComplete', () => {
         {...defaultProps}
         renderQuery={item => item.id}
       />)
+      wrapper.instance().onInputChange({ value: 'title' })
 
       const items = fakeSearchForItems()
       // Simulate a "searchForItems" cycle by passing `isSearching` from `true` to `false`

--- a/src/autoComplete/index.unit.tsx
+++ b/src/autoComplete/index.unit.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import AutoComplete from 'autoComplete'
-import AutoCompleteListItem from './AutoCompleteListItem'
+import { ItemChoiceStatus } from 'itemChoice'
 
 const initialFakeItems = [
   { id: '1', title: 'title1', description: 'description1' },
@@ -67,7 +67,7 @@ describe('AutoComplete', () => {
     const wrapper = mount(<AutoComplete
       {...defaultProps}
       onDoneAnimationEnd={event}
-      selectedItemStatus={AutoCompleteListItem.STATUS.CHECKED}
+      selectedItemStatus={ItemChoiceStatus.CHECKED}
     />)
     wrapper.instance().onInputChange({ value: 'title' })
 

--- a/src/autoComplete/story.tsx
+++ b/src/autoComplete/story.tsx
@@ -19,7 +19,7 @@ const places:AutocompleteItem[] = [
 
 interface AutoCompleteExampleProps {
   readonly searchForItemsDelay?: number
-  readonly renderEmptySearch?: JSX.Element[]
+  readonly renderEmptySearch?: AutocompleteItem[]
 }
 
 interface AutoCompleteExampleState {
@@ -96,13 +96,8 @@ stories.add(
   'AutoComplete test',
   withInfo('AutoComplete')(() => {
     const emptySearch = [
-      <ItemChoice label="Test 1" />,
-      <ItemChoice label="Test 2" />,
-      <ItemChoice
-        label="Test 3"
-        subLabel="Secondary info"
-        leftAddon={<CircleIcon />}
-      />,
+      { id: '1', title: 'Get my location', description: '' },
+      { id: '2', title: 'Favorite address', description: '' },
     ]
     return <AutoCompleteExample renderEmptySearch={emptySearch} />
   }),

--- a/src/autoComplete/story.tsx
+++ b/src/autoComplete/story.tsx
@@ -2,10 +2,10 @@ import React, { Component } from 'react'
 import { storiesOf } from '@storybook/react'
 import { withInfo } from '@storybook/addon-info'
 import { action } from '@storybook/addon-actions'
+import ItemChoice, { ItemChoiceStatus } from 'itemChoice'
 import { withKnobs, number, text, boolean, select } from '@storybook/addon-knobs'
 
 import CircleIcon from 'icon/circleIcon'
-import ItemChoice from 'itemChoice'
 import AutoComplete from 'autoComplete'
 
 const stories = storiesOf('AutoComplete', module)
@@ -70,9 +70,12 @@ class AutoCompleteExample extends Component<AutoCompleteExampleProps, AutoComple
           maxItems={number('maxItems', 5)}
           showList={boolean('showList', true)}
           searchForItemsMinChars={number('searchForItemsMinChars', 3)}
-          loadingItemIndex={number('loadingItemIndex', -1)}
+          selectedItemStatus={select(
+            'selectedItemStatus', 
+            [ItemChoiceStatus.DEFAULT, ItemChoiceStatus.LOADING, ItemChoiceStatus.CHECKED], 
+            ItemChoiceStatus.DEFAULT,
+          )}
           autoCorrect={select('autoCorrect', { on:'on', off:'off' }, 'off')}
-          valid={boolean('valid', false)}
           disabled={boolean('disabled', false)}
           readOnly={boolean('readOnly', false)}
           required={boolean('required', false)}
@@ -93,7 +96,7 @@ stories.add(
 )
 
 stories.add(
-  'AutoComplete test',
+  'AutoComplete with empty search',
   withInfo('AutoComplete')(() => {
     const emptySearch = [
       { id: '1', title: 'Get my location', description: '' },


### PR DESCRIPTION
- Reuse the `autoCompleteList` to render the empty search. 
- Fix the condition of display for empty search / item list
- Refactor the loading/checked status of the list items

![image](https://user-images.githubusercontent.com/2495124/41046984-d0523cd8-69ab-11e8-837d-8935707d4401.png)
