### PR TITLE
Release/v10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Unreleased
 
+- [...]
+
+# v10.0.0 (07/08/2019)
+
 - **[FIX]** Non-valid CSS property on Snackbar
 - **[UPDATE]** `<Itinerary>`: Change font weight of the headline to medium
 - **[BREAKING CHANGE]** `<Profile>`: will have medium font weight when isMedium is true
 - **[BREAKING CHANGE]** `DISPLAY1` and `DISPLAY2` css has been inverted to comply to the design specification names
-- [...]
 
 # v9.0.0 (01/08/2019)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "homepage": "https://blablacar.github.io/ui-library",


### PR DESCRIPTION
- **[FIX]** Non-valid CSS property on Snackbar
- **[UPDATE]** `<Itinerary>`: Change font weight of the headline to medium
- **[BREAKING CHANGE]** `<Profile>`: will have medium font weight when isMedium is true
- **[BREAKING CHANGE]** `DISPLAY1` and `DISPLAY2` css has been inverted to comply to the design specification names