### PR TITLE
Set Button to inline-flex to solve alignment issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **[FIX]** `Item` should not have an empty href on non A tags.
 - **[FIX]** Check icon animation not played correctly on Safari
+- **[FIX]** `Button` alignment issues fixed with `inline-flex` instead of `flex`
 
 # v0.22.0 (11/02/2019)
 

--- a/src/button/style.ts
+++ b/src/button/style.ts
@@ -7,7 +7,7 @@ export default css`
   :global(.kirk-button) {
     position: relative;
     box-sizing: border-box;
-    display: flex;
+    display: inline-flex;
     padding: ${space.l} ${space.xl};
     border: 1px solid transparent;
     border-radius: 48px;
@@ -144,7 +144,7 @@ export default css`
   }
 
   :global(.kirk-button-bubble) {
-    display: inline-block;
+    display: inline-flex;
     padding: 0;
     line-height: 0;
     width: ${buttonIconSize};

--- a/src/textField/index.tsx
+++ b/src/textField/index.tsx
@@ -68,9 +68,13 @@ export interface TextFieldState {
 const DisplayError = (error: errorField) => {
   const className = 'kirk-error-message'
 
-  return React.isValidElement(error)
-    ? React.cloneElement(error, { className } as Object)
-    : <span role="alert" className={className}>{error}</span>
+  return React.isValidElement(error) ? (
+    React.cloneElement(error, { className } as Object)
+  ) : (
+    <span role="alert" className={className}>
+      {error}
+    </span>
+  )
 }
 
 export default class TextField extends PureComponent<TextFieldProps, TextFieldState> {

--- a/src/textField/index.unit.tsx
+++ b/src/textField/index.unit.tsx
@@ -132,6 +132,16 @@ describe('#error', () => {
     expect(wrapper.find('span').text()).toBe(errorText)
   })
 
+  it('Should have an error state when passing a JSX element', () => {
+    const errorText = 'this is an error'
+    const error = <span>{errorText}</span>
+    const wrapper = shallow(<TextField name="test" error={error} />)
+    expect(wrapper.hasClass('kirk-error')).toBe(true)
+    expect(wrapper.find('.kirk-error-message')).toHaveLength(1)
+    expect(wrapper.find('input').prop('aria-invalid')).toBe('true')
+    expect(wrapper.find('span').text()).toBe(errorText)
+  })
+
   it('Should not have an error state when passing a boolean `false`', () => {
     const wrapper = shallow(<TextField name="test" error={false} />)
     expect(wrapper.hasClass('kirk-error')).toBe(false)


### PR DESCRIPTION
We had regressions when importing 0.22.1 version as Button used with links were full width and Button used as TextField add-ons had icon-alignment issues.

This fixes both problems, and also added a missing unit test on the TextField component.