### PR TITLE
Add missing display modes in Disclaimer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **[UPDATE]** Fix `Tabs` content aligned to the left
 - **[NEW]** Add `Divider` Pixar widget.
 - **[NEW]** Add `BlankSeparator` Pixar widget.
+- **[UPDATE]** Add new display modes for `Disclaimer` widget (isCaption and deprecatedHelpUrl).
 - [...]
 
 # v11.3.1 (07/10/2019)

--- a/src/disclaimer/Disclaimer.tsx
+++ b/src/disclaimer/Disclaimer.tsx
@@ -1,18 +1,41 @@
 import React from 'react'
 import Item from '_utils/item'
 import InfoIcon from 'icon/infoIcon'
+import QuestionIcon from 'icon/questionIcon'
+import Button, { ButtonStatus } from 'button'
 import { TextDisplayType } from 'text'
+import { color } from '_utils/branding'
+
 
 interface DisclaimerProps {
-    readonly useInfoIcon: boolean
+    // Whether to use a decoration Info icon on the left side of the Disclaimer or not.
+    readonly useInfoIcon?: boolean
     readonly children: string|JSX.Element
+    // Whether this Disclaimer will be used as caption to another fragment of UI. In that case, it
+    // will use some caption visual styles (e.g. smaller font)
+    readonly isCaption?: boolean
+    // Whether to use a clickable Question mark blue icon on the right side of the Disclaimer or
+    // not. Activating this affordance will redirect to deprecatedHelpUrl.
+    // This is deprecated, you should use inline links inside the Disclaimer content instead.
+    readonly deprecatedHelpUrl?: string
 }
 
-const Disclaimer = ({ useInfoIcon, children}: DisclaimerProps) => (
+const deprecatedHelpButtonIcon = (deprecatedHelpUrl: string): JSX.Element => {
+    return <Button href={deprecatedHelpUrl} status={ButtonStatus.UNSTYLED} isBubble>
+        <QuestionIcon iconColor={color.primary} />
+    </Button>
+}
+
+const Disclaimer = ({
+        useInfoIcon = true,
+        isCaption = true,
+        children,
+        deprecatedHelpUrl = null}: DisclaimerProps) => (
     <Item
         leftBody={children}
-        leftBodyDisplay={TextDisplayType.CAPTION}
+        leftBodyDisplay={isCaption ? TextDisplayType.CAPTION : TextDisplayType.BODY}
         leftAddon={useInfoIcon ? <InfoIcon /> : null}
+        rightAddon={deprecatedHelpUrl ? deprecatedHelpButtonIcon(deprecatedHelpUrl) : null}
     />
 )
 

--- a/src/disclaimer/Disclaimer.unit.tsx
+++ b/src/disclaimer/Disclaimer.unit.tsx
@@ -1,16 +1,30 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import { InfoIcon } from 'icon/infoIcon'
+import { QuestionIcon } from 'icon/questionIcon'
 import Disclaimer from './Disclaimer'
 import Button from 'button'
 
 const disclaimerContent = 'Disclaimer content'
 
 describe('Disclaimer', () => {
-    it('Should render the disclaimer with icon', () => {
+    it('Should render the disclaimer with Info icon', () => {
         const wrapper = mount(<Disclaimer useInfoIcon>{disclaimerContent}</Disclaimer>)
         expect(wrapper.text()).toBe('Disclaimer content')
         expect(wrapper.find(InfoIcon).exists()).toBe(true)
+    })
+
+    it('Should render the deprecated question mark icon link disclaimer', () => {
+        const wrapper = mount(
+            <Disclaimer useInfoIcon={false} deprecatedHelpUrl='http://google.fr'>
+                {disclaimerContent}
+            </Disclaimer>)
+        expect(wrapper.text()).toBe('Disclaimer content')
+
+        const button = wrapper.find(Button)
+        expect(button.exists()).toBe(true)
+        expect(button.find(QuestionIcon).exists()).toBe(true)
+        expect(button.prop('href')).toBe('http://google.fr')
     })
 
     it('Should render the disclaimer without icon', () => {

--- a/src/disclaimer/story.tsx
+++ b/src/disclaimer/story.tsx
@@ -22,6 +22,10 @@ stories.add('With info icon', () => (
         </Disclaimer>
 
         <Disclaimer useInfoIcon >Some short text disclaimer</Disclaimer>
+
+        <Disclaimer isCaption={false} useInfoIcon >
+            Some short text disclaimer, not styled as a caption
+        </Disclaimer>
     </div>
 
 
@@ -33,6 +37,14 @@ stories.add('Without info icon', () => (
         <Disclaimer useInfoIcon={false} >Some short text disclaimer</Disclaimer>
         <Disclaimer useInfoIcon={false} >
             {longDisclaimer}
+        </Disclaimer>
+    </div>
+))
+
+stories.add('With deprecated help url', () => (
+    <div style={{width: '400px'}}>
+        <Disclaimer useInfoIcon={false} deprecatedHelpUrl={'http://google.fr'}>
+            Some disclaimer with help button icon.
         </Disclaimer>
     </div>
 ))


### PR DESCRIPTION
- Add deprecated rendering for button icon on the right side (used for SRP)
- Add non-caption mode for body text 