### PR TITLE
[BBCSPA-1446] Checkbox position change and more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - [timePicker] Fix display on small devices
 - Remove deprecated updateColor() method
 - [itemChoice] Fix right content display
+- [Checkbox] Reverse label and input and made it configurable
 
 # v0.3.0 (08/06/2018)
 Breaking changes:

--- a/src/checkbox/__snapshots__/index.unit.tsx.snap
+++ b/src/checkbox/__snapshots__/index.unit.tsx.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should display the label on the left and the checkbox on the right 1`] = `
+<label
+  className="jsx-214393563 kirk-checkbox kirk-checkbox--labelDisplay-left"
+>
+  <div
+    className="jsx-214393563"
+  >
+    <input
+      checked={false}
+      className="jsx-214393563"
+      disabled={false}
+      name={undefined}
+      onChange={[Function]}
+      type="checkbox"
+      value="value"
+    />
+    <span
+      aria-hidden="true"
+      className="jsx-214393563 "
+    />
+  </div>
+  <div
+    className="jsx-214393563"
+  >
+    <span
+      className="jsx-214393563 kirk-label"
+    >
+      Label
+    </span>
+    
+  </div>
+</label>
+`;
+
+exports[`should not display either the label or the sublabel 1`] = `
+<label
+  className="jsx-214393563 kirk-checkbox kirk-checkbox--labelDisplay-none"
+>
+  <div
+    className="jsx-214393563"
+  >
+    <input
+      checked={false}
+      className="jsx-214393563"
+      disabled={false}
+      name={undefined}
+      onChange={[Function]}
+      type="checkbox"
+      value="value"
+    />
+    <span
+      aria-hidden="true"
+      className="jsx-214393563 "
+    />
+  </div>
+  <div
+    className="jsx-214393563"
+  >
+    <span
+      className="jsx-214393563 kirk-label"
+    >
+      Label
+    </span>
+    
+  </div>
+</label>
+`;

--- a/src/checkbox/index.tsx
+++ b/src/checkbox/index.tsx
@@ -11,7 +11,14 @@ export interface CheckboxProps {
   readonly value?: string,
   readonly checked?: boolean,
   readonly disabled?: boolean,
+  readonly labelDisplay?: labelDisplays,
   readonly onChange?: (obj:onChangeParameters) => void,
+}
+
+export enum labelDisplays {
+  LEFT = 'left',
+  RIGHT = 'right',
+  NONE = 'none',
 }
 
 export interface CheckboxState {
@@ -25,6 +32,7 @@ export default class Checkbox extends PureComponent <CheckboxProps, CheckboxStat
     subLabel: '',
     checked: false,
     disabled: false,
+    labelDisplay: labelDisplays.RIGHT,
   }
   state:CheckboxState = {
     isChecked: this.props.checked,
@@ -58,9 +66,22 @@ export default class Checkbox extends PureComponent <CheckboxProps, CheckboxStat
   }))
 
   render() {
-    const { className, name, children, value, subLabel } = this.props
+    const { className, name, value, children, subLabel, labelDisplay } = this.props
+
     return (
-      <label className={cc(['kirk-checkbox', className])}>
+      <label className={cc([
+        'kirk-checkbox',
+        {
+          'kirk-checkbox--labelDisplay-left': (
+            labelDisplay === labelDisplays.LEFT
+          ),
+          'kirk-checkbox--labelDisplay-none': (
+            labelDisplay === labelDisplays.NONE
+          ),
+        },
+        className,
+      ])}
+      >
         <div>
           <input
             type="checkbox"
@@ -74,7 +95,7 @@ export default class Checkbox extends PureComponent <CheckboxProps, CheckboxStat
         </div>
         <div>
           <span className="kirk-label">{children}</span>
-          { subLabel && <span className="kirk-subLabel">{subLabel}</span> }
+          {subLabel && <span className="kirk-subLabel">{subLabel}</span>}
         </div>
         <style jsx>{style}</style>
       </label>

--- a/src/checkbox/index.unit.tsx
+++ b/src/checkbox/index.unit.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
+import renderer from 'react-test-renderer'
 
-import Checkbox from 'checkbox'
+import Checkbox, { labelDisplays } from 'checkbox'
 
 it('should have the proper text & attributes', () => {
   const checkbox = shallow((
@@ -76,4 +77,20 @@ it('should trigger a change event on an async checkbox', () => {
     </Checkbox>
   ))
   checkbox.find('input').simulate('change')
+})
+
+it('should display the label on the left and the checkbox on the right', () => {
+  const checkbox = renderer.create(<Checkbox
+    labelDisplay={labelDisplays.LEFT}
+    labelFirstname="checkbox1"
+    value="value">Label</Checkbox>).toJSON()
+  expect(checkbox).toMatchSnapshot()
+})
+
+it('should not display either the label or the sublabel', () => {
+  const checkbox = renderer.create(<Checkbox
+    labelDisplay={labelDisplays.NONE}
+    labelFirstname="checkbox1"
+    value="value">Label</Checkbox>).toJSON()
+  expect(checkbox).toMatchSnapshot()
 })

--- a/src/checkbox/story.tsx
+++ b/src/checkbox/story.tsx
@@ -2,40 +2,22 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { withInfo } from '@storybook/addon-info'
 import { action } from '@storybook/addon-actions'
-import { withKnobs, text, boolean, number, select } from '@storybook/addon-knobs'
-import Checkbox from 'checkbox'
+import { withKnobs, text, boolean, selectV2 } from '@storybook/addon-knobs'
+import Checkbox, { labelDisplays } from 'checkbox'
 
 const stories = storiesOf('Checkbox', module)
 stories.addDecorator(withKnobs)
 
 stories.add(
-  'Simple checkbox',
-  withInfo('')(() => (
-    <Checkbox name="checkbox1" value="value" onChange={action('Checkbox changed')}>
-      {text('Label', 'Label checkbox')}
-    </Checkbox>
-  )),
-)
-
-stories.add(
-  'Checked checkbox',
-  withInfo('')(() => (
-    <Checkbox name="checkbox1" value="value" checked onChange={action('Checkbox changed')}>
-      {text('Label', 'Label checkbox')}
-    </Checkbox>
-  )),
-)
-
-stories.add(
-  'Checkbox with sublabel',
+  'default',
   withInfo('')(() => (
     <Checkbox
       name="checkbox1"
       value="value"
-      checked
       onChange={action('Checkbox changed')}
-      subLabel={text('Sub label', 'Sublabel checkbox')}
-    >
+      checked={boolean('Checked', false)}
+      labelDisplay={selectV2('Label display', labelDisplays, labelDisplays.RIGHT)}
+      subLabel={text('Sub label', 'Sublabel checkbox')}>
       {text('Label', 'Label checkbox')}
     </Checkbox>
   )),

--- a/src/checkbox/style.ts
+++ b/src/checkbox/style.ts
@@ -8,10 +8,14 @@ export default css`
     line-height: ${font.m.lineHeight};
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: start;
     position: relative;
     color: ${color.primaryText};
     cursor: pointer;
+  }
+
+  .kirk-checkbox.kirk-checkbox--labelDisplay-left {
+    justify-content: space-between;
   }
 
   .kirk-checkbox div {
@@ -20,8 +24,31 @@ export default css`
   }
 
   .kirk-checkbox div:first-child {
+    padding-left: 0;
+    padding-right: ${space.l};
+  }
+
+  .kirk-checkbox.kirk-checkbox--labelDisplay-left div:first-child {
     padding-left: ${space.l};
+    padding-right: 0;
     order: 2;
+  }
+
+  .kirk-checkbox.kirk-checkbox--labelDisplay-none div:first-child {
+    padding-right: 0;
+  }
+
+  .kirk-checkbox.kirk-checkbox--labelDisplay-none div:last-child {
+    /* label visually hidden (webaim.org) */
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    border: 0;
+    clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+    clip; rect(1px, 1px, 1px, 1px);
+    overflow: hidden;
   }
 
   .kirk-subLabel {


### PR DESCRIPTION
Add a prop to invert text and checkbox, defaults to checkbox before text.
Prevent empty nodes when labels are missing.
Unify stories into one entry.