### PR TITLE
Build ItemDeclaredChoice on top of ItemChoice for Radio buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- [...]
+- **[UPDATE]** `<ItemChoice>` and `<Radio>` now have a `declared` prop displaying the selected value
 
 # v0.17.3 (23/10/2018)
 

--- a/src/icon/checkIcon.tsx
+++ b/src/icon/checkIcon.tsx
@@ -8,6 +8,7 @@ import { color } from '_utils/branding'
 interface CheckProps extends Icon {
   readonly absolute?: boolean,
   readonly validate?: boolean,
+  readonly backgroundColor?: string,
 }
 
 const style = css`.absolute {
@@ -37,6 +38,7 @@ class CheckIcon extends PureComponent<CheckProps> {
     size: 24,
     title: '',
     validate: false,
+    backgroundColor: 'transparent',
   }
 
   render() {
@@ -61,6 +63,12 @@ class CheckIcon extends PureComponent<CheckProps> {
           strokeMiterlimit="10"
         />
         <style jsx>{style}</style>
+        <style jsx>{`
+          svg {
+            background-color: ${this.props.backgroundColor};
+            border-radius: 100%;
+          }
+        `}</style>
       </svg>
     )
   }

--- a/src/itemChoice/index.tsx
+++ b/src/itemChoice/index.tsx
@@ -3,7 +3,9 @@ import cc from 'classcat'
 import isEmpty from 'lodash.isempty'
 
 import prefix from '_utils'
+import { color } from '_utils/branding'
 import ChevronIcon from 'icon/chevronIcon'
+import CheckIcon from 'icon/checkIcon'
 import Loader from 'loader'
 import style from './style'
 
@@ -32,6 +34,7 @@ export interface ItemChoiceProps {
   readonly rightAddon?: React.ReactNode,
   readonly highlighted?: boolean,
   readonly selected?: boolean,
+  readonly declared?: boolean,
   readonly status?: ItemChoiceStatus,
   readonly onDoneAnimationEnd?: () => void,
   readonly onClick?: (event: React.MouseEvent<HTMLElement>) => void,
@@ -44,13 +47,14 @@ class ItemChoice extends PureComponent <ItemChoiceProps> {
   static defaultProps: Partial<ItemChoiceProps> = {
     highlighted: false,
     selected: false,
+    declared: false,
     status: ItemChoiceStatus.DEFAULT,
     href: '',
   }
   static STATUS = ItemChoiceStatus
   render() {
     const {
-      children, className, highlighted, selected, status,
+      children, className, highlighted, selected, status, declared,
       onClick, onBlur, onFocus, onMouseDown, href, label, subLabel, leftAddon, rightAddon,
       onDoneAnimationEnd,
     } = this.props
@@ -58,9 +62,17 @@ class ItemChoice extends PureComponent <ItemChoiceProps> {
       itemChoice: true,
       'itemChoice--highlighted': highlighted,
       'itemChoice--withSubLabel': !!subLabel,
+      'itemChoice--declared': declared,
     }), className])
 
     let rightIcon = <ChevronIcon className={cc(prefix({ chevron: true }))} />
+
+    if (declared && selected) {
+      rightIcon = <CheckIcon iconColor={color.white} backgroundColor={color.primary} />
+    }
+    if (declared && !selected) {
+      rightIcon = null
+    }
 
     if (status === ItemChoiceStatus.LOADING) {
       rightIcon = <Loader

--- a/src/itemChoice/index.unit.tsx
+++ b/src/itemChoice/index.unit.tsx
@@ -97,6 +97,18 @@ describe('ItemChoice', () => {
     })
   })
 
+  describe('#declared', () => {
+    it('Should not have a declared state by default', () => {
+      const wrapper = shallow(<ItemChoice>...</ItemChoice>)
+      expect(wrapper.hasClass('kirk-itemChoice--declared')).toBe(false)
+    })
+
+    it('Should have a declared state', () => {
+      const wrapper = shallow(<ItemChoice declared>...</ItemChoice>)
+      expect(wrapper.hasClass('kirk-itemChoice--declared')).toBe(true)
+    })
+  })
+
   describe('#leftAddon', () => {
     it('Render a left addon given a string', () => {
       const wrapper = shallow(<ItemChoice leftAddon="Info">...</ItemChoice>)

--- a/src/itemChoice/style.ts
+++ b/src/itemChoice/style.ts
@@ -121,4 +121,12 @@ export default css`
     min-height: 24px;
     min-width: 24px;
   }
+
+  :global(.kirk-itemChoice.kirk-itemChoice--declared) {
+    min-height: 56px; /* icon height + vertical padding */
+  }
+
+  :global(.kirk-itemChoice.kirk-itemChoice--declared[aria-selected="true"]) {
+    background-color: transparent;
+  }
 `

--- a/src/radio/index.tsx
+++ b/src/radio/index.tsx
@@ -13,6 +13,7 @@ export interface RadioProps {
   readonly name?: string,
   readonly checked?: boolean,
   readonly highlighted?: boolean,
+  readonly declared?: boolean,
   readonly onChange?: (obj: onChangeParameters) => void,
   readonly subLabel?: string,
   readonly icon?: JSX.Element,
@@ -25,6 +26,7 @@ export default class Radio extends Component <RadioProps> {
     onChange() {},
     checked: false,
     highlighted: false,
+    declared: false,
     status: ItemChoice.STATUS.DEFAULT,
   }
 
@@ -37,7 +39,7 @@ export default class Radio extends Component <RadioProps> {
 
   render() {
     const { className, name, value, subLabel, highlighted, checked, children, icon,
-      status, onDoneAnimationEnd, key } = this.props
+      status, onDoneAnimationEnd, key, declared } = this.props
 
     return (
       <ItemChoice
@@ -48,6 +50,8 @@ export default class Radio extends Component <RadioProps> {
         highlighted={highlighted}
         className={cc([prefix({ radio: true }), className])}
         status={status}
+        declared={declared}
+        selected={checked}
         onDoneAnimationEnd={onDoneAnimationEnd}
       >
         <input

--- a/src/radioGroup/story.tsx
+++ b/src/radioGroup/story.tsx
@@ -70,3 +70,18 @@ stories.add(
     </RadioGroup>
   )),
 )
+
+stories.add(
+  'With declared style',
+  withInfo('')(() => (
+    <RadioGroup
+      name="radioName"
+      onChange={action('changed')}
+      status={select('status', Radio.STATUS, Radio.STATUS.DEFAULT)}
+    >
+      <Radio value="radioValue1" declared checked>{text('label', 'Choice 1')}</Radio>
+      <Radio value="radioValue2" declared>{text('label', 'Choice 2')}</Radio>
+      <Radio value="radioValue3" declared>{text('label', 'Choice 3')}</Radio>
+    </RadioGroup>
+  )),
+)


### PR DESCRIPTION
### Specs:
This change adds a new "skin" for `Radio` components which shows the selected option. This hides the chevron and display a circled Check icon on the right of the selected option.

### Screenshots:
<img width="431" alt="capture d ecran 2018-11-12 a 18 20 39" src="https://user-images.githubusercontent.com/14176147/48364101-d60e7a00-e6a7-11e8-9e89-fbabf0865b92.png">
