### PR TITLE
CSS-inJS: Fix loader animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **[BREAKING CHANGE]** `<Modal>`: rename `className` props to `modalContentClassName`
 - **[BREAKING CHANGE]** `<PhoneField>`: changed `className` prop position to the root element, added `innerWrapperClassName` prop as replacement
 - **[BREAKING CHANGE]** Migrated every component to Styled Components which is now a peer dependency of this project
+- **[BREAKING CHANGE]** `<BaseIcon>`: rename `className` props to `iconClassName`
 - [...]
 
 # v8.8.0 (24/07/2019)

--- a/src/_utils/checkboxIcon/__snapshots__/index.unit.tsx.snap
+++ b/src/_utils/checkboxIcon/__snapshots__/index.unit.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CheckboxIcon Should render a check icon if isChecked is set to true 1`] = `
-.c1 {
+.c1.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -57,7 +57,7 @@ exports[`CheckboxIcon Should render a check icon if isChecked is set to true 1`]
 `;
 
 exports[`CheckboxIcon Should render a loader if isLoading and isChecked are set to true 1`] = `
-.c2 {
+.c2.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -69,8 +69,8 @@ exports[`CheckboxIcon Should render a loader if isLoading and isChecked are set 
 }
 
 .c1.spinning {
-  -webkit-animation: rotator 1.4s linear infinite;
-  animation: rotator 1.4s linear infinite;
+  -webkit-animation: cqjtzU 1.4s linear infinite;
+  animation: cqjtzU 1.4s linear infinite;
 }
 
 .c1 circle {
@@ -84,8 +84,8 @@ exports[`CheckboxIcon Should render a loader if isLoading and isChecked are set 
   -webkit-transform-origin: center;
   -ms-transform-origin: center;
   transform-origin: center;
-  -webkit-animation: dash 1.4s ease-in-out infinite;
-  animation: dash 1.4s ease-in-out infinite;
+  -webkit-animation: hqYbNG 1.4s ease-in-out infinite;
+  animation: hqYbNG 1.4s ease-in-out infinite;
 }
 
 .c1.thin circle {
@@ -142,7 +142,7 @@ exports[`CheckboxIcon Should render a loader if isLoading and isChecked are set 
 >
   <svg
     aria-hidden={true}
-    className="kirk-icon kirk-icon-circle c1 spinning c2"
+    className="kirk-icon kirk-icon-circle spinning c1 c2"
     fill="#5DD167"
     height={24}
     viewBox="0 0 66 66"
@@ -162,7 +162,7 @@ exports[`CheckboxIcon Should render a loader if isLoading and isChecked are set 
 `;
 
 exports[`CheckboxIcon Should render a loader if isLoading is set to true 1`] = `
-.c2 {
+.c2.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -174,8 +174,8 @@ exports[`CheckboxIcon Should render a loader if isLoading is set to true 1`] = `
 }
 
 .c1.spinning {
-  -webkit-animation: rotator 1.4s linear infinite;
-  animation: rotator 1.4s linear infinite;
+  -webkit-animation: cqjtzU 1.4s linear infinite;
+  animation: cqjtzU 1.4s linear infinite;
 }
 
 .c1 circle {
@@ -189,8 +189,8 @@ exports[`CheckboxIcon Should render a loader if isLoading is set to true 1`] = `
   -webkit-transform-origin: center;
   -ms-transform-origin: center;
   transform-origin: center;
-  -webkit-animation: dash 1.4s ease-in-out infinite;
-  animation: dash 1.4s ease-in-out infinite;
+  -webkit-animation: hqYbNG 1.4s ease-in-out infinite;
+  animation: hqYbNG 1.4s ease-in-out infinite;
 }
 
 .c1.thin circle {
@@ -247,7 +247,7 @@ exports[`CheckboxIcon Should render a loader if isLoading is set to true 1`] = `
 >
   <svg
     aria-hidden={true}
-    className="kirk-icon kirk-icon-circle c1 spinning c2"
+    className="kirk-icon kirk-icon-circle spinning c1 c2"
     fill="#5DD167"
     height={24}
     viewBox="0 0 66 66"
@@ -267,7 +267,7 @@ exports[`CheckboxIcon Should render a loader if isLoading is set to true 1`] = `
 `;
 
 exports[`CheckboxIcon Should render an empty circle by default 1`] = `
-.c1 {
+.c1.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -279,8 +279,8 @@ exports[`CheckboxIcon Should render an empty circle by default 1`] = `
 }
 
 .c0.spinning {
-  -webkit-animation: rotator 1.4s linear infinite;
-  animation: rotator 1.4s linear infinite;
+  -webkit-animation: cqjtzU 1.4s linear infinite;
+  animation: cqjtzU 1.4s linear infinite;
 }
 
 .c0 circle {
@@ -294,8 +294,8 @@ exports[`CheckboxIcon Should render an empty circle by default 1`] = `
   -webkit-transform-origin: center;
   -ms-transform-origin: center;
   transform-origin: center;
-  -webkit-animation: dash 1.4s ease-in-out infinite;
-  animation: dash 1.4s ease-in-out infinite;
+  -webkit-animation: hqYbNG 1.4s ease-in-out infinite;
+  animation: hqYbNG 1.4s ease-in-out infinite;
 }
 
 .c0.thin circle {

--- a/src/_utils/icon/BaseIcon.tsx
+++ b/src/_utils/icon/BaseIcon.tsx
@@ -12,6 +12,7 @@ export interface IconProps extends Icon {
 
 export const BaseIconDefaultProps = {
   className: '',
+  iconClassName: '',
   iconColor: color.icon,
   size: 24,
   title: '',
@@ -21,6 +22,7 @@ export const BaseIconDefaultProps = {
 
 const BaseIcon = ({
   className,
+  iconClassName,
   iconColor,
   size,
   title,
@@ -29,11 +31,19 @@ const BaseIcon = ({
   badgeContent,
   badgeAriaLabel,
 }: IconProps) => {
+
+  const iconClasses = ['kirk-icon', iconClassName]
+  if (!badgeContent) {
+    // When there is no badge, the icon is not wrapped and is the root element.
+    // Therefore className classes needs to be added to the icon itself.
+    iconClasses.push(className)
+  }
+
   const icon = (
     <svg
       viewBox={viewBox}
       xmlns="http://www.w3.org/2000/svg"
-      className={cc(['kirk-icon', className])}
+      className={cc(iconClasses)}
       width={size}
       height={size}
       aria-hidden={isEmpty(title)}
@@ -46,7 +56,7 @@ const BaseIcon = ({
 
   if (badgeContent) {
     return (
-      <div className="kirk-icon-wrapper">
+      <div className={cc(['kirk-icon-wrapper', className])}>
         {icon}
         <Badge className="kirk-icon-badge" ariaLabel={badgeAriaLabel}>
           {badgeContent}

--- a/src/_utils/icon/index.tsx
+++ b/src/_utils/icon/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import BaseIcon from './BaseIcon'
 
 const StyledBaseIcon = styled(BaseIcon)`
-  & {
+  &.kirk-icon-wrapper {
     display: inline-block;
     position: relative;
   }

--- a/src/_utils/item/__snapshots__/Item.unit.tsx.snap
+++ b/src/_utils/item/__snapshots__/Item.unit.tsx.snap
@@ -64,7 +64,7 @@ exports[`Item Should not have changed 1`] = `
   font-weight: 500;
 }
 
-.c2 {
+.c2.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }

--- a/src/_utils/radioIcon/__snapshots__/index.unit.tsx.snap
+++ b/src/_utils/radioIcon/__snapshots__/index.unit.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RadioIcon Should render a check icon if isChecked is set to true 1`] = `
-.c1 {
+.c1.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -13,8 +13,8 @@ exports[`RadioIcon Should render a check icon if isChecked is set to true 1`] = 
 }
 
 .c0.spinning {
-  -webkit-animation: rotator 1.4s linear infinite;
-  animation: rotator 1.4s linear infinite;
+  -webkit-animation: cqjtzU 1.4s linear infinite;
+  animation: cqjtzU 1.4s linear infinite;
 }
 
 .c0 circle {
@@ -28,8 +28,8 @@ exports[`RadioIcon Should render a check icon if isChecked is set to true 1`] = 
   -webkit-transform-origin: center;
   -ms-transform-origin: center;
   transform-origin: center;
-  -webkit-animation: dash 1.4s ease-in-out infinite;
-  animation: dash 1.4s ease-in-out infinite;
+  -webkit-animation: hqYbNG 1.4s ease-in-out infinite;
+  animation: hqYbNG 1.4s ease-in-out infinite;
 }
 
 .c0.thin circle {
@@ -72,7 +72,7 @@ exports[`RadioIcon Should render a check icon if isChecked is set to true 1`] = 
 `;
 
 exports[`RadioIcon Should render a loader if isLoading and isChecked are set to true 1`] = `
-.c2 {
+.c2.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -84,8 +84,8 @@ exports[`RadioIcon Should render a loader if isLoading and isChecked are set to 
 }
 
 .c1.spinning {
-  -webkit-animation: rotator 1.4s linear infinite;
-  animation: rotator 1.4s linear infinite;
+  -webkit-animation: cqjtzU 1.4s linear infinite;
+  animation: cqjtzU 1.4s linear infinite;
 }
 
 .c1 circle {
@@ -99,8 +99,8 @@ exports[`RadioIcon Should render a loader if isLoading and isChecked are set to 
   -webkit-transform-origin: center;
   -ms-transform-origin: center;
   transform-origin: center;
-  -webkit-animation: dash 1.4s ease-in-out infinite;
-  animation: dash 1.4s ease-in-out infinite;
+  -webkit-animation: hqYbNG 1.4s ease-in-out infinite;
+  animation: hqYbNG 1.4s ease-in-out infinite;
 }
 
 .c1.thin circle {
@@ -157,7 +157,7 @@ exports[`RadioIcon Should render a loader if isLoading and isChecked are set to 
 >
   <svg
     aria-hidden={true}
-    className="kirk-icon kirk-icon-circle c1 spinning c2"
+    className="kirk-icon kirk-icon-circle spinning c1 c2"
     fill="#5DD167"
     height={24}
     viewBox="0 0 66 66"
@@ -177,7 +177,7 @@ exports[`RadioIcon Should render a loader if isLoading and isChecked are set to 
 `;
 
 exports[`RadioIcon Should render a loader if isLoading is set to true 1`] = `
-.c2 {
+.c2.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -189,8 +189,8 @@ exports[`RadioIcon Should render a loader if isLoading is set to true 1`] = `
 }
 
 .c1.spinning {
-  -webkit-animation: rotator 1.4s linear infinite;
-  animation: rotator 1.4s linear infinite;
+  -webkit-animation: cqjtzU 1.4s linear infinite;
+  animation: cqjtzU 1.4s linear infinite;
 }
 
 .c1 circle {
@@ -204,8 +204,8 @@ exports[`RadioIcon Should render a loader if isLoading is set to true 1`] = `
   -webkit-transform-origin: center;
   -ms-transform-origin: center;
   transform-origin: center;
-  -webkit-animation: dash 1.4s ease-in-out infinite;
-  animation: dash 1.4s ease-in-out infinite;
+  -webkit-animation: hqYbNG 1.4s ease-in-out infinite;
+  animation: hqYbNG 1.4s ease-in-out infinite;
 }
 
 .c1.thin circle {
@@ -262,7 +262,7 @@ exports[`RadioIcon Should render a loader if isLoading is set to true 1`] = `
 >
   <svg
     aria-hidden={true}
-    className="kirk-icon kirk-icon-circle c1 spinning c2"
+    className="kirk-icon kirk-icon-circle spinning c1 c2"
     fill="#5DD167"
     height={24}
     viewBox="0 0 66 66"
@@ -282,7 +282,7 @@ exports[`RadioIcon Should render a loader if isLoading is set to true 1`] = `
 `;
 
 exports[`RadioIcon Should render an empty circle by default 1`] = `
-.c1 {
+.c1.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -294,8 +294,8 @@ exports[`RadioIcon Should render an empty circle by default 1`] = `
 }
 
 .c0.spinning {
-  -webkit-animation: rotator 1.4s linear infinite;
-  animation: rotator 1.4s linear infinite;
+  -webkit-animation: cqjtzU 1.4s linear infinite;
+  animation: cqjtzU 1.4s linear infinite;
 }
 
 .c0 circle {
@@ -309,8 +309,8 @@ exports[`RadioIcon Should render an empty circle by default 1`] = `
   -webkit-transform-origin: center;
   -ms-transform-origin: center;
   transform-origin: center;
-  -webkit-animation: dash 1.4s ease-in-out infinite;
-  animation: dash 1.4s ease-in-out infinite;
+  -webkit-animation: hqYbNG 1.4s ease-in-out infinite;
+  animation: hqYbNG 1.4s ease-in-out infinite;
 }
 
 .c0.thin circle {

--- a/src/datePicker/__snapshots__/DatePicker.unit.tsx.snap
+++ b/src/datePicker/__snapshots__/DatePicker.unit.tsx.snap
@@ -17,7 +17,7 @@ exports[`DatePicker renderCaption Should render the given month title with year 
 `;
 
 exports[`DatePicker renderNavbar Should render the previous/next buttons in horizontal mode 1`] = `
-.c1 {
+.c1.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }

--- a/src/icon/checkIcon.tsx
+++ b/src/icon/checkIcon.tsx
@@ -13,9 +13,9 @@ interface CheckProps extends Icon {
 }
 
 const CheckIcon = (props: CheckProps) => (
-  <BaseIcon {...props} className={cc([
+  <BaseIcon {...props} iconClassName={cc([
     'kirk-icon-check',
-    props.className,
+    props.iconClassName,
     {
       validate: props.validate,
       absolute: props.absolute

--- a/src/icon/circleIcon.tsx
+++ b/src/icon/circleIcon.tsx
@@ -3,7 +3,7 @@ import React, { Fragment } from 'react'
 import cc from 'classcat'
 import BaseIcon from '_utils/icon'
 import { BaseIconDefaultProps } from '_utils/icon/BaseIcon'
-import styled from 'styled-components'
+import styled, { keyframes } from 'styled-components'
 
 interface CircleProps extends Icon {
   readonly absolute?: boolean
@@ -16,9 +16,9 @@ const offset = 187
 const duration = '1.4s'
 
 const CircleIcon = (props: CircleProps) => (
-    <BaseIcon {...props} viewBox="0 0 66 66" className={cc([
+    <BaseIcon {...props} viewBox="0 0 66 66" iconClassName={cc([
       'kirk-icon-circle',
-      props.className,
+      props.iconClassName,
       {
         spinning: props.spinning,
         absolute: props.absolute,
@@ -32,31 +32,34 @@ const CircleIcon = (props: CircleProps) => (
     </BaseIcon>
 )
 
-export const StyledCircleIcon = styled(CircleIcon)`
-  @keyframes dash {
-    0% {
-      stroke-dashoffset: ${offset};
-    }
-    50% {
-      stroke-dashoffset: ${offset / 4};
-      transform: rotate(135deg);
-    }
-    100% {
-      stroke-dashoffset: ${offset};
-      transform: rotate(450deg);
-    }
-  }
-  @keyframes rotator {
+const dashKeyframesBuilder = (offset: number) => {
+    return keyframes`
+        0% {
+          stroke-dashoffset: ${offset};
+        }
+        50% {
+          stroke-dashoffset: ${offset / 4};
+          transform: rotate(135deg);
+        }
+        100% {
+          stroke-dashoffset: ${offset};
+          transform: rotate(450deg);
+        }
+      `
+}
+
+const rotatorKeyframes = keyframes`
     0% {
       transform: rotate(0deg);
     }
     100% {
       transform: rotate(270deg);
     }
-  }
+  `
 
+export const StyledCircleIcon = styled(CircleIcon)`
   &.spinning {
-    animation: rotator ${duration} linear infinite;
+    animation: ${rotatorKeyframes} ${duration} linear infinite;
   }
 
   & circle {
@@ -68,7 +71,7 @@ export const StyledCircleIcon = styled(CircleIcon)`
     stroke-dasharray: ${offset};
     stroke-dashoffset: 0;
     transform-origin: center;
-    animation: dash ${duration} ease-in-out infinite;
+    animation: ${dashKeyframesBuilder(offset)} ${duration} ease-in-out infinite;
   }
 
   &.thin circle {

--- a/src/itemCheckbox/__snapshots__/ItemCheckbox.unit.tsx.snap
+++ b/src/itemCheckbox/__snapshots__/ItemCheckbox.unit.tsx.snap
@@ -64,7 +64,7 @@ exports[`ItemCheckbox Should display a CheckIcon when the input is checked 1`] =
   font-weight: 500;
 }
 
-.c3 {
+.c3.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -317,7 +317,7 @@ exports[`ItemCheckbox Should display a Loader when the component is in loading s
   font-weight: 500;
 }
 
-.c4 {
+.c4.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -420,8 +420,8 @@ button.c0 {
 }
 
 .c3.spinning {
-  -webkit-animation: rotator 1.4s linear infinite;
-  animation: rotator 1.4s linear infinite;
+  -webkit-animation: cqjtzU 1.4s linear infinite;
+  animation: cqjtzU 1.4s linear infinite;
 }
 
 .c3 circle {
@@ -435,8 +435,8 @@ button.c0 {
   -webkit-transform-origin: center;
   -ms-transform-origin: center;
   transform-origin: center;
-  -webkit-animation: dash 1.4s ease-in-out infinite;
-  animation: dash 1.4s ease-in-out infinite;
+  -webkit-animation: hqYbNG 1.4s ease-in-out infinite;
+  animation: hqYbNG 1.4s ease-in-out infinite;
 }
 
 .c3.thin circle {
@@ -534,7 +534,7 @@ button.c0 {
     >
       <svg
         aria-hidden={true}
-        className="kirk-icon kirk-icon-circle c3 spinning c4"
+        className="kirk-icon kirk-icon-circle spinning c3 c4"
         fill="#5DD167"
         height={24}
         viewBox="0 0 66 66"
@@ -619,7 +619,7 @@ exports[`ItemCheckbox Should forward its props to the Item component 1`] = `
   font-weight: 500;
 }
 
-.c3 {
+.c3.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -722,8 +722,8 @@ button.c0 {
 }
 
 .c2.spinning {
-  -webkit-animation: rotator 1.4s linear infinite;
-  animation: rotator 1.4s linear infinite;
+  -webkit-animation: cqjtzU 1.4s linear infinite;
+  animation: cqjtzU 1.4s linear infinite;
 }
 
 .c2 circle {
@@ -737,8 +737,8 @@ button.c0 {
   -webkit-transform-origin: center;
   -ms-transform-origin: center;
   transform-origin: center;
-  -webkit-animation: dash 1.4s ease-in-out infinite;
-  animation: dash 1.4s ease-in-out infinite;
+  -webkit-animation: hqYbNG 1.4s ease-in-out infinite;
+  animation: hqYbNG 1.4s ease-in-out infinite;
 }
 
 .c2.thin circle {

--- a/src/itemChoice/__snapshots__/index.unit.tsx.snap
+++ b/src/itemChoice/__snapshots__/index.unit.tsx.snap
@@ -64,7 +64,7 @@ exports[`ItemChoice Should display a Loader when the component is in loading sta
   font-weight: 500;
 }
 
-.c1 {
+.c1.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -167,8 +167,8 @@ button.c0 {
 }
 
 .c4.spinning {
-  -webkit-animation: rotator 1.4s linear infinite;
-  animation: rotator 1.4s linear infinite;
+  -webkit-animation: cqjtzU 1.4s linear infinite;
+  animation: cqjtzU 1.4s linear infinite;
 }
 
 .c4 circle {
@@ -182,8 +182,8 @@ button.c0 {
   -webkit-transform-origin: center;
   -ms-transform-origin: center;
   transform-origin: center;
-  -webkit-animation: dash 1.4s ease-in-out infinite;
-  animation: dash 1.4s ease-in-out infinite;
+  -webkit-animation: hqYbNG 1.4s ease-in-out infinite;
+  animation: hqYbNG 1.4s ease-in-out infinite;
 }
 
 .c4.thin circle {
@@ -332,7 +332,7 @@ button.c0 {
     >
       <svg
         aria-hidden={true}
-        className="kirk-icon kirk-icon-circle c4 spinning c1"
+        className="kirk-icon kirk-icon-circle spinning c4 c1"
         fill="#5DD167"
         height={24}
         viewBox="0 0 66 66"
@@ -417,7 +417,7 @@ exports[`ItemChoice Should display a done Loader when the component is in checke
   font-weight: 500;
 }
 
-.c1 {
+.c1.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -675,7 +675,7 @@ button.c0 {
     >
       <svg
         aria-hidden={true}
-        className="kirk-icon kirk-icon-check c4 validate c1"
+        className="kirk-icon kirk-icon-check validate c4 c1"
         fill="#FFF"
         height={12}
         viewBox="0 0 24 24"
@@ -762,7 +762,7 @@ exports[`ItemChoice Should forward its props to the Item component 1`] = `
   font-weight: 500;
 }
 
-.c1 {
+.c1.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -1078,7 +1078,7 @@ exports[`ItemChoice Should support a disabled state 1`] = `
   font-weight: 500;
 }
 
-.c1 {
+.c1.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -1396,7 +1396,7 @@ exports[`ItemChoice Should use a button tag if no href is given 1`] = `
   font-weight: 500;
 }
 
-.c1 {
+.c1.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }

--- a/src/itemRadio/__snapshots__/ItemRadio.unit.tsx.snap
+++ b/src/itemRadio/__snapshots__/ItemRadio.unit.tsx.snap
@@ -64,7 +64,7 @@ exports[`ItemRadio Should display a CircleIcon with an innerDisc when the input 
   font-weight: 500;
 }
 
-.c3 {
+.c3.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -167,8 +167,8 @@ button.c0 {
 }
 
 .c2.spinning {
-  -webkit-animation: rotator 1.4s linear infinite;
-  animation: rotator 1.4s linear infinite;
+  -webkit-animation: cqjtzU 1.4s linear infinite;
+  animation: cqjtzU 1.4s linear infinite;
 }
 
 .c2 circle {
@@ -182,8 +182,8 @@ button.c0 {
   -webkit-transform-origin: center;
   -ms-transform-origin: center;
   transform-origin: center;
-  -webkit-animation: dash 1.4s ease-in-out infinite;
-  animation: dash 1.4s ease-in-out infinite;
+  -webkit-animation: hqYbNG 1.4s ease-in-out infinite;
+  animation: hqYbNG 1.4s ease-in-out infinite;
 }
 
 .c2.thin circle {
@@ -333,7 +333,7 @@ exports[`ItemRadio Should display a Loader when the component is in loading stat
   font-weight: 500;
 }
 
-.c4 {
+.c4.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -436,8 +436,8 @@ button.c0 {
 }
 
 .c3.spinning {
-  -webkit-animation: rotator 1.4s linear infinite;
-  animation: rotator 1.4s linear infinite;
+  -webkit-animation: cqjtzU 1.4s linear infinite;
+  animation: cqjtzU 1.4s linear infinite;
 }
 
 .c3 circle {
@@ -451,8 +451,8 @@ button.c0 {
   -webkit-transform-origin: center;
   -ms-transform-origin: center;
   transform-origin: center;
-  -webkit-animation: dash 1.4s ease-in-out infinite;
-  animation: dash 1.4s ease-in-out infinite;
+  -webkit-animation: hqYbNG 1.4s ease-in-out infinite;
+  animation: hqYbNG 1.4s ease-in-out infinite;
 }
 
 .c3.thin circle {
@@ -551,7 +551,7 @@ button.c0 {
     >
       <svg
         aria-hidden={true}
-        className="kirk-icon kirk-icon-circle c3 spinning c4"
+        className="kirk-icon kirk-icon-circle spinning c3 c4"
         fill="#5DD167"
         height={24}
         viewBox="0 0 66 66"
@@ -636,7 +636,7 @@ exports[`ItemRadio Should forward its props to the Item component 1`] = `
   font-weight: 500;
 }
 
-.c3 {
+.c3.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -739,8 +739,8 @@ button.c0 {
 }
 
 .c2.spinning {
-  -webkit-animation: rotator 1.4s linear infinite;
-  animation: rotator 1.4s linear infinite;
+  -webkit-animation: cqjtzU 1.4s linear infinite;
+  animation: cqjtzU 1.4s linear infinite;
 }
 
 .c2 circle {
@@ -754,8 +754,8 @@ button.c0 {
   -webkit-transform-origin: center;
   -ms-transform-origin: center;
   transform-origin: center;
-  -webkit-animation: dash 1.4s ease-in-out infinite;
-  animation: dash 1.4s ease-in-out infinite;
+  -webkit-animation: hqYbNG 1.4s ease-in-out infinite;
+  animation: hqYbNG 1.4s ease-in-out infinite;
 }
 
 .c2.thin circle {

--- a/src/itemRadioGroup/__snapshots__/index.unit.tsx.snap
+++ b/src/itemRadioGroup/__snapshots__/index.unit.tsx.snap
@@ -64,7 +64,7 @@ exports[`ItemRadioGroup Should map its children and render them with specific pr
   font-weight: 500;
 }
 
-.c5 {
+.c5.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -167,8 +167,8 @@ button.c2 {
 }
 
 .c4.spinning {
-  -webkit-animation: rotator 1.4s linear infinite;
-  animation: rotator 1.4s linear infinite;
+  -webkit-animation: cqjtzU 1.4s linear infinite;
+  animation: cqjtzU 1.4s linear infinite;
 }
 
 .c4 circle {
@@ -182,8 +182,8 @@ button.c2 {
   -webkit-transform-origin: center;
   -ms-transform-origin: center;
   transform-origin: center;
-  -webkit-animation: dash 1.4s ease-in-out infinite;
-  animation: dash 1.4s ease-in-out infinite;
+  -webkit-animation: hqYbNG 1.4s ease-in-out infinite;
+  animation: hqYbNG 1.4s ease-in-out infinite;
 }
 
 .c4.thin circle {

--- a/src/itemsList/__snapshots__/ItemsList.unit.tsx.snap
+++ b/src/itemsList/__snapshots__/ItemsList.unit.tsx.snap
@@ -64,7 +64,7 @@ exports[`ItemsList Should render an unordered list 1`] = `
   font-weight: 500;
 }
 
-.c3 {
+.c3.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -411,7 +411,7 @@ exports[`ItemsList Should render an unordered list with some separators 1`] = `
   font-weight: 500;
 }
 
-.c3 {
+.c3.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -758,7 +758,7 @@ exports[`ItemsList Should render an unordered list with the separators classname
   font-weight: 500;
 }
 
-.c3 {
+.c3.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }

--- a/src/messagingSummaryItem/__snapshots__/MessagingSummaryItem.unit.tsx.snap
+++ b/src/messagingSummaryItem/__snapshots__/MessagingSummaryItem.unit.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Should render properly with read messages 1`] = `
-.c3 {
+.c3.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -329,7 +329,7 @@ button.c0 {
 `;
 
 exports[`Should render properly with unread messages 1`] = `
-.c3 {
+.c3.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }

--- a/src/modal/__snapshots__/Modal.unit.tsx.snap
+++ b/src/modal/__snapshots__/Modal.unit.tsx.snap
@@ -46,7 +46,7 @@ exports[`Modal should not have changed 1`] = `
   transform: translateY(50%);
 }
 
-.c3 {
+.c3.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }

--- a/src/phoneField/__snapshots__/PhoneField.unit.tsx.snap
+++ b/src/phoneField/__snapshots__/PhoneField.unit.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PhoneField should have the expected markup in the DOM with custom settings 1`] = `
-.c2 {
+.c2.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -603,7 +603,7 @@ exports[`PhoneField should have the expected markup in the DOM with custom setti
 `;
 
 exports[`PhoneField should have the expected markup in the DOM with default settings 1`] = `
-.c2 {
+.c2.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }

--- a/src/proximity/__snapshots__/Proximity.unit.tsx.snap
+++ b/src/proximity/__snapshots__/Proximity.unit.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Should highlight CLOSE and have a title 1`] = `
-.c0 {
+.c0.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -63,7 +63,7 @@ exports[`Should highlight CLOSE and have a title 1`] = `
 `;
 
 exports[`Should highlight FAR and have a title 1`] = `
-.c0 {
+.c0.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -125,7 +125,7 @@ exports[`Should highlight FAR and have a title 1`] = `
 `;
 
 exports[`Should highlight MIDDLE without a title 1`] = `
-.c0 {
+.c0.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }

--- a/src/pushInfo/__snapshots__/PushInfo.unit.tsx.snap
+++ b/src/pushInfo/__snapshots__/PushInfo.unit.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Should also have the correct icon. 1`] = `
-.c1 {
+.c1.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }

--- a/src/selectField/__snapshots__/SelectField.unit.tsx.snap
+++ b/src/selectField/__snapshots__/SelectField.unit.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SelectField should have the expected markup in the DOM 1`] = `
-.c1 {
+.c1.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }

--- a/src/snackbar/__snapshots__/Snackbar.unit.tsx.snap
+++ b/src/snackbar/__snapshots__/Snackbar.unit.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Snackbar should not have changed 1`] = `
-.c4 {
+.c4.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }

--- a/src/typings/icons.d.ts
+++ b/src/typings/icons.d.ts
@@ -1,6 +1,7 @@
 declare interface Icon {
   readonly size?: number | string
   readonly className?: Classcat.Class
+  readonly iconClassName? : Classcat.Class
   readonly title?: string
   readonly iconColor?: string
   readonly badgeAriaLabel?: string


### PR DESCRIPTION
- use styled component keyframes utility to generate the dash and rotator keyframes for Circle icon (this is used by the loader in spinning mode)
- Add missing .kirk-icon-wrapper class for icons with a badge