### PR TITLE
stronger style override for badges in avatar

### DIFF
--- a/src/avatar/style.ts
+++ b/src/avatar/style.ts
@@ -32,13 +32,13 @@ export default css`
     object-fit: cover;
   }
 
-  :global(.kirk-avatar .kirk-avatar-badge--unreadNotifications),
-  :global(.kirk-avatar .kirk-avatar-badge--idCheck) {
+  :global(.kirk-avatar .kirk-badge.kirk-avatar-badge--unreadNotifications),
+  :global(.kirk-avatar .kirk-badge.kirk-avatar-badge--idCheck) {
     z-index: 2;
     position: absolute;
   }
 
-  :global(.kirk-avatar .kirk-avatar-badge--unreadNotifications) {
+  :global(.kirk-avatar .kirk-badge.kirk-avatar-badge--unreadNotifications) {
     top: -6px;
     right: -6px;
   }
@@ -53,30 +53,30 @@ export default css`
     background-color: ${color.success};
   }
 
-  :global(.kirk-avatar.kirk-avatar--medium .kirk-avatar-badge--idCheck),
-  :global(.kirk-avatar.kirk-avatar--large .kirk-avatar-badge--idCheck) {
+  :global(.kirk-avatar.kirk-avatar--medium .kirk-badge.kirk-avatar-badge--idCheck),
+  :global(.kirk-avatar.kirk-avatar--large .kirk-badge.kirk-avatar-badge--idCheck) {
     bottom: 0;
     right: 0;
   }
 
-  :global(.kirk-avatar--medium .kirk-avatar-badge--idCheck) {
+  :global(.kirk-avatar--medium .kirk-badge.kirk-avatar-badge--idCheck) {
     width: 24px;
     height: 24px;
   }
 
-  :global(.kirk-avatar--large .kirk-avatar-badge--idCheck) {
+  :global(.kirk-avatar--large .kirk-badge.kirk-avatar-badge--idCheck) {
     width: 36px;
     height: 36px;
   }
 
-  :global(.kirk-avatar--medium .kirk-avatar-badge--unreadNotifications) {
+  :global(.kirk-avatar--medium .kirk-badge.kirk-avatar-badge--unreadNotifications) {
     height: 24px;
     line-height: 23px;
     font-size: 14px;
     padding: 0 6px;
   }
 
-  :global(.kirk-avatar--large .kirk-avatar-badge--unreadNotifications) {
+  :global(.kirk-avatar--large .kirk-badge.kirk-avatar-badge--unreadNotifications) {
     height: 36px;
     line-height: 34px;
     font-size: 18px;


### PR DESCRIPTION
I realized that when changing the Avatar size, the size of the Badge was not adjusted accordingly
I wish I wouldn't have to write such overrides though...

<img width="186" alt="wrong" src="https://user-images.githubusercontent.com/373381/46466063-8e542300-c7ca-11e8-8963-e3b75031136f.png">
<img width="161" alt="expected" src="https://user-images.githubusercontent.com/373381/46466069-914f1380-c7ca-11e8-9dfc-b8a3f573dbb6.png">
