### PR TITLE
Add same z-index to WarningModal as Modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- [WarningModal] fix missing z-index
 
 # v0.5.0 (28/06/2018)
 - [Icons] Add Info

--- a/src/warningModal/style.ts
+++ b/src/warningModal/style.ts
@@ -5,6 +5,7 @@ const footerHeight = '96px' /* = padding + content */
 
 export default css`
   .kirk-warningModal {
+    z-index: 999;
     position: fixed;
     top: 0;
     right: 0;


### PR DESCRIPTION
The z-index property for the Modal component is on the dimmer.
I removed the dimmer for WarningModal but forgot to reimplement the correct z-index.