### PR TITLE
fix for fixed tabs content being left aligned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[UPDATE]** Fix `Tabs` content aligned to the left
 - **[NEW]** Add `Divider` Pixar widget.
 - **[NEW]** Add `BlankSeparator` Pixar widget.
 - [...]

--- a/src/tabs/index.tsx
+++ b/src/tabs/index.tsx
@@ -4,7 +4,6 @@ import { color, componentSizes, font, space, transition } from '_utils/branding'
 import Tabs from './Tabs'
 
 const highlightHeight = '2px'
-const iconSize = '32px'
 
 const StyledTabs = styled(Tabs)`
   & {
@@ -53,12 +52,14 @@ const StyledTabs = styled(Tabs)`
     flex-shrink: 0;
   }
 
+  & .kirk-tab-text {
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
   & .kirk-tab-text--with-icon {
     margin-left: ${space.l};
     text-align: left;
-    width: calc(100% - ${iconSize});
-    text-overflow: ellipsis;
-    overflow: hidden;
   }
 
   & .kirk-tab-container {


### PR DESCRIPTION
Before:
<img width="1198" alt="Screen Shot 2019-10-08 at 16 45 02" src="https://user-images.githubusercontent.com/373381/66406345-c4cf0a00-e9eb-11e9-99d9-f129295c42b1.png">

After:
<img width="1198" alt="Screen Shot 2019-10-08 at 16 45 35" src="https://user-images.githubusercontent.com/373381/66406363-cac4eb00-e9eb-11e9-984d-079651a07f40.png">