### PR TITLE
Make tab and their panel layouts independent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[BREAKING CHANGE]** - Make `Tabs` and their panels layouts independent at DOM level.
 [...]
 
 # v12.0.0 (09/10/2019)

--- a/src/tabs/Tabs.tsx
+++ b/src/tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { createRef, PureComponent, RefObject } from 'react'
+import React, { createRef, PureComponent, RefObject, Fragment } from 'react'
 import cc from 'classcat'
 import Badge from 'badge'
 
@@ -172,58 +172,59 @@ export class Tabs extends PureComponent<TabsProps, TabsState> {
     }
 
     return (
-      <div className={cc(['kirk-tabs', className, { 'kirk-tabs-fixed': isFixedTabs }])}>
-        <div className={cc(['kirk-tablist-wrapper', tablistWrapperClassName])}>
-          <div className="kirk-tab-highlight" ref={this.highlightRef} />
-          <div
-            role="tablist"
-            aria-orientation="horizontal"
-            aria-multiselectable="false"
-            className={cc(['kirk-tablist', { 'kirk-tablist-wrapped': isWrapped }])}
-          >
-            {tabs.map(tab => {
-              const isSelected = selectedTab.id === tab.id
-              return (
-                <div
-                  className={cc(['kirk-tab-container', { 'kirk-tab-selected': isSelected }])}
-                  style={isFixedTabs ? fixedTabContainerStyle : null}
-                  key={tab.id}
-                >
-                  <button
-                    role="tab"
-                    aria-controls={`${generateTabPanelId(tab)}`}
-                    aria-selected={isSelected ? 'true' : 'false'}
-                    title={`${tab.label}${tab.badgeAriaLabel ? ` ${tab.badgeAriaLabel}` : ''}`}
-                    tabIndex={isSelected ? 0 : -1}
-                    id={tab.id}
-                    ref={this.state.tabIdToRefs.get(tab.id)}
-                    onClick={this.handleTabClicked}
-                    onKeyDown={this.handleTabKeyDown}
-                    className="kirk-tab"
+      <Fragment>
+        <div className={cc(['kirk-tabs', className, { 'kirk-tabs-fixed': isFixedTabs }])}>
+          <div className={cc(['kirk-tablist-wrapper', tablistWrapperClassName])}>
+            <div className="kirk-tab-highlight" ref={this.highlightRef} />
+            <div
+              role="tablist"
+              aria-orientation="horizontal"
+              aria-multiselectable="false"
+              className={cc(['kirk-tablist', { 'kirk-tablist-wrapped': isWrapped }])}
+            >
+              {tabs.map(tab => {
+                const isSelected = selectedTab.id === tab.id
+                return (
+                  <div
+                    className={cc(['kirk-tab-container', { 'kirk-tab-selected': isSelected }])}
+                    style={isFixedTabs ? fixedTabContainerStyle : null}
+                    key={tab.id}
                   >
-                    {tab.icon}
-                    {!tab.showIconOnly && (
-                      <span
-                        className={cc([
-                          'kirk-tab-text',
-                          { 'kirk-tab-text--with-icon': tab.icon && !tab.showIconOnly },
-                        ])}
-                      >
-                        {tab.label}
-                      </span>
-                    )}
-                    {tab.badgeContent && (
-                      <Badge ariaLabel={tab.badgeAriaLabel} className="kirk-tab-badge">
-                        {tab.badgeContent}
-                      </Badge>
-                    )}
-                  </button>
-                </div>
-              )
-            })}
+                    <button
+                      role="tab"
+                      aria-controls={`${generateTabPanelId(tab)}`}
+                      aria-selected={isSelected ? 'true' : 'false'}
+                      title={`${tab.label}${tab.badgeAriaLabel ? ` ${tab.badgeAriaLabel}` : ''}`}
+                      tabIndex={isSelected ? 0 : -1}
+                      id={tab.id}
+                      ref={this.state.tabIdToRefs.get(tab.id)}
+                      onClick={this.handleTabClicked}
+                      onKeyDown={this.handleTabKeyDown}
+                      className="kirk-tab"
+                    >
+                      {tab.icon}
+                      {!tab.showIconOnly && (
+                        <span
+                          className={cc([
+                            'kirk-tab-text',
+                            { 'kirk-tab-text--with-icon': tab.icon && !tab.showIconOnly },
+                          ])}
+                        >
+                          {tab.label}
+                        </span>
+                      )}
+                      {tab.badgeContent && (
+                        <Badge ariaLabel={tab.badgeAriaLabel} className="kirk-tab-badge">
+                          {tab.badgeContent}
+                        </Badge>
+                      )}
+                    </button>
+                  </div>
+                )
+              })}
+            </div>
           </div>
         </div>
-
         {tabs.map(tab => {
           const isSelected = selectedTab.id === tab.id
           return (
@@ -239,7 +240,7 @@ export class Tabs extends PureComponent<TabsProps, TabsState> {
             </div>
           )
         })}
-      </div>
+      </Fragment>
     )
   }
 }

--- a/src/tabs/__snapshots__/Tabs.unit.tsx.snap
+++ b/src/tabs/__snapshots__/Tabs.unit.tsx.snap
@@ -1,89 +1,91 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Rendering testing should render properly 1`] = `
-<div
-  className="kirk-tabs"
->
+Array [
   <div
-    className="kirk-tablist-wrapper"
+    className="kirk-tabs"
   >
     <div
-      className="kirk-tab-highlight"
-    />
-    <div
-      aria-multiselectable="false"
-      aria-orientation="horizontal"
-      className="kirk-tablist"
-      role="tablist"
+      className="kirk-tablist-wrapper"
     >
       <div
-        className="kirk-tab-container kirk-tab-selected"
-        style={null}
-      >
-        <button
-          aria-controls="tab1_panel"
-          aria-selected="true"
-          className="kirk-tab"
-          id="tab1"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          role="tab"
-          tabIndex={0}
-          title="Tab 1"
-        >
-          <span
-            className="kirk-tab-text"
-          >
-            Tab 1
-          </span>
-        </button>
-      </div>
+        className="kirk-tab-highlight"
+      />
       <div
-        className="kirk-tab-container"
-        style={null}
+        aria-multiselectable="false"
+        aria-orientation="horizontal"
+        className="kirk-tablist"
+        role="tablist"
       >
-        <button
-          aria-controls="tab2_panel"
-          aria-selected="false"
-          className="kirk-tab"
-          id="tab2"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          role="tab"
-          tabIndex={-1}
-          title="Tab 2"
+        <div
+          className="kirk-tab-container kirk-tab-selected"
+          style={null}
         >
-          <span
-            className="kirk-tab-text"
+          <button
+            aria-controls="tab1_panel"
+            aria-selected="true"
+            className="kirk-tab"
+            id="tab1"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+            tabIndex={0}
+            title="Tab 1"
           >
-            Tab 2
-          </span>
-        </button>
-      </div>
-      <div
-        className="kirk-tab-container"
-        style={null}
-      >
-        <button
-          aria-controls="tab3_panel"
-          aria-selected="false"
-          className="kirk-tab"
-          id="tab3"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          role="tab"
-          tabIndex={-1}
-          title="Tab 3"
+            <span
+              className="kirk-tab-text"
+            >
+              Tab 1
+            </span>
+          </button>
+        </div>
+        <div
+          className="kirk-tab-container"
+          style={null}
         >
-          <span
-            className="kirk-tab-text"
+          <button
+            aria-controls="tab2_panel"
+            aria-selected="false"
+            className="kirk-tab"
+            id="tab2"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+            tabIndex={-1}
+            title="Tab 2"
           >
-            Tab 3
-          </span>
-        </button>
+            <span
+              className="kirk-tab-text"
+            >
+              Tab 2
+            </span>
+          </button>
+        </div>
+        <div
+          className="kirk-tab-container"
+          style={null}
+        >
+          <button
+            aria-controls="tab3_panel"
+            aria-selected="false"
+            className="kirk-tab"
+            id="tab3"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+            tabIndex={-1}
+            title="Tab 3"
+          >
+            <span
+              className="kirk-tab-text"
+            >
+              Tab 3
+            </span>
+          </button>
+        </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
     aria-labelledby="tab1"
     className="kirk-tab-panel"
@@ -100,26 +102,27 @@ exports[`Rendering testing should render properly 1`] = `
     >
       Content for first tab
     </div>
-  </div>
+  </div>,
   <div
     aria-labelledby="tab2"
     className="kirk-tab-panel"
     hidden={true}
     id="tab2_panel"
     role="tabpanel"
-  />
+  />,
   <div
     aria-labelledby="tab3"
     className="kirk-tab-panel"
     hidden={true}
     id="tab3_panel"
     role="tabpanel"
-  />
-</div>
+  />,
+]
 `;
 
 exports[`Rendering testing should render properly with icons 1`] = `
-.c0.kirk-icon-wrapper {
+Array [
+  .c0.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -131,127 +134,128 @@ exports[`Rendering testing should render properly with icons 1`] = `
 }
 
 <div
-  className="kirk-tabs"
->
-  <div
-    className="kirk-tablist-wrapper"
+    className="kirk-tabs"
   >
     <div
-      className="kirk-tab-highlight"
-    />
-    <div
-      aria-multiselectable="false"
-      aria-orientation="horizontal"
-      className="kirk-tablist"
-      role="tablist"
+      className="kirk-tablist-wrapper"
     >
       <div
-        className="kirk-tab-container kirk-tab-selected"
-        style={null}
-      >
-        <button
-          aria-controls="iconTab1_panel"
-          aria-selected="true"
-          className="kirk-tab"
-          id="iconTab1"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          role="tab"
-          tabIndex={0}
-          title="Tab 1"
-        >
-          <svg
-            aria-hidden={true}
-            className="kirk-icon c0"
-            fill="#708C91"
-            height={24}
-            viewBox="0 0 24 24"
-            width={24}
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            
-            <g
-              fill="none"
-              fillRule="evenodd"
-              stroke="none"
-              strokeWidth="1"
-            >
-              <path
-                d="M21.5,4 C21.7761424,4 22,4.22385763 22,4.5 L22,20.5 C22,20.7454599 21.8231248,20.9496084 21.5898756,20.9919443 L21.5,21 L2.5,21 C2.22385763,21 2,20.7761424 2,20.5 L2,4.5 C2,4.22385763 2.22385763,4 2.5,4 L21.5,4 Z M21,9.366 L12.7515544,14.1426395 C12.2866634,14.4117869 11.7133366,14.4117869 11.2484456,14.1426395 L2.99991707,9.367 L2.99991707,20 L21,20 L21,9.366 Z M21,5 L2.99991707,5 L2.99991707,8.212 L11.7494819,13.2772132 C11.8786183,13.3519764 12.0328555,13.3644369 12.1703589,13.3145948 L12.2505181,13.2772132 L21,8.211 L21,5 Z"
-                fill="#708C91"
-              />
-            </g>
-          </svg>
-          <span
-            className="kirk-tab-text kirk-tab-text--with-icon"
-          >
-            Tab 1
-          </span>
-        </button>
-      </div>
+        className="kirk-tab-highlight"
+      />
       <div
-        className="kirk-tab-container"
-        style={null}
+        aria-multiselectable="false"
+        aria-orientation="horizontal"
+        className="kirk-tablist"
+        role="tablist"
       >
-        <button
-          aria-controls="iconTab2_panel"
-          aria-selected="false"
-          className="kirk-tab"
-          id="iconTab2"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          role="tab"
-          tabIndex={-1}
-          title="Tab 2"
+        <div
+          className="kirk-tab-container kirk-tab-selected"
+          style={null}
         >
-          <span
-            className="kirk-tab-text"
+          <button
+            aria-controls="iconTab1_panel"
+            aria-selected="true"
+            className="kirk-tab"
+            id="iconTab1"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+            tabIndex={0}
+            title="Tab 1"
           >
-            Tab 2
-          </span>
-        </button>
-      </div>
-      <div
-        className="kirk-tab-container"
-        style={null}
-      >
-        <button
-          aria-controls="iconTab3_panel"
-          aria-selected="false"
-          className="kirk-tab"
-          id="iconTab3"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          role="tab"
-          tabIndex={-1}
-          title="Tab 3"
-        >
-          <svg
-            aria-hidden={true}
-            className="kirk-icon c0"
-            fill="#708C91"
-            height={24}
-            viewBox="0 0 24 24"
-            width={24}
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            
-            <g
-              fill="none"
-              fillRule="evenodd"
-              stroke="none"
-              strokeWidth="1"
+            <svg
+              aria-hidden={true}
+              className="kirk-icon c0"
+              fill="#708C91"
+              height={24}
+              viewBox="0 0 24 24"
+              width={24}
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <path
-                d="M21.5,4 C21.7761424,4 22,4.22385763 22,4.5 L22,20.5 C22,20.7454599 21.8231248,20.9496084 21.5898756,20.9919443 L21.5,21 L2.5,21 C2.22385763,21 2,20.7761424 2,20.5 L2,4.5 C2,4.22385763 2.22385763,4 2.5,4 L21.5,4 Z M21,9.366 L12.7515544,14.1426395 C12.2866634,14.4117869 11.7133366,14.4117869 11.2484456,14.1426395 L2.99991707,9.367 L2.99991707,20 L21,20 L21,9.366 Z M21,5 L2.99991707,5 L2.99991707,8.212 L11.7494819,13.2772132 C11.8786183,13.3519764 12.0328555,13.3644369 12.1703589,13.3145948 L12.2505181,13.2772132 L21,8.211 L21,5 Z"
-                fill="#708C91"
-              />
-            </g>
-          </svg>
-        </button>
+              
+              <g
+                fill="none"
+                fillRule="evenodd"
+                stroke="none"
+                strokeWidth="1"
+              >
+                <path
+                  d="M21.5,4 C21.7761424,4 22,4.22385763 22,4.5 L22,20.5 C22,20.7454599 21.8231248,20.9496084 21.5898756,20.9919443 L21.5,21 L2.5,21 C2.22385763,21 2,20.7761424 2,20.5 L2,4.5 C2,4.22385763 2.22385763,4 2.5,4 L21.5,4 Z M21,9.366 L12.7515544,14.1426395 C12.2866634,14.4117869 11.7133366,14.4117869 11.2484456,14.1426395 L2.99991707,9.367 L2.99991707,20 L21,20 L21,9.366 Z M21,5 L2.99991707,5 L2.99991707,8.212 L11.7494819,13.2772132 C11.8786183,13.3519764 12.0328555,13.3644369 12.1703589,13.3145948 L12.2505181,13.2772132 L21,8.211 L21,5 Z"
+                  fill="#708C91"
+                />
+              </g>
+            </svg>
+            <span
+              className="kirk-tab-text kirk-tab-text--with-icon"
+            >
+              Tab 1
+            </span>
+          </button>
+        </div>
+        <div
+          className="kirk-tab-container"
+          style={null}
+        >
+          <button
+            aria-controls="iconTab2_panel"
+            aria-selected="false"
+            className="kirk-tab"
+            id="iconTab2"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+            tabIndex={-1}
+            title="Tab 2"
+          >
+            <span
+              className="kirk-tab-text"
+            >
+              Tab 2
+            </span>
+          </button>
+        </div>
+        <div
+          className="kirk-tab-container"
+          style={null}
+        >
+          <button
+            aria-controls="iconTab3_panel"
+            aria-selected="false"
+            className="kirk-tab"
+            id="iconTab3"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+            tabIndex={-1}
+            title="Tab 3"
+          >
+            <svg
+              aria-hidden={true}
+              className="kirk-icon c0"
+              fill="#708C91"
+              height={24}
+              viewBox="0 0 24 24"
+              width={24}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              
+              <g
+                fill="none"
+                fillRule="evenodd"
+                stroke="none"
+                strokeWidth="1"
+              >
+                <path
+                  d="M21.5,4 C21.7761424,4 22,4.22385763 22,4.5 L22,20.5 C22,20.7454599 21.8231248,20.9496084 21.5898756,20.9919443 L21.5,21 L2.5,21 C2.22385763,21 2,20.7761424 2,20.5 L2,4.5 C2,4.22385763 2.22385763,4 2.5,4 L21.5,4 Z M21,9.366 L12.7515544,14.1426395 C12.2866634,14.4117869 11.7133366,14.4117869 11.2484456,14.1426395 L2.99991707,9.367 L2.99991707,20 L21,20 L21,9.366 Z M21,5 L2.99991707,5 L2.99991707,8.212 L11.7494819,13.2772132 C11.8786183,13.3519764 12.0328555,13.3644369 12.1703589,13.3145948 L12.2505181,13.2772132 L21,8.211 L21,5 Z"
+                  fill="#708C91"
+                />
+              </g>
+            </svg>
+          </button>
+        </div>
       </div>
     </div>
-  </div>
+  </div>,
   <div
     aria-labelledby="iconTab1"
     className="kirk-tab-panel"
@@ -268,20 +272,20 @@ exports[`Rendering testing should render properly with icons 1`] = `
     >
       Content for first tab
     </div>
-  </div>
+  </div>,
   <div
     aria-labelledby="iconTab2"
     className="kirk-tab-panel"
     hidden={true}
     id="iconTab2_panel"
     role="tabpanel"
-  />
+  />,
   <div
     aria-labelledby="iconTab3"
     className="kirk-tab-panel"
     hidden={true}
     id="iconTab3_panel"
     role="tabpanel"
-  />
-</div>
+  />,
+]
 `;


### PR DESCRIPTION
This is needed to have different layout rules between tabs and their panel contents.

TESTED=Locally in storybook and locally in prod version by copypasting nodes in DOM in inspector.