### PR TITLE
Release 0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Unreleased
 
+- [...]
+
+# v0.21.1 (12/02/2019)
+
 - **[Fix]** Remove the breaking change that added horizontal padding on Toggle button and profile in the previous version
 - **[Fix]** Forward href props to the Item component
-- [...]
 
 # v0.21.0 (11/02/2019)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "React component library",
   "main": "build/index.js",
   "homepage": "https://blablacar.github.io/ui-library",


### PR DESCRIPTION
* [Fix] Remove the breaking change that added horizontal padding on Toggle button and profile in the previous version
* [Fix] Forward href props to the Item component