### PR TITLE
Bbc 693/tabs icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
 
 - **[FIX]** Fix font-size for `MessagingSummaryItem` sublabel.
-- [...]
+- **[UPDATE]** Add possibility to use icons in `Tabs`
+- **[NEW]** Add `BusIcon` and `CarpoolIcon`
 
 # v11.2.4 (16/09/2019)
 

--- a/src/icon/busIcon.tsx
+++ b/src/icon/busIcon.tsx
@@ -1,0 +1,36 @@
+// tslint:disable:max-line-length
+import React from 'react'
+import { color } from '_utils/branding'
+import BaseIcon from '_utils/icon'
+import { BaseIconDefaultProps } from '_utils/icon/BaseIcon'
+
+export const BusIcon = (props: Icon) => (
+  <BaseIcon {...props} viewBox="0 0 28 17">
+    <g transform="translate(0 1)" fill="none" fillRule="evenodd">
+      <path
+        d="M.67 6.33V2C.67.92 1.33.33 2.33.33h21.02C26 .33 27.33 3.01 27.33 5v6.34a1 1 0 0 1-1 1H4.67l-3.32-1.11a1 1 0 0 1-.68-.95V6.33z"
+        stroke={props.iconColor}
+        fill={color.white}
+      />
+      <path
+        d="M.67 5h20c1 0 1.66 1.66 2.66 1.66h4v4.67a1 1 0 0 1-1 1H4.67L1 11.1a.5.5 0 0 1-.34-.47V5z"
+        stroke={props.iconColor}
+        fill={props.iconColor}
+      />
+      <path d="M4 7h7.33" stroke={color.white} strokeLinecap="round" strokeLinejoin="round" />
+      <path
+        d="M4.67 5.67V.33M10 5V.33m5.33 6v-6m5.34 6v-6"
+        stroke={props.iconColor}
+        fill={color.white}
+        strokeLinecap="square"
+      />
+      <circle stroke={props.iconColor} fill={color.white} cx="22.67" cy="13" r="2" />
+      <circle stroke={props.iconColor} fill={color.white} cx="6" cy="13" r="2" />
+      <circle stroke={props.iconColor} fill={color.white} cx="11.67" cy="13" r="2" />
+    </g>
+  </BaseIcon>
+)
+
+BusIcon.defaultProps = BaseIconDefaultProps
+
+export default React.memo(BusIcon)

--- a/src/icon/carpoolIcon.tsx
+++ b/src/icon/carpoolIcon.tsx
@@ -1,0 +1,24 @@
+// tslint:disable:max-line-length
+import React from 'react'
+import { color } from '_utils/branding'
+import BaseIcon from '_utils/icon'
+import { BaseIconDefaultProps } from '_utils/icon/BaseIcon'
+
+export const CarpoolIcon = (props: Icon) => (
+  <BaseIcon {...props} viewBox="0 0 28 16">
+    <g stroke={props.iconColor} fill="none" fillRule="evenodd">
+      <path d="M6.62.33h8.04a4 4 0 0 1 3.2 1.6l2.8 3.75 4.06.8a3.25 3.25 0 0 1 2.61 3.19v1.66a1 1 0 0 1-1 1H4.68l-3.33-1.1a1 1 0 0 1-.68-.95v-3.6a1 1 0 0 1 1-1h1.66l2.4-4.8a1 1 0 0 1 .89-.55z" />
+      <path d="M10 .33v5.34" strokeLinecap="square" />
+      <path
+        d="M1.67 5.67h19l4.05.8a3.25 3.25 0 0 1 2.61 3.2v1.66a1 1 0 0 1-1 1H4.68l-3.33-1.1a1 1 0 0 1-.68-.95V6.67a1 1 0 0 1 1-1z"
+        fill={props.iconColor}
+      />
+      <circle fill={color.white} cx="7.33" cy="12.33" r="2.67" />
+      <circle fill={color.white} cx="20.67" cy="12.33" r="2.67" />
+    </g>
+  </BaseIcon>
+)
+
+CarpoolIcon.defaultProps = BaseIconDefaultProps
+
+export default React.memo(CarpoolIcon)

--- a/src/icon/index.tsx
+++ b/src/icon/index.tsx
@@ -56,6 +56,8 @@ import ShareIcon from './shareIcon'
 import SmokeIcon from './smokeIcon'
 import SpeakIcon from './speakIcon'
 import StarIcon from './starIcon'
+import BusIcon from './busIcon'
+import CarpoolIcon from './carpoolIcon'
 import TicketIcon from './ticketIcon'
 import TrashIcon from './trashIcon'
 import TwitterIcon from './twitterIcon'
@@ -123,6 +125,8 @@ export {
   SmokeIcon,
   SpeakIcon,
   StarIcon,
+  BusIcon,
+  CarpoolIcon,
   TicketIcon,
   TrashIcon,
   TwitterIcon,

--- a/src/tabs/Tabs.tsx
+++ b/src/tabs/Tabs.tsx
@@ -1,7 +1,6 @@
 import React, { createRef, PureComponent, RefObject } from 'react'
 import cc from 'classcat'
 import Badge from 'badge'
-import { space } from '_utils/branding'
 
 export enum TabStatus {
   SCROLLABLE = 'scrollable',
@@ -11,6 +10,8 @@ export enum TabStatus {
 interface Tab {
   readonly id: string
   readonly label: string
+  readonly icon?: React.ReactElement<Icon>
+  readonly showIconOnly?: boolean
   readonly panelContent: JSX.Element
   readonly badgeContent?: string
   readonly badgeAriaLabel?: string
@@ -93,11 +94,11 @@ export class Tabs extends PureComponent<TabsProps, TabsState> {
   static STATUS = TabStatus
 
   handleTabClicked = (e: React.MouseEvent<HTMLButtonElement>) => {
-    this.activateTabById((e.target as HTMLButtonElement).id)
+    this.activateTabById((e.currentTarget as HTMLButtonElement).id)
   }
 
   handleTabKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
-    const tabId = (e.target as HTMLButtonElement).id
+    const tabId = (e.currentTarget as HTMLButtonElement).id
     const tabIds = this.props.tabs.map(tab => tab.id)
     let nextTabId = null
     switch (e.key) {
@@ -184,27 +185,35 @@ export class Tabs extends PureComponent<TabsProps, TabsState> {
                   className={cc(['kirk-tab-container', { 'kirk-tab-selected': isSelected }])}
                   key={tab.id}
                 >
-                  <div className="kirk-tab-relative">
-                    <button
-                      role="tab"
-                      aria-controls={`${generateTabPanelId(tab)}`}
-                      aria-selected={isSelected ? 'true' : 'false'}
-                      title={`${tab.label}${tab.badgeAriaLabel ? ` ${tab.badgeAriaLabel}` : ''}`}
-                      tabIndex={isSelected ? 0 : -1}
-                      id={tab.id}
-                      ref={this.state.tabIdToRefs.get(tab.id)}
-                      onClick={this.handleTabClicked}
-                      onKeyDown={this.handleTabKeyDown}
-                      className={cc(['kirk-tab'])}
-                    >
-                      {tab.label}
-                      {tab.badgeContent && (
-                        <Badge ariaLabel={tab.badgeAriaLabel} className="kirk-tab-badge">
-                          {tab.badgeContent}
-                        </Badge>
-                      )}
-                    </button>
-                  </div>
+                  <button
+                    role="tab"
+                    aria-controls={`${generateTabPanelId(tab)}`}
+                    aria-selected={isSelected ? 'true' : 'false'}
+                    title={`${tab.label}${tab.badgeAriaLabel ? ` ${tab.badgeAriaLabel}` : ''}`}
+                    tabIndex={isSelected ? 0 : -1}
+                    id={tab.id}
+                    ref={this.state.tabIdToRefs.get(tab.id)}
+                    onClick={this.handleTabClicked}
+                    onKeyDown={this.handleTabKeyDown}
+                    className="kirk-tab"
+                  >
+                    {tab.icon}
+                    {!tab.showIconOnly && (
+                      <span
+                        className={cc([
+                          'kirk-tab-text',
+                          { 'kirk-tab-text--with-icon': tab.icon && !tab.showIconOnly },
+                        ])}
+                      >
+                        {tab.label}
+                      </span>
+                    )}
+                    {tab.badgeContent && (
+                      <Badge ariaLabel={tab.badgeAriaLabel} className="kirk-tab-badge">
+                        {tab.badgeContent}
+                      </Badge>
+                    )}
+                  </button>
                 </div>
               )
             })}

--- a/src/tabs/Tabs.unit.tsx
+++ b/src/tabs/Tabs.unit.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 
 import Tabs from './Tabs'
+import MailIcon from 'icon/mailIcon'
 import renderer from 'react-test-renderer'
 
 const defaultTabsConfig = {
@@ -20,7 +21,28 @@ const defaultTabsConfig = {
     {
       id: 'tab3',
       label: 'Tab 3',
-      panelContent: <div style={{ padding: 30 }}>Content for first tab3</div>,
+      panelContent: <div style={{ padding: 30 }}>Content for third tab3</div>,
+    },
+  ],
+}
+
+const iconTabsConfig = {
+  activeTabId: 'iconTab1',
+  tabs: [
+    {
+      ...defaultTabsConfig.tabs[0],
+      id: 'iconTab1',
+      icon: <MailIcon />,
+    },
+    {
+      ...defaultTabsConfig.tabs[1],
+      id: 'iconTab2',
+    },
+    {
+      ...defaultTabsConfig.tabs[2],
+      id: 'iconTab3',
+      icon: <MailIcon />,
+      showIconOnly: true,
     },
   ],
 }
@@ -29,6 +51,13 @@ describe('Rendering testing', () => {
   it('should render properly', () => {
     const tabsAsJson = renderer
       .create(<Tabs tabs={defaultTabsConfig.tabs} activeTabId={defaultTabsConfig.activeTabId} />)
+      .toJSON()
+    expect(tabsAsJson).toMatchSnapshot()
+  })
+
+  it('should render properly with icons', () => {
+    const tabsAsJson = renderer
+      .create(<Tabs tabs={iconTabsConfig.tabs} activeTabId={iconTabsConfig.activeTabId} />)
       .toJSON()
     expect(tabsAsJson).toMatchSnapshot()
   })

--- a/src/tabs/__snapshots__/Tabs.unit.tsx.snap
+++ b/src/tabs/__snapshots__/Tabs.unit.tsx.snap
@@ -19,65 +19,65 @@ exports[`Rendering testing should render properly 1`] = `
       <div
         className="kirk-tab-container kirk-tab-selected"
       >
-        <div
-          className="kirk-tab-relative"
+        <button
+          aria-controls="tab1_panel"
+          aria-selected="true"
+          className="kirk-tab"
+          id="tab1"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="tab"
+          tabIndex={0}
+          title="Tab 1"
         >
-          <button
-            aria-controls="tab1_panel"
-            aria-selected="true"
-            className="kirk-tab"
-            id="tab1"
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            role="tab"
-            tabIndex={0}
-            title="Tab 1"
+          <span
+            className="kirk-tab-text"
           >
             Tab 1
-          </button>
-        </div>
+          </span>
+        </button>
       </div>
       <div
         className="kirk-tab-container"
       >
-        <div
-          className="kirk-tab-relative"
+        <button
+          aria-controls="tab2_panel"
+          aria-selected="false"
+          className="kirk-tab"
+          id="tab2"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="tab"
+          tabIndex={-1}
+          title="Tab 2"
         >
-          <button
-            aria-controls="tab2_panel"
-            aria-selected="false"
-            className="kirk-tab"
-            id="tab2"
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            role="tab"
-            tabIndex={-1}
-            title="Tab 2"
+          <span
+            className="kirk-tab-text"
           >
             Tab 2
-          </button>
-        </div>
+          </span>
+        </button>
       </div>
       <div
         className="kirk-tab-container"
       >
-        <div
-          className="kirk-tab-relative"
+        <button
+          aria-controls="tab3_panel"
+          aria-selected="false"
+          className="kirk-tab"
+          id="tab3"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="tab"
+          tabIndex={-1}
+          title="Tab 3"
         >
-          <button
-            aria-controls="tab3_panel"
-            aria-selected="false"
-            className="kirk-tab"
-            id="tab3"
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            role="tab"
-            tabIndex={-1}
-            title="Tab 3"
+          <span
+            className="kirk-tab-text"
           >
             Tab 3
-          </button>
-        </div>
+          </span>
+        </button>
       </div>
     </div>
   </div>
@@ -110,6 +110,171 @@ exports[`Rendering testing should render properly 1`] = `
     className="kirk-tab-panel"
     hidden={true}
     id="tab3_panel"
+    role="tabpanel"
+  />
+</div>
+`;
+
+exports[`Rendering testing should render properly with icons 1`] = `
+.c0.kirk-icon-wrapper {
+  display: inline-block;
+  position: relative;
+}
+
+.c0 .kirk-icon-badge {
+  position: absolute;
+  bottom: 12px;
+  left: 12px;
+}
+
+<div
+  className="kirk-tabs"
+>
+  <div
+    className="kirk-tablist-wrapper"
+  >
+    <div
+      className="kirk-tab-highlight"
+    />
+    <div
+      aria-multiselectable="false"
+      aria-orientation="horizontal"
+      className="kirk-tablist"
+      role="tablist"
+    >
+      <div
+        className="kirk-tab-container kirk-tab-selected"
+      >
+        <button
+          aria-controls="iconTab1_panel"
+          aria-selected="true"
+          className="kirk-tab"
+          id="iconTab1"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="tab"
+          tabIndex={0}
+          title="Tab 1"
+        >
+          <svg
+            aria-hidden={true}
+            className="kirk-icon c0"
+            fill="#708C91"
+            height={24}
+            viewBox="0 0 24 24"
+            width={24}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            
+            <g
+              fill="none"
+              fillRule="evenodd"
+              stroke="none"
+              strokeWidth="1"
+            >
+              <path
+                d="M21.5,4 C21.7761424,4 22,4.22385763 22,4.5 L22,20.5 C22,20.7454599 21.8231248,20.9496084 21.5898756,20.9919443 L21.5,21 L2.5,21 C2.22385763,21 2,20.7761424 2,20.5 L2,4.5 C2,4.22385763 2.22385763,4 2.5,4 L21.5,4 Z M21,9.366 L12.7515544,14.1426395 C12.2866634,14.4117869 11.7133366,14.4117869 11.2484456,14.1426395 L2.99991707,9.367 L2.99991707,20 L21,20 L21,9.366 Z M21,5 L2.99991707,5 L2.99991707,8.212 L11.7494819,13.2772132 C11.8786183,13.3519764 12.0328555,13.3644369 12.1703589,13.3145948 L12.2505181,13.2772132 L21,8.211 L21,5 Z"
+                fill="#708C91"
+              />
+            </g>
+          </svg>
+          <span
+            className="kirk-tab-text kirk-tab-text--with-icon"
+          >
+            Tab 1
+          </span>
+        </button>
+      </div>
+      <div
+        className="kirk-tab-container"
+      >
+        <button
+          aria-controls="iconTab2_panel"
+          aria-selected="false"
+          className="kirk-tab"
+          id="iconTab2"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="tab"
+          tabIndex={-1}
+          title="Tab 2"
+        >
+          <span
+            className="kirk-tab-text"
+          >
+            Tab 2
+          </span>
+        </button>
+      </div>
+      <div
+        className="kirk-tab-container"
+      >
+        <button
+          aria-controls="iconTab3_panel"
+          aria-selected="false"
+          className="kirk-tab"
+          id="iconTab3"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="tab"
+          tabIndex={-1}
+          title="Tab 3"
+        >
+          <svg
+            aria-hidden={true}
+            className="kirk-icon c0"
+            fill="#708C91"
+            height={24}
+            viewBox="0 0 24 24"
+            width={24}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            
+            <g
+              fill="none"
+              fillRule="evenodd"
+              stroke="none"
+              strokeWidth="1"
+            >
+              <path
+                d="M21.5,4 C21.7761424,4 22,4.22385763 22,4.5 L22,20.5 C22,20.7454599 21.8231248,20.9496084 21.5898756,20.9919443 L21.5,21 L2.5,21 C2.22385763,21 2,20.7761424 2,20.5 L2,4.5 C2,4.22385763 2.22385763,4 2.5,4 L21.5,4 Z M21,9.366 L12.7515544,14.1426395 C12.2866634,14.4117869 11.7133366,14.4117869 11.2484456,14.1426395 L2.99991707,9.367 L2.99991707,20 L21,20 L21,9.366 Z M21,5 L2.99991707,5 L2.99991707,8.212 L11.7494819,13.2772132 C11.8786183,13.3519764 12.0328555,13.3644369 12.1703589,13.3145948 L12.2505181,13.2772132 L21,8.211 L21,5 Z"
+                fill="#708C91"
+              />
+            </g>
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+  <div
+    aria-labelledby="iconTab1"
+    className="kirk-tab-panel"
+    hidden={false}
+    id="iconTab1_panel"
+    role="tabpanel"
+  >
+    <div
+      style={
+        Object {
+          "padding": 30,
+        }
+      }
+    >
+      Content for first tab
+    </div>
+  </div>
+  <div
+    aria-labelledby="iconTab2"
+    className="kirk-tab-panel"
+    hidden={true}
+    id="iconTab2_panel"
+    role="tabpanel"
+  />
+  <div
+    aria-labelledby="iconTab3"
+    className="kirk-tab-panel"
+    hidden={true}
+    id="iconTab3_panel"
     role="tabpanel"
   />
 </div>

--- a/src/tabs/index.tsx
+++ b/src/tabs/index.tsx
@@ -32,7 +32,12 @@ const StyledTabs = styled(Tabs)`
   }
 
   & .kirk-tab {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
     width: 100%;
+    height: 100%;
     outline: none;
     padding: ${space.l};
     background: none;
@@ -43,13 +48,20 @@ const StyledTabs = styled(Tabs)`
     white-space: nowrap;
   }
 
-  & .kirk-tab-container {
-    margin-left: ${space.l};
+  & .kirk-tab > .kirk-icon {
+    flex-shrink: 0;
   }
 
-  & .kirk-tab-relative {
-    display: inline;
-    position: relative;
+  & .kirk-tab-text--with-icon {
+    margin-left: ${space.l};
+    text-align: left;
+  }
+
+  & .kirk-tab-container {
+    margin-left: ${space.l};
+    display: flex;
+    justify-content: center;
+    align-items: last baseline;
   }
 
   &.kirk-tabs-fixed .kirk-tablist {
@@ -58,12 +70,8 @@ const StyledTabs = styled(Tabs)`
 
   &.kirk-tabs-fixed .kirk-tab-container {
     margin-left: 0;
-    flex: 1;
     flex-grow: 1;
-    flex-shrink: 1;
-    flex-basis: 0;
     text-align: center;
-    align-self: flex-end;
   }
 
   &.kirk-tabs-fixed .kirk-tab {
@@ -79,9 +87,10 @@ const StyledTabs = styled(Tabs)`
   }
 
   & .kirk-tab-container .kirk-badge {
-    position: absolute;
-    z-index: 1;
-    top: calc(-1 * (${space.m}));
+    position: relative;
+    left: 0;
+    top: calc(-1 * ${space.s});
+    align-self: flex-start;
   }
 
   & .kirk-tab-highlight {

--- a/src/tabs/story.tsx
+++ b/src/tabs/story.tsx
@@ -1,14 +1,30 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 
 import { storiesOf } from '@storybook/react'
 import { withKnobs, boolean, text, select } from '@storybook/addon-knobs'
 import { action } from '@storybook/addon-actions'
 import Button from 'button'
+import CarpoolIcon from 'icon/carpoolIcon'
+import BusIcon from 'icon/busIcon'
 
 import Tabs, { TabStatus } from 'tabs'
 
 const stories = storiesOf('Tabs', module)
 stories.addDecorator(withKnobs)
+
+const panels = [
+  <div style={{ padding: 30 }}>Content for first tab</div>,
+  <div style={{ padding: 30 }}>
+    <Button
+      onClick={() => {
+        action('onClickButton')
+      }}
+    >
+      Button inside panel 2.
+    </Button>
+  </div>,
+  <div style={{ padding: 30 }}>Content for tab3</div>,
+]
 
 stories.add('default', () => {
   const defaultTabsConfig = {
@@ -19,30 +35,20 @@ stories.add('default', () => {
       {
         id: 'tab1',
         label: text('Tab label 1', 'Tab 1'),
-        panelContent: <div style={{ padding: 30 }}>Content for first tab</div>,
+        panelContent: panels[0],
         badgeContent: text('Badge content 1', ''),
       },
       {
         id: 'tab2',
         label: text('Tab label 2', 'Very Very Long Tab 2'),
-        panelContent: (
-          <div style={{ padding: 30 }}>
-            <Button
-              onClick={() => {
-                action('onClickButton')
-              }}
-            >
-              Button inside panel 2.
-            </Button>
-          </div>
-        ),
+        panelContent: panels[1],
         badgeContent: text('Badge content 2', '2'),
         badgeAriaLabel: 'Unread Message',
       },
       {
         id: 'tab3',
         label: text('Tab label 3', 'Tab 3'),
-        panelContent: <div style={{ padding: 30 }}>Content for first tab3</div>,
+        panelContent: panels[2],
         badgeContent: text('Badge content 3', ''),
       },
     ],
@@ -54,6 +60,48 @@ stories.add('default', () => {
       activeTabId={defaultTabsConfig.activeTabId}
       status={defaultTabsConfig.status}
       isWrapped={defaultTabsConfig.isWrapped}
+    />
+  )
+})
+
+stories.add('with icons', () => {
+  const iconTabsConfig = {
+    activeTabId: 'tab1',
+    status: select('status', TabStatus, TabStatus.FIXED),
+    isWrapped: boolean('isWrapped', false),
+    tabs: [
+      {
+        id: 'tab1',
+        label: text('Tab label 1', 'Tab 1'),
+        panelContent: panels[0],
+        badgeContent: text('Badge content 1', ''),
+      },
+      {
+        id: 'tab2',
+        label: text('Tab label 2', 'Very long Tab 2'),
+        icon: <CarpoolIcon size="32" />,
+        showIconOnly: boolean('showIconOnly Tab 2', false),
+        panelContent: panels[1],
+        badgeContent: text('Badge content 2', '2'),
+        badgeAriaLabel: 'Unread Message',
+      },
+      {
+        id: 'tab3',
+        label: text('Tab label 3', 'Tab 3'),
+        icon: <BusIcon size="32" />,
+        showIconOnly: boolean('showIconOnly Tab 3', true),
+        panelContent: panels[2],
+        badgeContent: text('Badge content 3', ''),
+      },
+    ],
+  }
+  return (
+    <Tabs
+      onChange={action('onChange')}
+      tabs={iconTabsConfig.tabs}
+      activeTabId={iconTabsConfig.activeTabId}
+      status={iconTabsConfig.status}
+      isWrapped={iconTabsConfig.isWrapped}
     />
   )
 })


### PR DESCRIPTION
Add the possibility to use icons within Tabs.
You can chose to also display the text (label) along with the icon (desktop context). This needed to review the alignment of the different elements withing a tab.

Also added 2 icons that are specific to tabs.
<img width="535" alt="Screen Shot 2019-09-20 at 13 45 05" src="https://user-images.githubusercontent.com/373381/65324610-00c13d00-dbad-11e9-83ae-e1753e248e8b.png">
<img width="356" alt="Screen Shot 2019-09-20 at 13 45 52" src="https://user-images.githubusercontent.com/373381/65324611-0159d380-dbad-11e9-96c2-55ef7f8d99e9.png">
