### PR TITLE
Remove breaking change on margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- **[Fix]** Remove the breaking change that added horizontal padding on Toggle button and profile in the previous version
+- **[Fix]** Forward href props to the Item component
 - [...]
 
 # v0.21.0 (11/02/2019)

--- a/src/_utils/item/index.tsx
+++ b/src/_utils/item/index.tsx
@@ -49,9 +49,11 @@ const Item = ({
   tag = <div />,
 }: ItemProps) => {
   let Tag = tag.type
+  let tagProps = tag.props
   if (href) {
     if (typeof href !== 'string') {
       Tag = href.type
+      tagProps = { ...tagProps, ...href.props }
     } else {
       Tag = 'a'
     }
@@ -61,7 +63,7 @@ const Item = ({
 
   return (
     <Tag
-      {...tag.props}
+      {...tagProps}
       onClick={onClick}
       onFocus={onFocus}
       onBlur={onBlur}

--- a/src/_utils/item/index.unit.tsx
+++ b/src/_utils/item/index.unit.tsx
@@ -36,6 +36,12 @@ it('Should return a tag A when href is present', () => {
   expect(wrapper.type()).toEqual('button')
 })
 
+it('Should return href props when href is present', () => {
+  const wrapper = shallow(<Item href={<button role="foo" />} />)
+  expect(wrapper.type()).toEqual('button')
+  expect(wrapper.prop('role')).toBe('foo')
+})
+
 it('Should display a left add-on', () => {
   const wrapper = shallow(<Item leftAddon={<ClockIcon />} />)
   expect(wrapper.find(ClockIcon).exists()).toBe(true)

--- a/src/_utils/item/style.ts
+++ b/src/_utils/item/style.ts
@@ -7,7 +7,8 @@ export default css`
     position: relative;
     display: flex;
     padding: 0;
-    padding: ${space.l} ${space.xl};
+    padding-top: ${space.l};
+    padding-bottom: ${space.l};
     align-items: center;
     flex: 1;
     border: 0;

--- a/src/itemInfo/index.tsx
+++ b/src/itemInfo/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import Item from '_utils/item/index'
+import Item from '_utils/item'
 
 interface ItemInfoProps {
   readonly mainInfo: string


### PR DESCRIPTION
I should have listen @Bidjii 🙇. The breaking change introduced in #173 on margins to have a Pixar hover was too big to be introduced by the item action. It requires a dedicated project so I'm reverting it.

Also forward href props to item component