### PR TITLE
Fix Textarea visual for scrollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Fix scrolling visual for `Textarea`.
 [...]
 
 # v13.0.2 (04/11/2019)

--- a/src/textarea/Textarea.tsx
+++ b/src/textarea/Textarea.tsx
@@ -138,9 +138,7 @@ export default class Textarea extends PureComponent<TextAreaProps, TextAreaState
     // Fit height to content.
     if (this.textareaRef && this.textareaRef.current) {
       this.textareaRef.current.style.height = '0'
-      const verticalPadding = 16
-      this.textareaRef.current.style.height = `${this.textareaRef.current.scrollHeight -
-        2 * verticalPadding}px`
+      this.textareaRef.current.style.height = `${this.textareaRef.current.scrollHeight}px`
     }
   }
 

--- a/src/textarea/index.tsx
+++ b/src/textarea/index.tsx
@@ -35,7 +35,6 @@ const StyledTextarea = styled(Textarea)`
     outline: none;
     appearance: none;
     border: 0;
-    border-radius: ${radius.l};
     background-color: ${color.inputBackground};
     color: ${color.primaryText};
     flex: 1;
@@ -43,9 +42,11 @@ const StyledTextarea = styled(Textarea)`
     line-height: ${font.base.lineHeight};
     width: 100%;
     caret-color: ${color.inputCaret};
-    padding: calc(${space.l} + 1px - ${inputBorderSize.focus});
+    padding: 0 calc(${space.l} + 1px - ${inputBorderSize.focus}); 
+    margin: calc(${space.l} + 1px - ${inputBorderSize.focus}) 0;
     box-sizing: content-box;
     height: ${font.base.lineHeight};
+    scrollbar-width: thin;
   }
 
   & textarea.kirk-textarea-hasButton {


### PR DESCRIPTION
Previously, the scrolling area was including the 16px padding top/bottom. It begets a scrollbar that could go above the rounded corners of the Textarea widget.
With this PR, the top and bottom padding are converted to margin and are not part of the scrollable area anymore, hence there is no overlap anymore between the corners and the scrollbar.

TESTED=Locally in storybook.