### PR TITLE
fix `flush` import from `styled-jsx`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- [...]
+- [FIX] Wrong flush import from 'styled-jsx/server' (issue #42)
 
 # v0.9.0 (24/08/2018)
 

--- a/bin/templates/components.tsx
+++ b/bin/templates/components.tsx
@@ -4,7 +4,7 @@
 ${components.map(component => "import " + component.capitalized + " from '" + component.root + component.name + "'").join('\n')}
 
 import branding from '_utils/branding'
-import { flush, flushToHTML } from 'styled-jsx/server'
+import flush, { flushToHTML } from 'styled-jsx/server'
 
 export * from 'icon/index'
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,8 +35,7 @@ import WarningModal from 'warningModal'
 import Why from 'why'
 
 import branding from '_utils/branding'
-import { flushToHTML } from 'styled-jsx/server'
-import flush from 'styled-jsx/server'
+import { flush, flushToHTML } from 'styled-jsx/server'
 
 export * from 'icon/index'
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,7 +35,8 @@ import WarningModal from 'warningModal'
 import Why from 'why'
 
 import branding from '_utils/branding'
-import { flush, flushToHTML } from 'styled-jsx/server'
+import { flushToHTML } from 'styled-jsx/server'
+import flush from 'styled-jsx/server'
 
 export * from 'icon/index'
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,7 +39,7 @@ import WarningModal from 'warningModal'
 import Why from 'why'
 
 import branding from '_utils/branding'
-import { flush, flushToHTML } from 'styled-jsx/server'
+import flush, { flushToHTML } from 'styled-jsx/server'
 
 export * from 'icon/index'
 


### PR DESCRIPTION
`flush` and `flushToHTML` exports are not the same.
See usage example: https://github.com/zeit/styled-jsx#styled-jsxserver