### PR TITLE
Release/v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+- [...]
+
+# v0.17.1 (19/10/2018)
+
 - **[Change]** Content of the `<Button>` is now taking 100% of the width
 - **[Fix]** Fix `<Button>` content ellipsis
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "React component library",
   "main": "build/index.js",
   "homepage": "https://blablacar.github.io/ui-library",


### PR DESCRIPTION

- **[Change]** Content of the `<Button>` is now taking 100% of the width
- **[Fix]** Fix `<Button>` content ellipsis