### PR TITLE
Checkbox loading state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- [...]
+- **[UPDATE]** `<Checkbox>` now supports loading state
 
 # v0.17.3 (23/10/2018)
 

--- a/src/checkbox/__snapshots__/index.unit.tsx.snap
+++ b/src/checkbox/__snapshots__/index.unit.tsx.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should display the label on the left and the checkbox on the right 1`] = `
+exports[`Checkbox should display the label on the left and the checkbox on the right 1`] = `
 <label
-  className="jsx-214393563 kirk-checkbox kirk-checkbox--labelDisplay-left"
+  className="jsx-4006430834 kirk-checkbox kirk-checkbox--labelDisplay-left"
 >
   <div
-    className="jsx-214393563"
+    className="jsx-4006430834"
   >
     <input
       checked={false}
-      className="jsx-214393563"
+      className="jsx-4006430834"
       disabled={false}
       onChange={[Function]}
       type="checkbox"
@@ -17,14 +17,14 @@ exports[`should display the label on the left and the checkbox on the right 1`] 
     />
     <span
       aria-hidden="true"
-      className="jsx-214393563 "
+      className="jsx-4006430834 "
     />
   </div>
   <div
-    className="jsx-214393563"
+    className="jsx-4006430834"
   >
     <span
-      className="jsx-214393563 kirk-label"
+      className="jsx-4006430834 kirk-label"
     >
       Label
     </span>
@@ -33,16 +33,16 @@ exports[`should display the label on the left and the checkbox on the right 1`] 
 </label>
 `;
 
-exports[`should not display either the label or the sublabel 1`] = `
+exports[`Checkbox should not display either the label or the sublabel 1`] = `
 <label
-  className="jsx-214393563 kirk-checkbox kirk-checkbox--labelDisplay-none"
+  className="jsx-4006430834 kirk-checkbox kirk-checkbox--labelDisplay-none"
 >
   <div
-    className="jsx-214393563"
+    className="jsx-4006430834"
   >
     <input
       checked={false}
-      className="jsx-214393563"
+      className="jsx-4006430834"
       disabled={false}
       onChange={[Function]}
       type="checkbox"
@@ -50,14 +50,14 @@ exports[`should not display either the label or the sublabel 1`] = `
     />
     <span
       aria-hidden="true"
-      className="jsx-214393563 "
+      className="jsx-4006430834 "
     />
   </div>
   <div
-    className="jsx-214393563"
+    className="jsx-4006430834"
   >
     <span
-      className="jsx-214393563 kirk-label"
+      className="jsx-4006430834 kirk-label"
     >
       Label
     </span>

--- a/src/checkbox/index.tsx
+++ b/src/checkbox/index.tsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react'
 import cc from 'classcat'
+import Loader from 'loader'
 
 import style from 'checkbox/style'
 
@@ -11,14 +12,22 @@ export interface CheckboxProps {
   readonly value?: string,
   readonly checked?: boolean,
   readonly disabled?: boolean,
+  readonly status?: CheckboxStatus,
   readonly labelDisplay?: labelDisplays,
   readonly onChange?: (obj:onChangeParameters) => void,
+  readonly onDoneAnimationEnd?: () => void,
 }
 
 export enum labelDisplays {
   LEFT = 'left',
   RIGHT = 'right',
   NONE = 'none',
+}
+
+export enum CheckboxStatus {
+  DEFAULT = 'default',
+  LOADING = 'loading',
+  CHECKED = 'checked',
 }
 
 export interface CheckboxState {
@@ -34,6 +43,8 @@ export default class Checkbox extends PureComponent <CheckboxProps, CheckboxStat
     disabled: false,
     labelDisplay: labelDisplays.RIGHT,
   }
+  static STATUS = CheckboxStatus
+
   state:CheckboxState = {
     isChecked: this.props.checked,
     disabled: this.props.disabled,
@@ -66,7 +77,13 @@ export default class Checkbox extends PureComponent <CheckboxProps, CheckboxStat
   }))
 
   render() {
-    const { className, name, value, children, subLabel, labelDisplay } = this.props
+    const {
+      className, name, value, children, subLabel,
+      labelDisplay, status, onDoneAnimationEnd,
+    } = this.props
+
+    const isStatusLoading = status === CheckboxStatus.LOADING
+    const isStatusChecked = status === CheckboxStatus.CHECKED
 
     return (
       <label className={cc([
@@ -78,6 +95,8 @@ export default class Checkbox extends PureComponent <CheckboxProps, CheckboxStat
           'kirk-checkbox--labelDisplay-none': (
             labelDisplay === labelDisplays.NONE
           ),
+          'kirk-checkbox--loading': isStatusLoading,
+          'kirk-checkbox--checked': isStatusChecked,
         },
         className,
       ])}
@@ -92,6 +111,12 @@ export default class Checkbox extends PureComponent <CheckboxProps, CheckboxStat
             disabled={this.state.disabled}
           />
           <span aria-hidden="true" className={cc({ checked: this.state.isChecked })} />
+          {(isStatusLoading || isStatusChecked) && <Loader
+            size={24}
+            onDoneAnimationEnd={onDoneAnimationEnd}
+            done={isStatusChecked}
+            inline
+          />}
         </div>
         <div>
           <span className="kirk-label">{children}</span>

--- a/src/checkbox/index.unit.tsx
+++ b/src/checkbox/index.unit.tsx
@@ -1,92 +1,143 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import Checkbox, { labelDisplays } from 'checkbox'
+import Loader from 'loader'
 
-it('should have the proper text & attributes', () => {
-  const checkbox = shallow((
-    <Checkbox
-      name="checkbox1"
-      value="value"
-      subLabel="subLabel"
-      checked
-    >
-      Label checkbox
-    </Checkbox>
-  ))
-  expect(checkbox.text()).toContain('Label checkbox')
-  expect(checkbox.find('input').prop('type')).toBe('checkbox')
-  expect(checkbox.find('input').prop('name')).toBe('checkbox1')
-  expect(checkbox.find('input').prop('value')).toBe('value')
-  expect(checkbox.find('input').prop('checked')).not.toBeNull()
-  expect(checkbox.find('.kirk-subLabel')).toHaveLength(1)
-})
+describe('Checkbox', () => {
+  jest.useFakeTimers()
 
-it('should not be checked by default', () => {
-  const checkbox = shallow(<Checkbox name="checkbox1" value="value">Label</Checkbox>)
-  expect(checkbox.find('input').prop('checked')).toBe(false)
-})
+  it('should have the proper text & attributes', () => {
+    const checkbox = shallow((
+      <Checkbox
+        name="checkbox1"
+        value="value"
+        subLabel="subLabel"
+        checked
+      >
+        Label checkbox
+      </Checkbox>
+    ))
+    expect(checkbox.text()).toContain('Label checkbox')
+    expect(checkbox.find('input').prop('type')).toBe('checkbox')
+    expect(checkbox.find('input').prop('name')).toBe('checkbox1')
+    expect(checkbox.find('input').prop('value')).toBe('value')
+    expect(checkbox.find('input').prop('checked')).not.toBeNull()
+    expect(checkbox.find('.kirk-subLabel')).toHaveLength(1)
+  })
 
-it('should have the accessibility attributes', () => {
-  const checkbox = shallow(<Checkbox name="checkbox1" value="value">Label</Checkbox>)
-  expect(checkbox.find('label input')).toHaveLength(1)
-})
+  it('should not be checked by default', () => {
+    const checkbox = shallow(<Checkbox name="checkbox1" value="value">Label</Checkbox>)
+    expect(checkbox.find('input').prop('checked')).toBe(false)
+  })
 
-it('should be able to receive props', () => {
-  const checkbox = shallow(<Checkbox name="checkbox1" value="value">Label</Checkbox>)
-  // Default value
-  expect(checkbox.state('isChecked')).toBe(false)
-  // Value changing
-  checkbox.setProps({ checked: true })
-  expect(checkbox.state('isChecked')).toBe(true)
-  checkbox.setProps({ checked: false })
-  expect(checkbox.state('isChecked')).toBe(false)
-})
+  it('should have the accessibility attributes', () => {
+    const checkbox = shallow(<Checkbox name="checkbox1" value="value">Label</Checkbox>)
+    expect(checkbox.find('label input')).toHaveLength(1)
+  })
 
-it('should trigger a change event on a normal checkbox', () => {
-  const onCheckboxClick = jest.fn()
-  const checkbox = shallow((
-    <Checkbox onChange={onCheckboxClick} name="checkbox1" value="value">
-      Label
-    </Checkbox>
-  ))
-  expect(checkbox.state('isChecked')).toBe(false)
-  checkbox.instance().onChange()
-  expect(onCheckboxClick).toHaveBeenCalledWith({ name: 'checkbox1', value: true })
-  expect(checkbox.state('isChecked')).toBe(true)
-})
+  it('should be able to receive props', () => {
+    const checkbox = shallow(<Checkbox name="checkbox1" value="value">Label</Checkbox>)
+    // Default value
+    expect(checkbox.state('isChecked')).toBe(false)
+    // Value changing
+    checkbox.setProps({ checked: true })
+    expect(checkbox.state('isChecked')).toBe(true)
+    checkbox.setProps({ checked: false })
+    expect(checkbox.state('isChecked')).toBe(false)
+  })
 
-it('should trigger a change event on an async checkbox', () => {
-  const onCheckboxClick = jest.fn()
-  function callback() {
-    expect(onCheckboxClick).toHaveBeenCalledTimes(1)
-  }
-  const checkbox = shallow((
-    <Checkbox
-      onChange={() => {
-        setTimeout(() => { onCheckboxClick(callback) }, 1000)
-      }}
-      name="checkbox1"
-      value="value"
-      asynchronous
-    >
-      Label
-    </Checkbox>
-  ))
-  checkbox.find('input').simulate('change')
-})
+  it('should trigger a change event on a normal checkbox', () => {
+    const onCheckboxClick = jest.fn()
+    const checkbox = shallow((
+      <Checkbox onChange={onCheckboxClick} name="checkbox1" value="value">
+        Label
+      </Checkbox>
+    ))
+    expect(checkbox.state('isChecked')).toBe(false)
+    checkbox.instance().onChange()
+    expect(onCheckboxClick).toHaveBeenCalledWith({ name: 'checkbox1', value: true })
+    expect(checkbox.state('isChecked')).toBe(true)
+  })
 
-it('should display the label on the left and the checkbox on the right', () => {
-  const checkbox = renderer.create(<Checkbox
-    labelDisplay={labelDisplays.LEFT}
-    labelFirstname="checkbox1"
-    value="value">Label</Checkbox>).toJSON()
-  expect(checkbox).toMatchSnapshot()
-})
+  it('should trigger a change event on an async checkbox', () => {
+    const onCheckboxClick = jest.fn()
+    function callback() {
+      expect(onCheckboxClick).toHaveBeenCalledTimes(1)
+    }
+    const checkbox = shallow((
+      <Checkbox
+        onChange={() => {
+          setTimeout(() => { onCheckboxClick(callback) }, 1000)
+        }}
+        name="checkbox1"
+        value="value"
+        asynchronous
+      >
+        Label
+      </Checkbox>
+    ))
+    checkbox.find('input').simulate('change')
+  })
 
-it('should not display either the label or the sublabel', () => {
-  const checkbox = renderer.create(<Checkbox
-    labelDisplay={labelDisplays.NONE}
-    labelFirstname="checkbox1"
-    value="value">Label</Checkbox>).toJSON()
-  expect(checkbox).toMatchSnapshot()
+  it('should display the label on the left and the checkbox on the right', () => {
+    const checkbox = renderer.create(<Checkbox
+      labelDisplay={labelDisplays.LEFT}
+      labelFirstname="checkbox1"
+      value="value">Label</Checkbox>).toJSON()
+    expect(checkbox).toMatchSnapshot()
+  })
+
+  it('should not display either the label or the sublabel', () => {
+    const checkbox = renderer.create(<Checkbox
+      labelDisplay={labelDisplays.NONE}
+      labelFirstname="checkbox1"
+      value="value">Label</Checkbox>).toJSON()
+    expect(checkbox).toMatchSnapshot()
+  })
+
+  it('should not have a loader by default', () => {
+    const checkbox = shallow(<Checkbox name="checkbox1" value="value">Label</Checkbox>)
+    expect(checkbox.find(Loader).exists()).toBe(false)
+  })
+  it('should have a loading state', () => {
+    const checkbox = shallow(
+      <Checkbox
+        name="checkbox1"
+        value="value"
+        status={Checkbox.STATUS.LOADING}
+      >
+        Label
+      </Checkbox>,
+    )
+    expect(checkbox.find(Loader).exists()).toBe(true)
+  })
+  it('should have a valid state', () => {
+    const checkbox = shallow(
+      <Checkbox
+        name="checkbox1"
+        value="value"
+        status={Checkbox.STATUS.CHECKED}
+      >
+        Label
+      </Checkbox>,
+    )
+    expect(checkbox.find(Loader).exists()).toBe(true)
+    expect(checkbox.find(Loader).prop('done')).toBe(true)
+  })
+  it('should fire the callback when valid', () => {
+    const event = jest.fn()
+    const checkbox = mount(
+      <Checkbox
+        name="checkbox1"
+        value="value"
+        onDoneAnimationEnd={event}
+      >
+        Label
+      </Checkbox>,
+    )
+    checkbox.setProps({ status: Checkbox.STATUS.CHECKED })
+    expect(event).not.toBeCalled()
+    jest.advanceTimersByTime(1500)
+    expect(event).toBeCalled()
+  })
 })

--- a/src/checkbox/story.tsx
+++ b/src/checkbox/story.tsx
@@ -17,7 +17,8 @@ stories.add(
       onChange={action('Checkbox changed')}
       checked={boolean('Checked', false)}
       labelDisplay={selectV2('Label display', labelDisplays, labelDisplays.RIGHT)}
-      subLabel={text('Sub label', 'Sublabel checkbox')}>
+      subLabel={text('Sub label', 'Sublabel checkbox')}
+      status={selectV2('status', Checkbox.STATUS, Checkbox.STATUS.DEFAULT)}>
       {text('Label', 'Label checkbox')}
     </Checkbox>
   )),

--- a/src/checkbox/style.ts
+++ b/src/checkbox/style.ts
@@ -96,4 +96,9 @@ export default css`
     border-bottom: 2px solid ${color.white};
     transform: rotate(-45deg);
   }
+
+  .kirk-checkbox.kirk-checkbox--loading input + span,
+  .kirk-checkbox.kirk-checkbox--checked input + span {
+    display: none;
+  }
 `


### PR DESCRIPTION
### Specs:
Checkboxes should be able to display API request status when being clicked. It uses the same STATUS prop than Item components and variants for consistency.
Loader replaces the blue check icon, either placed on right or left.

### Screenshots:
<img width="435" alt="capture d ecran 2018-11-12 a 12 01 21" src="https://user-images.githubusercontent.com/14176147/48343713-67172e00-e673-11e8-9356-bd3cae7c3072.png">
<img width="437" alt="capture d ecran 2018-11-12 a 12 01 09" src="https://user-images.githubusercontent.com/14176147/48343714-67172e00-e673-11e8-9d9a-876233c054a7.png">
