### PR TITLE
[BBCSPA-1490] IE 11 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # unreleased
 - [Proximity] Adjust margins
+- [PushInfo] Fixed IE11 issues
+- [UneditableTextField] Fixed IE11 issues
 ...
 
 # v0.6.1 (19/07/2018)

--- a/src/pushInfo/__snapshots__/index.unit.tsx.snap
+++ b/src/pushInfo/__snapshots__/index.unit.tsx.snap
@@ -2,10 +2,10 @@
 
 exports[`Should also have the correct icon. 1`] = `
 <div
-  className="jsx-3843307786 kirk-pushInfo"
+  className="jsx-2073333923 kirk-pushInfo"
 >
   <div
-    className="jsx-3843307786 kirk-pushInfo-icon"
+    className="jsx-2073333923 kirk-pushInfo-icon"
   >
     <svg
       aria-hidden={true}
@@ -23,15 +23,15 @@ exports[`Should also have the correct icon. 1`] = `
     </svg>
   </div>
   <div
-    className="jsx-3843307786"
+    className="jsx-2073333923"
   >
     <h2
-      className="jsx-3843307786 kirk-pushInfo-headline"
+      className="jsx-2073333923 kirk-pushInfo-headline"
     >
       If it's green it's a win!
     </h2>
     <p
-      className="jsx-3843307786 kirk-pushInfo-content"
+      className="jsx-2073333923 kirk-pushInfo-content"
     >
       Green icons show meeting points closest to you!
     </p>
@@ -41,18 +41,18 @@ exports[`Should also have the correct icon. 1`] = `
 
 exports[`Should have the correct attributes and text. 1`] = `
 <div
-  className="jsx-3843307786 kirk-pushInfo"
+  className="jsx-2073333923 kirk-pushInfo"
 >
   <div
-    className="jsx-3843307786"
+    className="jsx-2073333923"
   >
     <h2
-      className="jsx-3843307786 kirk-pushInfo-headline"
+      className="jsx-2073333923 kirk-pushInfo-headline"
     >
       If it's green it's a win!
     </h2>
     <p
-      className="jsx-3843307786 kirk-pushInfo-content"
+      className="jsx-2073333923 kirk-pushInfo-content"
     >
       Green icons show meeting points closest to you!
     </p>

--- a/src/pushInfo/style.ts
+++ b/src/pushInfo/style.ts
@@ -51,8 +51,8 @@ export default css`
     align-items: center;
     justify-content: center;
     border-radius: 50%;
-    min-width: 40px;
-    min-height: 40px;
+    width: 40px;
+    height: 40px;
     margin-right: ${space.l};
     background-color: ${color.white};
   }

--- a/src/uneditableTextField/__snapshots__/index.unit.tsx.snap
+++ b/src/uneditableTextField/__snapshots__/index.unit.tsx.snap
@@ -5,7 +5,7 @@ exports[`UneditableTextField Should have the proper default props 1`] = `
   className="uneditableTextField"
 >
   <div
-    className="jsx-2152150793 uneditableTextField-label"
+    className="jsx-1508129181 uneditableTextField-label"
   >
     Hello world
   </div>
@@ -17,7 +17,7 @@ exports[`UneditableTextField Should have the text ellipsed 1`] = `
   className="uneditableTextField"
 >
   <div
-    className="jsx-2152150793 uneditableTextField-label uneditableTextField-label--ellipsis"
+    className="jsx-1508129181 uneditableTextField-label uneditableTextField-label--ellipsis"
   >
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec nec tristique sapien, eu placerat justo. Donec tempor, risus ac cursus fringilla, lorem ipsum facilisis tortor, vel molestie sapien justo nec orci.
   </div>
@@ -32,7 +32,7 @@ exports[`UneditableTextField Should support add-ons 1`] = `
     Add-on
   </div>
   <div
-    className="jsx-2152150793 uneditableTextField-label"
+    className="jsx-1508129181 uneditableTextField-label"
   >
     Hello world
   </div>
@@ -45,7 +45,7 @@ exports[`UneditableTextField Should support component links 1`] = `
   href="#bar"
 >
   <div
-    className="jsx-2152150793 uneditableTextField-label"
+    className="jsx-1508129181 uneditableTextField-label"
   >
     Click me
   </div>
@@ -58,7 +58,7 @@ exports[`UneditableTextField Should support simple links 1`] = `
   href="#foo"
 >
   <div
-    className="jsx-2152150793 uneditableTextField-label"
+    className="jsx-1508129181 uneditableTextField-label"
   >
     Click me
   </div>

--- a/src/uneditableTextField/style.ts
+++ b/src/uneditableTextField/style.ts
@@ -1,17 +1,19 @@
 import css from 'styled-jsx/css'
 import { color, radius, space, font } from '_utils/branding'
 
+const inputHeight = '54px'
+
 export default css`
   :global(.uneditableTextField) {
     display: flex;
     align-items: center;
-    min-height: 54px;
-    padding: ${space.m} ${space.l};
+    min-height: ${inputHeight};
+    padding: 0 ${space.l};
     background-color: ${color.inputBackground};
     border-radius: ${radius.l};
     color: ${color.primaryText};
     font-size: ${font.base.size};
-    line-height: ${font.base.lineHeight};
+    line-height: ${inputHeight};
     text-decoration: none;
   }
 
@@ -23,5 +25,9 @@ export default css`
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
+  }
+
+  :global(.uneditableTextField .kirk-icon) {
+    height: ${space.xl};
   }
 `


### PR DESCRIPTION
Fixes for UneditableTextField and PushInfo
Loader is still not working but it will require a complete change (no SVG transformation) and not a fix.

PushInfo BEFORE
<img width="212" alt="bbcspa1490-pushinfo-before" src="https://user-images.githubusercontent.com/373381/43082349-25e78c86-8e94-11e8-98cc-4944ab649dee.png">
PushInfo AFTER
<img width="215" alt="bbcspa1490-pushinfo-after" src="https://user-images.githubusercontent.com/373381/43082347-25d1970a-8e94-11e8-9b2f-f57764d015da.png">

UneditableTextField BEFORE
<img width="485" alt="bbcspa1490-utf-text-before" src="https://user-images.githubusercontent.com/373381/43082355-2640ef38-8e94-11e8-90da-ca570ae81251.png">
UneditableTextField AFTER
<img width="504" alt="bbcspa1490-utf-text-after" src="https://user-images.githubusercontent.com/373381/43082354-262a87b6-8e94-11e8-8f3c-e9c4fe36091e.png">

UneditableTextField with icon BEFORE
<img width="395" alt="bbcspa1490-utf-icon-before" src="https://user-images.githubusercontent.com/373381/43082353-261360ae-8e94-11e8-9966-087f9a2e5c02.png">
UneditableTextField with icon AFTER
<img width="259" alt="bbcspa1490-utf-icon-after" src="https://user-images.githubusercontent.com/373381/43082351-25fbc78c-8e94-11e8-9650-ece1012b8e98.png">
