### PR TITLE
force equal width to fixed tabs and ellipsis for long words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- [...]
+- **[UPDATE]** Force equal width among fixed `Tabs`
 
 # v11.3.0 (04/10/2019)
 

--- a/src/tabs/Tabs.tsx
+++ b/src/tabs/Tabs.tsx
@@ -167,6 +167,9 @@ export class Tabs extends PureComponent<TabsProps, TabsState> {
     const { activeTabId } = this.state
     const selectedTab = tabs.find(tab => activeTabId === tab.id)
     const isFixedTabs = this.props.status === TabStatus.FIXED
+    const fixedTabContainerStyle: React.CSSProperties = {
+      width: `calc(100% / ${tabs.length})`,
+    }
 
     return (
       <div className={cc(['kirk-tabs', className, { 'kirk-tabs-fixed': isFixedTabs }])}>
@@ -183,6 +186,7 @@ export class Tabs extends PureComponent<TabsProps, TabsState> {
               return (
                 <div
                   className={cc(['kirk-tab-container', { 'kirk-tab-selected': isSelected }])}
+                  style={isFixedTabs ? fixedTabContainerStyle : null}
                   key={tab.id}
                 >
                   <button

--- a/src/tabs/__snapshots__/Tabs.unit.tsx.snap
+++ b/src/tabs/__snapshots__/Tabs.unit.tsx.snap
@@ -18,6 +18,7 @@ exports[`Rendering testing should render properly 1`] = `
     >
       <div
         className="kirk-tab-container kirk-tab-selected"
+        style={null}
       >
         <button
           aria-controls="tab1_panel"
@@ -39,6 +40,7 @@ exports[`Rendering testing should render properly 1`] = `
       </div>
       <div
         className="kirk-tab-container"
+        style={null}
       >
         <button
           aria-controls="tab2_panel"
@@ -60,6 +62,7 @@ exports[`Rendering testing should render properly 1`] = `
       </div>
       <div
         className="kirk-tab-container"
+        style={null}
       >
         <button
           aria-controls="tab3_panel"
@@ -144,6 +147,7 @@ exports[`Rendering testing should render properly with icons 1`] = `
     >
       <div
         className="kirk-tab-container kirk-tab-selected"
+        style={null}
       >
         <button
           aria-controls="iconTab1_panel"
@@ -187,6 +191,7 @@ exports[`Rendering testing should render properly with icons 1`] = `
       </div>
       <div
         className="kirk-tab-container"
+        style={null}
       >
         <button
           aria-controls="iconTab2_panel"
@@ -208,6 +213,7 @@ exports[`Rendering testing should render properly with icons 1`] = `
       </div>
       <div
         className="kirk-tab-container"
+        style={null}
       >
         <button
           aria-controls="iconTab3_panel"

--- a/src/tabs/index.tsx
+++ b/src/tabs/index.tsx
@@ -4,6 +4,7 @@ import { color, componentSizes, font, space, transition } from '_utils/branding'
 import Tabs from './Tabs'
 
 const highlightHeight = '2px'
+const iconSize = '32px'
 
 const StyledTabs = styled(Tabs)`
   & {
@@ -55,6 +56,9 @@ const StyledTabs = styled(Tabs)`
   & .kirk-tab-text--with-icon {
     margin-left: ${space.l};
     text-align: left;
+    width: calc(100% - ${iconSize});
+    text-overflow: ellipsis;
+    overflow: hidden;
   }
 
   & .kirk-tab-container {

--- a/src/tabs/story.tsx
+++ b/src/tabs/story.tsx
@@ -72,13 +72,13 @@ stories.add('with icons', () => {
     tabs: [
       {
         id: 'tab1',
-        label: text('Tab label 1', 'Tab 1'),
+        label: text('Tab label 1', 'Text only'),
         panelContent: panels[0],
         badgeContent: text('Badge content 1', ''),
       },
       {
         id: 'tab2',
-        label: text('Tab label 2', 'Very long Tab 2'),
+        label: text('Tab label 2', 'Multiple words with an icon'),
         icon: <CarpoolIcon size="32" />,
         showIconOnly: boolean('showIconOnly Tab 2', false),
         panelContent: panels[1],
@@ -87,11 +87,19 @@ stories.add('with icons', () => {
       },
       {
         id: 'tab3',
-        label: text('Tab label 3', 'Tab 3'),
+        label: text('Tab label 3', 'Tremendouslylongwording'),
         icon: <BusIcon size="32" />,
-        showIconOnly: boolean('showIconOnly Tab 3', true),
+        showIconOnly: boolean('showIconOnly Tab 3', false),
         panelContent: panels[2],
         badgeContent: text('Badge content 3', ''),
+      },
+      {
+        id: 'tab4',
+        label: text('Tab label 4', 'Icon only'),
+        icon: <BusIcon size="32" />,
+        showIconOnly: boolean('showIconOnly Tab 4', true),
+        panelContent: panels[2],
+        badgeContent: text('Badge content 4', ''),
       },
     ],
   }


### PR DESCRIPTION
Fixed tabs should have equal width. This wasn't the case as tabs with more content could squish the little ones.
Also, the specs show that a looooong word in a fixed tab should be truncated (ellipsis). This is fixed too.
<img width="814" alt="Screen Shot 2019-10-04 at 17 35 02" src="https://user-images.githubusercontent.com/373381/66221804-0d2ab700-e6d0-11e9-9ceb-e3692cb79c33.png">
