### PR TITLE
Fix Itinerary/TripCard visual alignment and a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - **[BREAKING CHANGE]** - Make `Tabs` and their panels layouts independent at DOM level.
+- **[FIX]** Fix various alignment issues and some a11y for `Itinerary` and `TripCard`.
 [...]
 
 # v12.0.0 (09/10/2019)

--- a/src/_utils/branding.ts
+++ b/src/_utils/branding.ts
@@ -98,7 +98,7 @@ export const delay = {
 }
 
 export const componentSizes = {
-  timeWidth: '64px',
+  timeWidth: '48px',
   buttonIconSize: '48px',
   wrapper: '662px',
 }

--- a/src/itinerary/Itinerary.tsx
+++ b/src/itinerary/Itinerary.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import cc from 'classcat'
 import isEmpty from 'lodash.isempty'
 import isString from 'lodash.isstring'
@@ -6,6 +6,8 @@ import isString from 'lodash.isstring'
 import { color } from '_utils/branding'
 import Text, { TextDisplayType, TextTagType } from 'text'
 import ChevronIcon from 'icon/chevronIcon'
+import SubHeader from 'subHeader'
+import BlankSeparator from 'blankSeparator'
 
 interface ItineraryProps {
   readonly places: Place[]
@@ -16,7 +18,18 @@ interface ItineraryProps {
   readonly headline?: string
 }
 
+
 const isNonEmptyString = (str: string) => isString(str) && str.trim().length > 0
+
+const computeKeyFromPlace = (place: Place) => {
+  if (place.key && typeof place.key === 'string') {
+    return place.key
+  }
+  if (typeof place.subLabel === 'string') {
+    return `${place.mainLabel}-${place.subLabel}-${place.isoDate}`
+  }
+  return `${place.mainLabel}-${place.isoDate}`
+}
 
 const Itinerary = ({
   className,
@@ -30,116 +43,116 @@ const Itinerary = ({
   const isSmall = small || places.filter(p => !isEmpty(p.time) || !isEmpty(p.subLabel)).length === 0
 
   return (
-    <ul className={cc([className, { 'kirk-itinerary--small': isSmall }])}>
+    <Fragment>
       {isNonEmptyString(headline) && (
-        <li className="kirk-itinerary-headline">
-          <Text display={TextDisplayType.TITLESTRONG}>{headline}</Text>
-        </li>
+          <Fragment>
+            <SubHeader>{headline}</SubHeader>
+            <BlankSeparator />
+          </Fragment>
       )}
-      {isNonEmptyString(fromAddon) && (
-        <li className="kirk-itinerary-fromAddon">
-          <Text display={TextDisplayType.CAPTION}>{fromAddon}</Text>
-        </li>
-      )}
-      {places.map((place, index) => {
-        let Component
-        let chevron = false
-        let hrefProps
-        let key
-
-        const link = place.href
-        const isLastPlace = places.length - 1 === index
-
-        if (place.key && typeof place.key === 'string') {
-          key = place.key
-        } else if (typeof place.subLabel === 'string') {
-          key = `${place.mainLabel}-${place.subLabel}-${place.isoDate}`
-        } else {
-          key = `${place.mainLabel}-${place.isoDate}`
-        }
-
-        if (!isEmpty(link) && typeof link !== 'string') {
-          Component = link.type
-          chevron = true
-          hrefProps = {
-            ...link.props,
-            className: cc(['kirk-itinerary-location-wrapper', link.props.className]),
-          }
-        } else if (typeof link === 'string') {
-          Component = 'a'
-          chevron = true
-          hrefProps = {
-            href: place.href,
-            className: 'kirk-itinerary-location-wrapper',
-          }
-        } else {
-          Component = 'div'
-          hrefProps = {
-            className: 'kirk-itinerary-location-wrapper',
-          }
-        }
-
-        return (
-          <li
-            className={cc([
-              'kirk-itinerary-location',
-              {
-                'kirk-itinerary--departure': index === 0,
-                'kirk-itinerary--arrival': isLastPlace,
-                'kirk-itinerary-location--toAddon': isLastPlace && isNonEmptyString(toAddon),
-              },
-            ])}
-            key={key}
-            itemProp="location"
-            itemScope
-            itemType="http://schema.org/Place"
-          >
-            <meta itemProp="name" content={place.mainLabel} />
-            <meta
-              itemProp="address"
-              content={
-                place.subLabel && typeof place.subLabel === 'string'
-                  ? place.subLabel
-                  : place.mainLabel
-              }
-            />
-            <Component {...hrefProps}>
-              {!isSmall && (
-                <time dateTime={place.isoDate}>
-                  <Text display={TextDisplayType.TITLESTRONG}>{place.time}</Text>
-                </time>
-              )}
-              <div className="kirk-itinerary-location-city">
-                <Text display={TextDisplayType.TITLESTRONG}>{place.mainLabel}</Text>
-                {!isSmall &&
-                  place.subLabel &&
-                  (typeof place.subLabel === 'string' ? (
-                    <Text
-                      tag={TextTagType.PARAGRAPH}
-                      display={TextDisplayType.CAPTION}
-                      textColor={color.primaryText}
-                    >
-                      {place.subLabel}
-                    </Text>
-                  ) : (
-                    <div>{place.subLabel}</div>
-                  ))}
-              </div>
-              {chevron && (
-                <div className="kirk-itinerary-location-chevron">
-                  <ChevronIcon />
-                </div>
-              )}
-            </Component>
+      <ul className={cc([className, { 'kirk-itinerary--small': isSmall }])}>
+        {isNonEmptyString(fromAddon) && (
+          <li className="kirk-itinerary-fromAddon">
+            <Text className="kirk-itinerary-addon-content"
+                  display={TextDisplayType.CAPTION}>{fromAddon}</Text>
           </li>
-        )
-      })}
-      {isNonEmptyString(toAddon) && (
-        <li className="kirk-itinerary-toAddon">
-          <Text display={TextDisplayType.CAPTION}>{toAddon}</Text>
-        </li>
-      )}
-    </ul>
+        )}
+        {places.map((place, index) => {
+          let Component
+          let chevron = false
+          let hrefProps
+
+          const link = place.href
+          const isLastPlace = places.length - 1 === index
+
+          if (!isEmpty(link) && typeof link !== 'string') {
+            Component = link.type
+            chevron = true
+            hrefProps = {
+              ...link.props,
+              className: cc(['kirk-itinerary-location-wrapper', link.props.className]),
+            }
+          } else if (typeof link === 'string') {
+            Component = 'a'
+            chevron = true
+            hrefProps = {
+              href: place.href,
+              className: 'kirk-itinerary-location-wrapper',
+            }
+          } else {
+            Component = 'div'
+            hrefProps = {
+              className: 'kirk-itinerary-location-wrapper',
+            }
+          }
+
+          return (
+            <li
+              className={cc([
+                'kirk-itinerary-location',
+                {
+                  'kirk-itinerary--departure': index === 0,
+                  'kirk-itinerary--arrival': isLastPlace,
+                  'kirk-itinerary-location--toAddon': isLastPlace && isNonEmptyString(toAddon),
+                },
+              ])}
+              key={computeKeyFromPlace(place)}
+              itemProp="location"
+              itemScope
+              itemType="http://schema.org/Place"
+            >
+              <meta itemProp="name" content={place.mainLabel} />
+              <meta
+                itemProp="address"
+                content={
+                  place.subLabel && typeof place.subLabel === 'string'
+                    ? place.subLabel
+                    : place.mainLabel
+                }
+              />
+              <Component {...hrefProps}>
+                {!isSmall && (
+                  <time dateTime={place.isoDate}>
+                    <Text tag={TextTagType.DIV} display={TextDisplayType.TITLESTRONG}>
+                      {place.time}
+                    </Text>
+                  </time>
+                )}
+                <div className="kirk-itinerary-location-city">
+                  <Text tag={TextTagType.DIV} display={TextDisplayType.TITLESTRONG}>
+                    {place.mainLabel}
+                  </Text>
+                  {!isSmall &&
+                    place.subLabel &&
+                    (typeof place.subLabel === 'string' ? (
+                      <Text
+                        tag={TextTagType.PARAGRAPH}
+                        display={TextDisplayType.CAPTION}
+                        textColor={color.primaryText}
+                      >
+                        {place.subLabel}
+                      </Text>
+                    ) : (
+                      <div>{place.subLabel}</div>
+                    ))}
+                </div>
+                {chevron && (
+                  <div className="kirk-itinerary-location-chevron">
+                    <ChevronIcon />
+                  </div>
+                )}
+              </Component>
+            </li>
+          )
+        })}
+        {isNonEmptyString(toAddon) && (
+          <li className="kirk-itinerary-toAddon">
+            <Text className="kirk-itinerary-addon-content"
+                  display={TextDisplayType.CAPTION}>{toAddon}</Text>
+          </li>
+        )}
+      </ul>
+    </Fragment>
   )
 }
 

--- a/src/itinerary/Itinerary.unit.tsx
+++ b/src/itinerary/Itinerary.unit.tsx
@@ -30,7 +30,8 @@ const places = [
 describe('Itinerary component', () => {
   it('Render with custom className', () => {
     const itinerary = shallow(<Itinerary className="test" places={places} />)
-    expect(itinerary.hasClass('test')).toBe(true)
+    const ul = itinerary.find('ul')
+    expect(ul.hasClass('test')).toBe(true)
   })
 
   it('Should display the top addon', () => {
@@ -208,12 +209,14 @@ describe('Itinerary component', () => {
   describe('small', () => {
     it('Should be displayed as small if required in props', () => {
       const itinerary = shallow(<Itinerary places={places} small />)
-      expect(itinerary.hasClass('kirk-itinerary--small')).toBe(true)
+      const ul = itinerary.find('ul')
+      expect(ul.hasClass('kirk-itinerary--small')).toBe(true)
     })
 
     it('Should not be displayed as small if not in props and time or sublabel exists', () => {
       const itinerary = shallow(<Itinerary places={places} />)
-      expect(itinerary.hasClass('kirk-itinerary--small')).toBe(false)
+      const ul = itinerary.find('ul')
+      expect(ul.hasClass('kirk-itinerary--small')).toBe(false)
     })
 
     it('Should be displayed as small if no time nor subLabel', () => {
@@ -231,7 +234,8 @@ describe('Itinerary component', () => {
       ]
 
       const itinerary = shallow(<Itinerary places={places} />)
-      expect(itinerary.hasClass('kirk-itinerary--small')).toBe(true)
+      const ul = itinerary.find('ul')
+      expect(ul.hasClass('kirk-itinerary--small')).toBe(true)
     })
   })
 })

--- a/src/itinerary/index.tsx
+++ b/src/itinerary/index.tsx
@@ -4,15 +4,13 @@ import { color, space, componentSizes } from '_utils/branding'
 import Itinerary from './Itinerary'
 
 const distanceFromHeight = '40px'
+const gutterPaddingStart = space.m
+const gutterTopOffset = '2px'
 
 const StyledItinerary = styled(Itinerary)`
   li {
     position: relative;
     list-style-type: none;
-  }
-
-  & .kirk-itinerary-headline {
-    padding-bottom: ${space.l};
   }
 
   & .kirk-itinerary-location-wrapper {
@@ -47,19 +45,20 @@ const StyledItinerary = styled(Itinerary)`
   }
 
   & .kirk-itinerary-location time {
-    min-width: ${componentSizes.timeWidth};
+    min-width: calc(${gutterPaddingStart} + ${componentSizes.timeWidth});
   }
 
   & .kirk-itinerary-location-city {
     padding-left: ${space.l}; /* Adding the width of the step points to the regular spacing */
   }
 
-  &.kirk-itinerary--small .kirk-itinerary-location:not(.kirk-itinerary--arrival) div {
+  &.kirk-itinerary--small .kirk-itinerary-location:not(.kirk-itinerary--arrival)
+      .kirk-itinerary-location-city {
     padding-bottom: 0;
   }
 
-  & .kirk-itinerary-location div::before,
-  & .kirk-itinerary-location div::after {
+  & .kirk-itinerary-location .kirk-itinerary-location-city::before,
+  & .kirk-itinerary-location .kirk-itinerary-location-city::after {
     box-sizing: border-box;
     content: '';
     display: block;
@@ -67,38 +66,43 @@ const StyledItinerary = styled(Itinerary)`
     position: absolute;
   }
 
-  & .kirk-itinerary-location div::before {
+  & .kirk-itinerary-location .kirk-itinerary-location-city::before {
     height: 100%;
     background-color: ${color.primaryText};
     top: 0;
-    left: ${componentSizes.timeWidth};
+    left: calc(${gutterPaddingStart} + ${componentSizes.timeWidth});
   }
 
-  &.kirk-itinerary--small .kirk-itinerary-location div::before {
+  &.kirk-itinerary--small .kirk-itinerary-location .kirk-itinerary-location-city::before {
     left: 2px;
   }
 
-  & .kirk-itinerary-location div::after {
+  & .kirk-itinerary-location .kirk-itinerary-location-city::after {
     width: 8px;
     height: 8px;
     background-color: ${color.white};
     border: 2px solid ${color.primaryText};
     border-radius: 50%;
-    top: calc(4px + ${space.m});
-    left: calc(${componentSizes.timeWidth} - 2px);
+    top: calc(4px + ${space.m} + ${gutterTopOffset});
+    left: calc(${gutterPaddingStart} + ${componentSizes.timeWidth} - 2px);
+  }
+  
+  & .kirk-itinerary-location.kirk-itinerary--departure .kirk-itinerary-location-city::after,
+  & .kirk-itinerary-location.kirk-itinerary--arrival .kirk-itinerary-location-city::after {
+    top: calc(4px + ${space.m} + ${gutterTopOffset});
   }
 
-  &.kirk-itinerary--small .kirk-itinerary-location div::after {
+  &.kirk-itinerary--small .kirk-itinerary-location .kirk-itinerary-location-city::after {
     left: 0;
   }
 
-  & .kirk-itinerary-location.kirk-itinerary--departure div::before {
+  & .kirk-itinerary-location.kirk-itinerary--departure .kirk-itinerary-location-city::before {
     height: calc(100% - calc(6px + ${space.m}));
-    top: calc(6px + ${space.m});
+    top: calc(6px + ${space.m} + ${gutterTopOffset});
   }
 
-  & .kirk-itinerary-location.kirk-itinerary--arrival div::before {
-    height: calc(6px + ${space.m});
+  & .kirk-itinerary-location.kirk-itinerary--arrival .kirk-itinerary-location-city::before {
+    height: calc(6px + ${space.m} + ${gutterTopOffset});
   }
 
   & .kirk-itinerary-fromAddon,
@@ -119,7 +123,7 @@ const StyledItinerary = styled(Itinerary)`
   & .kirk-itinerary-location.kirk-itinerary-location--toAddon::before {
     width: 0;
     border: 2px solid ${color.border};
-    left: ${componentSizes.timeWidth};
+    left: calc(${gutterPaddingStart} + ${componentSizes.timeWidth});
     bottom: -4px;
   }
 
@@ -129,7 +133,7 @@ const StyledItinerary = styled(Itinerary)`
   }
 
   & .kirk-itinerary-fromAddon::before {
-    height: calc(100% + ${space.m});
+    height: calc(100% + ${space.m} + 4px);
     top: 6px;
   }
 
@@ -145,7 +149,7 @@ const StyledItinerary = styled(Itinerary)`
     background-color: #fff;
     border: 2px solid ${color.border};
     border-radius: 50%;
-    left: calc(${componentSizes.timeWidth} - 2px);
+    left: calc(${gutterPaddingStart} + ${componentSizes.timeWidth} - 2px);
   }
 
   &.kirk-itinerary--small .kirk-itinerary-fromAddon::after,
@@ -161,25 +165,25 @@ const StyledItinerary = styled(Itinerary)`
     bottom: -${distanceFromHeight};
   }
 
-  & .kirk-itinerary-fromAddon span,
-  & .kirk-itinerary-toAddon span {
+  & .kirk-itinerary-fromAddon .kirk-itinerary-addon-content,
+  & .kirk-itinerary-toAddon .kirk-itinerary-addon-content {
     display: inline-block;
     padding-left: ${space.l};
     color: ${color.fadedText};
     position: absolute;
-    left: ${componentSizes.timeWidth};
+    left: calc(${gutterPaddingStart} + ${componentSizes.timeWidth});
   }
 
-  &.kirk-itinerary--small .kirk-itinerary-fromAddon span,
-  &.kirk-itinerary--small .kirk-itinerary-toAddon span {
+  &.kirk-itinerary--small .kirk-itinerary-fromAddon .kirk-itinerary-addon-content,
+  &.kirk-itinerary--small .kirk-itinerary-toAddon .kirk-itinerary-addon-content {
     left: 0;
   }
 
-  & .kirk-itinerary-fromAddon span {
+  & .kirk-itinerary-fromAddon .kirk-itinerary-addon-content {
     top: -4px;
   }
 
-  & .kirk-itinerary-toAddon span {
+  & .kirk-itinerary-toAddon .kirk-itinerary-addon-content {
     bottom: -4px;
   }
 

--- a/src/itinerary/story.tsx
+++ b/src/itinerary/story.tsx
@@ -38,11 +38,17 @@ const placesWithStopover = [
     isoDate: '2017-12-11T12:00',
     subLabel: 'Gare de Tours',
     mainLabel: 'Tours',
-    href: <button type="button" />,
+    href: '#',
   },
   {
     time: '15:00',
     isoDate: '2017-12-11T15:00',
+    mainLabel: 'Nogent-le-Rotrou',
+    href: '#',
+  },
+  {
+    time: '19 :00',
+    isoDate: '2017-12-11T19:00',
     subLabel: 'Gare Bordeaux Saint-Jean',
     mainLabel: 'Bordeaux',
   },
@@ -103,3 +109,57 @@ stories.add('with proximity', () => {
     />
   )
 })
+
+stories.add('with stopovers', () => {
+  const fromAddonLabel = text('From addon label', 'Lille')
+  const toAddonLabel = text('To addon label', 'Biarritz')
+  const headlineLabel = text('Headline label', 'Mon 11 December')
+  return (
+      <Itinerary
+          fromAddon={fromAddonLabel}
+          toAddon={toAddonLabel}
+          places={placesWithStopover}
+          small={boolean('small', false)}
+          headline={headlineLabel}
+      />
+  )
+})
+
+stories.add('with button tiles', () => {
+  const fromAddonLabel = text('From addon label', 'Lille')
+  const toAddonLabel = text('To addon label', 'Biarritz')
+  const headlineLabel = text('Headline label', 'Mon 11 December')
+  const placesWithButton = [
+    {
+      time: '09:00',
+      isoDate: '2017-12-11T09:00',
+      subLabel: 'Porte de Vincennes',
+      mainLabel: 'Paris',
+      href: <button type="button" />,
+    },
+    {
+      time: '15:00',
+      isoDate: '2017-12-11T15:00',
+      subLabel: 'Gare Bordeaux Saint-Jean',
+      mainLabel: 'Bordeaux',
+    },
+    {
+      time: '12:00',
+      isoDate: '2017-12-11T12:00',
+      subLabel: 'Gare de Tours',
+      mainLabel: 'Tours',
+      href: <button type="button" />,
+    },
+  ]
+  return (
+      <Itinerary
+          fromAddon={fromAddonLabel}
+          toAddon={toAddonLabel}
+          places={placesWithButton}
+          small={boolean('small', false)}
+          headline={headlineLabel}
+      />
+  )
+})
+
+

--- a/src/tripCard/TripCard.tsx
+++ b/src/tripCard/TripCard.tsx
@@ -139,17 +139,15 @@ const TripCard = ({
           )}
 
           {statusInformation && (
-            <div className="kirk-tripCard-top">
-              <Item
-                className="kirk-tripCard-top-item"
-                leftAddon={React.cloneElement(statusInformation.icon, {
-                  iconColor: statusInformation.highlighted ? color.primary : color.icon,
-                })}
-                leftTitle={statusInformation.text}
-                leftTitleDisplay={TextDisplayType.BODY}
-                highlighted={statusInformation.highlighted}
-              />
-            </div>
+            <Item
+              className="kirk-tripCard-top-item"
+              leftAddon={React.cloneElement(statusInformation.icon, {
+                iconColor: statusInformation.highlighted ? color.primary : color.icon,
+              })}
+              leftTitle={statusInformation.text}
+              leftTitleDisplay={TextDisplayType.BODY}
+              highlighted={statusInformation.highlighted}
+            />
           )}
 
           {title && (

--- a/src/tripCard/TripCard.unit.tsx
+++ b/src/tripCard/TripCard.unit.tsx
@@ -134,7 +134,7 @@ describe('TripCard component', () => {
   it('Should render status information', () => {
     const statusInformation = { icon: <WarningIcon />, text: 'Warning!' }
     const component = shallow(<TripCard {...mockedProps} statusInformation={statusInformation} />)
-    expect(component.find('.kirk-tripCard-top').exists()).toBe(true)
+    expect(component.find('.kirk-tripCard-top-item').exists()).toBe(true)
   })
 
   it('Should render badge', () => {

--- a/src/tripCard/index.tsx
+++ b/src/tripCard/index.tsx
@@ -80,7 +80,7 @@ const StyledTripCard = styled(TripCard)`
 
   /* To match the width of the time area of the Itinerary */
   .kirk-tripCard-driver .kirk-tripCard-avatar {
-    min-width: ${componentSizes.timeWidth};
+    min-width: calc(${componentSizes.timeWidth} + ${space.m});
     margin-right: ${space.l};
   }
 


### PR DESCRIPTION
- Set time cell width to 48px (was 64px) + 8px of right padding (was 0)
- Fix a11y for title (it's now a SubHeader outside the list, it was a nested li/text)
- Fix departure/arrival city alignement with dot
- Fix multiple :before/:after elements being created due to non selective CSS rule (div/span)

Itinerary:
![image](https://user-images.githubusercontent.com/46651/67081282-208d5600-f197-11e9-862d-3dd0729cd702.png)
Small itinerary:
![image](https://user-images.githubusercontent.com/46651/67081337-3a2e9d80-f197-11e9-9ccc-27017847fe22.png)

TripCard:
![image](https://user-images.githubusercontent.com/46651/67084980-4b2edd00-f19e-11e9-8f6c-2232f7eb3c6f.png)
