### PR TITLE
Adapt Textarea height when changing programmatically its content in 'fitContent' mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [...]
 - **[NEW]** Add new `CarIcon`, `MailIcon`, `PhotoIcon`
 - **[UPDATE]** Update visual of `SendIcon`
+- **[FIX]** Update height of `Textarea` when its content is changed programmatically while using the `fitContent` behavior.
 
 # v11.0.3 (30/08/2019)
 

--- a/src/icon/sendIcon.tsx
+++ b/src/icon/sendIcon.tsx
@@ -1,3 +1,4 @@
+// tslint:disable:max-line-length
 import React from 'react'
 import BaseIcon from '_utils/icon'
 import { BaseIconDefaultProps } from '_utils/icon/BaseIcon'

--- a/src/textarea/Textarea.tsx
+++ b/src/textarea/Textarea.tsx
@@ -100,6 +100,11 @@ export default class Textarea extends PureComponent<TextAreaProps, TextAreaState
       this.setState({
         value: defaultValue,
       })
+      // Update height in next tick to give a chance to the contained text to
+      // give a proper layout to the surrounding parents.
+      setTimeout(() => {
+        this.maybeAdaptHeightToContent()
+      }, 0)
     }
     if (focus && this.props.focus !== focus &&
         this.textareaRef && this.textareaRef.current) {
@@ -132,20 +137,27 @@ export default class Textarea extends PureComponent<TextAreaProps, TextAreaState
     )
   }
 
+  maybeAdaptHeightToContent = () => {
+    if (!this.props.fitContent) {
+      return
+    }
+
+    // Fit height to content.
+    if (this.textareaRef && this.textareaRef.current) {
+      this.textareaRef.current.style.height = '0'
+      const verticalPadding = 16
+      this.textareaRef.current.style.height =
+          `${this.textareaRef.current.scrollHeight - 2 * verticalPadding}px`
+    }
+  }
+
   onChange = () => {
     this.props.onChange({
       name: this.props.name,
       value: this.state.value,
     })
 
-    // Fit to content.
-    if (this.props.fitContent && this.textareaRef && this.textareaRef.current) {
-      this.textareaRef.current.style.height = '0'
-      const verticalPadding = 16
-      this.textareaRef.current.style.height =
-          `${this.textareaRef.current.scrollHeight - 2 * verticalPadding}px`
-
-    }
+    this.maybeAdaptHeightToContent()
   }
 
   ref = (textarea: HTMLTextAreaElement) => {

--- a/src/textarea/story.tsx
+++ b/src/textarea/story.tsx
@@ -64,6 +64,7 @@ stories.add('Text area with icon and fit to content', () => (
         <TextArea
             fitContent={boolean('fitContent', true)}
             id={text('id')}
+            defaultValue={text('Value', '')}
             name={text('name', 'inputName')}
             placeholder={text('placeholder', 'Some placeholder text')}
             labelledBy={text('aria label')}


### PR DESCRIPTION
When used with fitContent mode, the Textarea is adapting its height as the user typs in the field. We need to update the height as well when the value of the field is updated programmatically using the defaultValue props.

TESTED=Locally in story book with programmatic and manual modifications of Textarea content.