### PR TITLE
Add format prop to TextField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - **[FIX]** `SuccessModal` display with small content
+- **[UPDATE]** Allow `format` prop on TextField component
 
 # v0.20.3 (09/01/2019)
 

--- a/src/textField/index.tsx
+++ b/src/textField/index.tsx
@@ -45,6 +45,7 @@ export interface TextFieldProps extends CommonFormFields {
   buttonTitle?: string
   focus?: boolean
   inputRef?: (input: textfield) => void
+  format?: (value: string) => string
 }
 
 interface FormAttributes extends CommonFormFields {
@@ -83,6 +84,7 @@ export default class TextField extends PureComponent<TextFieldProps, TextFieldSt
     inputRef() {},
     onClear() {},
     type: 'text',
+    format: value => value,
   }
 
   state = {
@@ -162,8 +164,9 @@ export default class TextField extends PureComponent<TextFieldProps, TextFieldSt
       autoComplete,
       title,
       buttonTitle,
+      format,
     } = this.props
-    const value = this.state.value || ''
+    const value = this.state.value ? format(this.state.value) : ''
 
     const attrs: FormAttributes = {
       type,

--- a/src/textField/index.unit.tsx
+++ b/src/textField/index.unit.tsx
@@ -236,9 +236,15 @@ it('Simulates a blur event.', () => {
   expect(onTextFieldBlur).toHaveBeenCalledTimes(1)
 })
 
-it('Be able to format the value', () => {
+it('Should format the default value', () => {
   const wrapper = mount(
     <TextField name="test" defaultValue="Hello" format={value => `${value} world`} />,
   )
+  expect(wrapper.find('input').prop('value')).toBe('Hello world')
+})
+
+it('Should format the values when it changes', () => {
+  const wrapper = mount(<TextField name="test" format={value => `${value} world`} />)
+  wrapper.setState({ value: 'Hello' })
   expect(wrapper.find('input').prop('value')).toBe('Hello world')
 })

--- a/src/textField/index.unit.tsx
+++ b/src/textField/index.unit.tsx
@@ -235,3 +235,10 @@ it('Simulates a blur event.', () => {
   wrapper.find('input').simulate('blur')
   expect(onTextFieldBlur).toHaveBeenCalledTimes(1)
 })
+
+it('Be able to format the value', () => {
+  const wrapper = mount(
+    <TextField name="test" defaultValue="Hello" format={value => `${value} world`} />,
+  )
+  expect(wrapper.find('input').prop('value')).toBe('Hello world')
+})

--- a/src/textField/story.tsx
+++ b/src/textField/story.tsx
@@ -194,3 +194,34 @@ stories.add(
     )
   }),
 )
+
+const formatValue: (value: string) => string = value => {
+  if (value.match(/^[0-9]{2}$/) || value.match(/^[0-9]{2}\/[0-9]{2}$/)) {
+    return `${value}/`
+  }
+  return value
+}
+
+stories.add(
+  'date input ',
+  withInfo('TextField with format method')(() => {
+    const error = boolean('error', false)
+    return (
+      <TextField
+        id={text('id')}
+        name={text('name')}
+        placeholder={text('placeholder')}
+        disabled={boolean('disabled', false)}
+        readOnly={boolean('readOnly', false)}
+        label={text('label')}
+        error={error ? text('error message', 'something went wrong') : ''}
+        onChange={action('changed')}
+        onFocus={action('focused')}
+        onBlur={action('blurred')}
+        maxLength={number('maxLength')}
+        autoComplete={select('autocomplete', ['on', 'off'])}
+        format={formatValue}
+      />
+    )
+  }),
+)


### PR DESCRIPTION
The new `format` prop allows to update the value each time it changes. This can be helpful for some inputs where you want the value to match a certain pattern (ex: a date, a phone number) and autofill some characters along.

In the story, I've put an example with a date input where you autofill the slash characters when the user is typing. Be mindful that this updates the value (this is the big difference between the TextField `format` and the Stepper `format` props).