### PR TITLE
Fix medium profile display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** `<Profile>`: name should be display in DISPLAY1 instead of DISPLAY2 when medium
 - [...]
 
 # v10.0.0 (07/08/2019)

--- a/src/profile/index.tsx
+++ b/src/profile/index.tsx
@@ -57,7 +57,7 @@ const Profile = ({
     <Item
       className={className}
       leftTitle={title}
-      leftTitleDisplay={isMedium ? TextDisplayType.DISPLAY2 : TextDisplayType.TITLE}
+      leftTitleDisplay={isMedium ? TextDisplayType.DISPLAY1 : TextDisplayType.TITLE}
       leftBody={getLeftBody}
       rightAddon={
         picture && (

--- a/src/profile/index.unit.tsx
+++ b/src/profile/index.unit.tsx
@@ -21,7 +21,7 @@ it('Should pass a title prop to Item', () => {
   expect(profile.find(Item).prop('leftTitleDisplay')).toEqual(TextDisplayType.TITLE)
 
   const profileMedium = shallow(<Profile title="Jack Sparrow" isMedium />)
-  expect(profileMedium.find(Item).prop('leftTitleDisplay')).toEqual(TextDisplayType.DISPLAY2)
+  expect(profileMedium.find(Item).prop('leftTitleDisplay')).toEqual(TextDisplayType.DISPLAY1)
 })
 
 it('Should display info if no rating is provided', () => {

--- a/src/title/index.tsx
+++ b/src/title/index.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { color, font } from '_utils/branding'
+import { color, font, fontWeight } from '_utils/branding'
 
 import Title from './Title'
 
@@ -7,7 +7,7 @@ const StyledTitle = styled(Title)`
   & {
     color: ${color.primaryText};
     font-size: ${font.xl.size};
-    font-weight: 500;
+    font-weight: ${fontWeight.medium};
     line-height: ${font.xl.lineHeight};
   }
 `


### PR DESCRIPTION
User name should be display in DISPLAY1 instead of DISPLAY2 for medium profile

This is a regression I introduced in the v10.0.0

*issue*
![image](https://user-images.githubusercontent.com/2495124/62640563-21f20500-b942-11e9-9194-4e225e4d8505.png)


*fix*
![image](https://user-images.githubusercontent.com/2495124/62640541-169ed980-b942-11e9-8feb-8b0ee9353d6d.png)
