### PR TITLE
New loading state for confirmation modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [...]
+- **[NEW]** Loading state for `ConfirmationModal` confirm button
 
 # v11.2.0 (04/09/2019)
 

--- a/src/confirmationModal/ConfirmationModal.tsx
+++ b/src/confirmationModal/ConfirmationModal.tsx
@@ -18,6 +18,7 @@ export interface ConfirmationModalProps extends ModalProps {
   readonly status: ConfirmationModalStatus
   readonly onConfirm?: () => void
   readonly confirmLabel?: string
+  readonly confirmIsLoading?: boolean
 }
 
 class ConfirmationModal extends Component<ConfirmationModalProps> {
@@ -35,6 +36,7 @@ class ConfirmationModal extends Component<ConfirmationModalProps> {
       ariaLabelledBy,
       ariaDescribedBy,
       forwardedRef,
+      confirmIsLoading,
     } = this.props
 
     const isWarning = status === ConfirmationModalStatus.WARNING
@@ -61,6 +63,9 @@ class ConfirmationModal extends Component<ConfirmationModalProps> {
       }
       return <InfoIcon {...iconProps} iconColor={color.info} />
     }
+
+    let confirmButtonStatus = isWarning ? ButtonStatus.WARNING : ButtonStatus.PRIMARY
+    confirmButtonStatus = confirmIsLoading ? ButtonStatus.LOADING : confirmButtonStatus
 
     return (
       <Modal
@@ -90,7 +95,7 @@ class ConfirmationModal extends Component<ConfirmationModalProps> {
               </Button>
             )}
             <Button
-              status={isWarning ? ButtonStatus.WARNING : ButtonStatus.PRIMARY}
+              status={confirmButtonStatus}
               className={`${baseClassName}-confirmButton`}
               onClick={onConfirm}
             >

--- a/src/confirmationModal/ConfirmationModal.unit.tsx
+++ b/src/confirmationModal/ConfirmationModal.unit.tsx
@@ -60,6 +60,21 @@ describe('<ConfirmationModal> with warning status', () => {
     confirmButton.simulate('click')
     expect(mockConfirm).toHaveBeenCalledTimes(1)
   })
+
+  it('should have a loading button if confirmIsLoading is set to true', () => {
+    const wrapper = mount(
+      <ConfirmationModal
+        {...defaultWarningProps}
+        isOpen
+        onConfirm={mockConfirm}
+        onClose={mockClose}
+        confirmIsLoading
+      />,
+    )
+
+    const confirmButton = wrapper.find('.kirk-button-loading')
+    expect(confirmButton).toHaveLength(1)
+  })
 })
 
 describe('<ConfirmationModal> with reminder status', () => {

--- a/src/confirmationModal/story.tsx
+++ b/src/confirmationModal/story.tsx
@@ -40,6 +40,7 @@ class ConfirmationModalOpener extends Component<ConfirmationModalProps> {
           onClose={this.closeConfirmationModal}
           onConfirm={this.confirmConfirmationModal}
           isOpen={this.state.confirmationModalOpen}
+          confirmIsLoading={this.props.confirmIsLoading}
         >
           <div>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
@@ -61,6 +62,7 @@ stories.add(
       confirmLabel={text('confirmLabel', 'Fhtagn')}
       size={select('size', ModalSize, ModalSize.MEDIUM)}
       closeOnEsc={boolean('closeOnEsc', true)}
+      confirmIsLoading={boolean('confirmIsLoading', false)}
     />
   ),
   {


### PR DESCRIPTION
<img width="674" alt="Capture d’écran 2019-09-04 à 17 24 48" src="https://user-images.githubusercontent.com/14176147/64268819-1aba1900-cf39-11e9-8ee1-f82fdb88039e.png">
