### PR TITLE
Content of the `<Button>` is now taking 100% of the width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-- [...]
+- **[Change]** Content of the `<Button>` is now taking 100% of the width
+- **[Fix]** Fix `<Button>` content ellipsis
 
 # v0.17.0 (17/10/2018)
 

--- a/src/button/style.ts
+++ b/src/button/style.ts
@@ -22,8 +22,7 @@ export default css`
     max-width: 100%;
     overflow: hidden;
     user-select: none;
-    transition:
-      max-width ${transition.duration.fast} ease-in,
+    transition: max-width ${transition.duration.fast} ease-in,
       background-color ${transition.duration.base} ease-in;
   }
 
@@ -36,9 +35,10 @@ export default css`
   :global(.kirk-button span) {
     position: relative;
     display: inline-block;
-    width: auto;
+    width: 100%;
     white-space: nowrap;
     text-overflow: ellipsis;
+    overflow: hidden;
   }
 
   :global(.kirk-button:hover),
@@ -62,7 +62,7 @@ export default css`
   }
 
   :global(.kirk-button[disabled]) {
-    opacity: .5;
+    opacity: 0.5;
     cursor: default;
   }
 
@@ -169,7 +169,7 @@ export default css`
     height: calc(${buttonIconSize} - ${borderSize} * 2);
   }
 
-  @media (hover:none), (hover:on-demand) {
+  @media (hover: none), (hover: on-demand) {
     :global(.kirk-button-secondary:hover) {
       background-color: ${color.white};
     }

--- a/src/modal/__snapshots__/index.unit.tsx.snap
+++ b/src/modal/__snapshots__/index.unit.tsx.snap
@@ -26,7 +26,7 @@ exports[`Modal should not have changed 1`] = `
           type="button"
         >
           <span
-            className="jsx-4075288211"
+            className="jsx-2341774513"
           >
             <svg
               aria-hidden={true}

--- a/src/snackbar/__snapshots__/index.unit.tsx.snap
+++ b/src/snackbar/__snapshots__/index.unit.tsx.snap
@@ -25,7 +25,7 @@ exports[`Snackbar should not have changed 1`] = `
       type="button"
     >
       <span
-        className="jsx-4075288211"
+        className="jsx-2341774513"
       >
         <svg
           aria-hidden={true}


### PR DESCRIPTION
Also fix button content ellipsis