### PR TITLE
Handle TimePicker focus on mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- **[NEW]** `focus` prop on `TimePicker` to focus the select on mount
+- **[NEW]** `focus` prop on `TimePicker`
 
 # v13.0.3 (06/11/2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-[...]
+- **[NEW]** `focus` prop on `TimePicker` to focus the select on mount
 
 # v13.0.3 (06/11/2019)
 

--- a/src/timePicker/TimePicker.tsx
+++ b/src/timePicker/TimePicker.tsx
@@ -48,6 +48,7 @@ type TimeSteps = {
 interface TimePickerState {
   readonly value: string
   readonly steps: Steps
+  readonly isFocused: boolean
 }
 
 export default class TimePicker extends PureComponent<TimePickerProps, TimePickerState> {
@@ -75,6 +76,7 @@ export default class TimePicker extends PureComponent<TimePickerProps, TimePicke
   state = {
     value: this.getDefaultValue(),
     steps: this.generateTimeSteps(this.props),
+    isFocused: false,
   }
 
   selectRef = React.createRef<HTMLSelectElement>()
@@ -109,17 +111,26 @@ export default class TimePicker extends PureComponent<TimePickerProps, TimePicke
     return this.props.defaultValue
   }
 
+  onSelectFocus = () => this.setState({ isFocused: true })
+
+  onSelectBlur = () => this.setState({ isFocused: false })
+
   render() {
     const { className = '', disabled = false, name } = this.props
     const { steps } = this.state
     return (
-      <div className={cc([prefix({ timePicker: true }), className])} aria-disabled={disabled}>
+      <div
+        className={cc([prefix({ timePicker: true }), { focus: this.state.isFocused }, className])}
+        aria-disabled={disabled}
+      >
         <time>{steps[this.state.value]}</time>
         <select
           name={name}
           value={this.state.value}
           disabled={disabled}
           onChange={this.onChange}
+          onFocus={this.onSelectFocus}
+          onBlur={this.onSelectBlur}
           ref={this.selectRef}
         >
           {Object.keys(steps).map(key => (

--- a/src/timePicker/TimePicker.tsx
+++ b/src/timePicker/TimePicker.tsx
@@ -3,18 +3,6 @@ import cc from 'classcat'
 import prefix from '_utils'
 
 /**
- * Whether or not Date#toLocaleTimeString supports arguments `locales` et `options`.
- */
-const toLocaleTimeStringSupportsLocales = (() => {
-  try {
-    new Date().toLocaleTimeString('i')
-  } catch (e) {
-    return e.name === 'RangeError'
-  }
-  return false
-})()
-
-/**
  * Format given dateTime in the format HH:MM.
  */
 const formatTimeValue = (dateTime: Date) => {
@@ -47,6 +35,7 @@ interface TimePickerProps {
   readonly renderTime?: (dt: Date) => string
   readonly onChange?: (obj: OnChangeParameters) => void
   readonly timeStart?: string
+  readonly focus?: boolean
 }
 
 type Steps = { [propName: string]: string }
@@ -88,6 +77,8 @@ export default class TimePicker extends PureComponent<TimePickerProps, TimePicke
     steps: this.generateTimeSteps(this.props),
   }
 
+  selectRef = React.createRef<HTMLSelectElement>()
+
   static getDerivedStateFromProps(props: TimePickerProps, state: TimePickerState) {
     if (state.value < props.timeStart) {
       return {
@@ -105,6 +96,12 @@ export default class TimePicker extends PureComponent<TimePickerProps, TimePicke
     this.props.onChange({ name, value })
   }
 
+  componentDidMount() {
+    if (this.selectRef && this.props.focus) {
+      this.selectRef.current.focus()
+    }
+  }
+
   getDefaultValue() {
     if (!this.props.defaultValue) {
       return formatTimeValue(this.referenceDate)
@@ -118,7 +115,13 @@ export default class TimePicker extends PureComponent<TimePickerProps, TimePicke
     return (
       <div className={cc([prefix({ timePicker: true }), className])} aria-disabled={disabled}>
         <time>{steps[this.state.value]}</time>
-        <select name={name} value={this.state.value} disabled={disabled} onChange={this.onChange}>
+        <select
+          name={name}
+          value={this.state.value}
+          disabled={disabled}
+          onChange={this.onChange}
+          ref={this.selectRef}
+        >
           {Object.keys(steps).map(key => (
             <option key={key} value={key}>
               {steps[key]}

--- a/src/timePicker/TimePicker.unit.tsx
+++ b/src/timePicker/TimePicker.unit.tsx
@@ -96,11 +96,26 @@ describe('<TimePicker />', () => {
     })
     it('should have `referenceDate` with time at 00:00:00', () => {
       const wrapper = shallow(<TimePicker {...defaultProps} />)
-      const referenceDate = wrapper.instance().referenceDate
+      const instance = wrapper.instance() as InstanceType<typeof TimePicker>
+      const referenceDate = instance.referenceDate
       expect(referenceDate.getHours()).toEqual(0)
       expect(referenceDate.getMinutes()).toEqual(0)
       expect(referenceDate.getSeconds()).toEqual(0)
       expect(referenceDate.getMilliseconds()).toEqual(0)
+    })
+  })
+
+  describe('focus prop', () => {
+    it('should focus the select on mount', () => {
+      const wrapper = shallow(<TimePicker {...defaultProps} focus />, {
+        disableLifecycleMethods: true,
+      })
+      const instance = wrapper.instance() as InstanceType<typeof TimePicker>
+      instance.selectRef = {
+        focus: jest.fn(),
+      }
+      instance.componentDidMount()
+      expect(instance.selectRef.focus).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/timePicker/TimePicker.unit.tsx
+++ b/src/timePicker/TimePicker.unit.tsx
@@ -112,10 +112,12 @@ describe('<TimePicker />', () => {
       })
       const instance = wrapper.instance() as InstanceType<typeof TimePicker>
       instance.selectRef = {
-        focus: jest.fn(),
+        current: {
+          focus: jest.fn(),
+        },
       }
       instance.componentDidMount()
-      expect(instance.selectRef.focus).toHaveBeenCalledTimes(1)
+      expect(instance.selectRef.current.focus).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/timePicker/index.tsx
+++ b/src/timePicker/index.tsx
@@ -17,9 +17,10 @@ export const StyledTimePicker = styled(TimePicker)`
     background-color: ${color.white};
     color: ${color.primaryText};
     border: 1px solid ${color.border};
-    border-radius: 66px;
+    border-radius: 2em;
     box-sizing: border-box;
     cursor: pointer;
+    padding: ${inputBorderSize.focus};
   }
 
   &:hover {
@@ -28,6 +29,7 @@ export const StyledTimePicker = styled(TimePicker)`
 
   &.focus {
     border: ${inputBorderSize.focus} solid ${color.inputBorderFocus};
+    padding: 1px;
   }
 
   &::after {
@@ -41,6 +43,10 @@ export const StyledTimePicker = styled(TimePicker)`
     border-width: 0 2px 2px 0;
     vertical-align: middle;
     transform: rotate(45deg);
+  }
+
+  &.focus::after {
+    right: 30px;
   }
 
   &[aria-disabled='true'] {

--- a/src/timePicker/index.tsx
+++ b/src/timePicker/index.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { color, font } from '_utils/branding'
+import { color, inputBorderSize, font } from '_utils/branding'
 
 import TimePicker from './TimePicker'
 
@@ -22,9 +22,12 @@ export const StyledTimePicker = styled(TimePicker)`
     cursor: pointer;
   }
 
-  &:hover,
-  &.focus {
+  &:hover {
     background-color: ${color.lightBackground};
+  }
+
+  &.focus {
+    border: ${inputBorderSize.focus} solid ${color.inputBorderFocus};
   }
 
   &::after {
@@ -49,7 +52,8 @@ export const StyledTimePicker = styled(TimePicker)`
     border-color: ${color.disabled};
   }
 
-  & > select {
+  & > select,
+  & > select:focus {
     position: absolute;
     top: 0;
     left: 0;
@@ -60,6 +64,7 @@ export const StyledTimePicker = styled(TimePicker)`
     /* Required to have <select /> with height 100% in Safari  */
     -webkit-appearance: menulist-button;
     cursor: pointer;
+    outline: none;
   }
 
   & > time {

--- a/src/timePicker/index.tsx
+++ b/src/timePicker/index.tsx
@@ -22,7 +22,8 @@ export const StyledTimePicker = styled(TimePicker)`
     cursor: pointer;
   }
 
-  &:hover {
+  &:hover,
+  &.focus {
     background-color: ${color.lightBackground};
   }
 

--- a/src/timePicker/story.tsx
+++ b/src/timePicker/story.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { storiesOf } from '@storybook/react'
-import { withKnobs, boolean, number, select } from '@storybook/addon-knobs'
+import { withKnobs, boolean, select } from '@storybook/addon-knobs'
 import { action } from '@storybook/addon-actions'
 
 import TimePicker from '.'
@@ -16,5 +16,6 @@ stories.add('default', () => (
     onChange={action('onChange')}
     disabled={boolean('disabled', false)}
     timeStart={select('timeStart', ['00:00', '08:00', '12:00', '21:00'], '00:00')}
+    focus
   />
 ))


### PR DESCRIPTION
In a similar fashion to TextField, we can now use the `focus` prop on the TimePicker to focus the select when the component is mounted.

Focused style (copied from TextField component):
<img width="408" alt="Capture d’écran 2019-11-08 à 15 27 25" src="https://user-images.githubusercontent.com/14176147/68484137-01855f80-023d-11ea-83ee-3a643a56ff98.png">
