### PR TITLE
Display itinerary as small if we don't provide time or subLabel 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Display `Itinerary` as small if we don't provide date or subLabel in places
 - **[FIX]** Added background for transparent avatars in `TripCard`
 - **[FIX]** Update `Title` style in `TripCard`
 - **[FIX]** Update margins in `EmptyState` component

--- a/src/itinerary/index.tsx
+++ b/src/itinerary/index.tsx
@@ -28,8 +28,12 @@ const Itinerary = ({
   small = false,
   headline = null,
 }: ItineraryProps) => {
+
+  // Dislay itinerary as small if required or if we don't have time or subLabel for provided places
+  const isSmall = small || places.filter(p => !isEmpty(p.time) || !isEmpty(p.subLabel)).length === 0
+
   return (
-    <ul className={cc([className, { 'kirk-itinerary--small': small }])}>
+    <ul className={cc([className, { 'kirk-itinerary--small': isSmall }])}>
       {isNonEmptyString(headline) && (
         <li className="kirk-itinerary-headline">
           <Text display={TextDisplayType.TITLE}>{headline}</Text>
@@ -103,14 +107,14 @@ const Itinerary = ({
               }
             />
             <Component {...hrefProps}>
-              {!small && (
+              {!isSmall && (
                 <time dateTime={place.isoDate}>
                   <Text display={TextDisplayType.TITLESTRONG}>{place.time}</Text>
                 </time>
               )}
               <div className="kirk-itinerary-location-city">
                 <Text display={TextDisplayType.TITLESTRONG}>{place.mainLabel}</Text>
-                {!small &&
+                {!isSmall &&
                   place.subLabel &&
                   (typeof place.subLabel === 'string' ? (
                     <Text

--- a/src/itinerary/index.unit.tsx
+++ b/src/itinerary/index.unit.tsx
@@ -203,4 +203,34 @@ describe('Itinerary component', () => {
       .key()
     expect(key2).toBe('route-end-tours')
   })
+
+  describe('small', () => {
+    it('Should be displayed as small if required in props', () => {
+      const itinerary = shallow(<Itinerary places={places} small />)
+      expect(itinerary.hasClass('kirk-itinerary--small')).toBe(true)
+    })
+
+    it('Should not be displayed as small if not in props and time or sublabel exists', () => {
+      const itinerary = shallow(<Itinerary places={places} />)
+      expect(itinerary.hasClass('kirk-itinerary--small')).toBe(false)
+    })
+
+    it('Should be displayed as small if no time nor subLabel', () => {
+      const places = [
+        {
+          isoDate: '2017-12-11T09:00',
+          mainLabel: 'Paris',
+          key: 'route-start-paris',
+        },
+        {
+          isoDate: '2017-12-11T12:00',
+          mainLabel: 'Tours',
+          key: 'route-end-tours',
+        },
+      ]
+
+      const itinerary = shallow(<Itinerary places={places} />)
+      expect(itinerary.hasClass('kirk-itinerary--small')).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
Before:
<img width="447" alt="Capture d’écran 2019-06-28 à 11 43 30" src="https://user-images.githubusercontent.com/729186/60333823-4d282280-999a-11e9-9a06-523ed8799836.png">

After:
<img width="168" alt="Capture d’écran 2019-06-28 à 11 43 37" src="https://user-images.githubusercontent.com/729186/60333824-4d282280-999a-11e9-80ac-ee5b208d57d1.png">

In both cases, we don't have the `small` property, but we don't have either time or subLabel in places. Especially used for `TripCard` component that don't give us full control over the itinerary.