### PR TITLE
Release/v10.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Unreleased
 
-- **[FIX]** `<Profile>`: name should be display in DISPLAY1 instead of DISPLAY2 when medium
 - [...]
+
+# v10.0.1 (07/08/2019)
+
+- **[FIX]** `<Profile>`: name should be display in DISPLAY1 instead of DISPLAY2 when medium
 
 # v10.0.0 (07/08/2019)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "homepage": "https://blablacar.github.io/ui-library",


### PR DESCRIPTION
# v10.0.1 (07/08/2019)

- **[FIX]** `<Profile>`: name should be display in DISPLAY1 instead of DISPLAY2 when medium