### PR TITLE
Fix check icon animation not played correctly on Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Check icon animation not played correctly on Safari
 - **[BREAKING CHANGE]** `TextField` no more boolean accepted in the error field
 - **[UPDATE]** `Button` no more span in the Button
 - **[UPDATE]** `Button` no more whitespace no wrap & text-ellipsis

--- a/src/icon/checkIcon.tsx
+++ b/src/icon/checkIcon.tsx
@@ -21,13 +21,13 @@ const style = css`
   }
   .validate path {
     stroke-dasharray: 24;
-    stroke-dashoffset: -24;
+    stroke-dashoffset: 24;
     stroke-linecap: round;
     animation: dash 0.5s cubic-bezier(0.65, 0, 0.45, 1) forwards;
   }
   @keyframes dash {
     from {
-      stroke-dashoffset: -24;
+      stroke-dashoffset: 24;
     }
     to {
       stroke-dashoffset: 0;


### PR DESCRIPTION
After 1 year, 3 months, 10 days this issue is finally fixed 🎉.

| Before | After |
|--------|------|
| ![wrong-animation](https://user-images.githubusercontent.com/2495124/52951800-08083a00-3383-11e9-9605-f740fa6963b5.gif) | ![valid-animation](https://user-images.githubusercontent.com/2495124/52951797-076fa380-3383-11e9-8e55-046ea54e1ce9.gif) |
