### PR TITLE
Fix Topbar children styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - **[NEW]** `WarningIcon` component
+- **[FIX]** `TopBar` children styles now load correctly
 
 # v0.19.0 (12/12/2018)
 

--- a/src/topBar/index.tsx
+++ b/src/topBar/index.tsx
@@ -34,6 +34,7 @@ const TopBar = ({
     children.push(
       <div key="leftItem" className="kirk-topBar-left">
         {leftItem}
+        <style jsx>{style}</style>
       </div>,
     )
   }
@@ -41,6 +42,7 @@ const TopBar = ({
     children.push(
       <div key="centerItem" className="kirk-topBar-center">
         {centerItem}
+        <style jsx>{style}</style>
       </div>,
     )
   }
@@ -48,6 +50,7 @@ const TopBar = ({
     children.push(
       <div key="rightItem" className="kirk-topBar-right">
         {rightItem}
+        <style jsx>{style}</style>
       </div>,
     )
   }


### PR DESCRIPTION
0.19.0 release broke the styling for the Topbar's children. Looks like `styled-jsx` does not read arrays of components correctly and does not apply its classes to them. Re-applying the styles in each component does the trick, and does not affect the CSS output (it is clever enough to not duplicate the code).