### PR TITLE
Fix random size issue on large stepper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Fix random font-size issue in `Stepper` using `StepperDisplay.LARGE`
 [...]
 
 # v15.0.3 (18/11/2019)

--- a/src/stepper/Stepper.tsx
+++ b/src/stepper/Stepper.tsx
@@ -19,7 +19,7 @@ const StepperValueSize = {
   [StepperDisplay.LARGE]: pxToInteger(font.xxl.size),
 }
 
-const StepperButtonSize = {
+export const StepperButtonSize = {
   [StepperDisplay.SMALL]: 24,
   [StepperDisplay.LARGE]: 48,
 }
@@ -98,14 +98,13 @@ export default class Stepper extends PureComponent<StepperProps, StepperState> {
     if (prevProps.value !== this.props.value) {
       this.update(this.props.value)
     }
-
-    this.handleFontSize()
   }
 
   update(newValue: number) {
     const value = this.filterValue(newValue, this.props.min, this.props.max)
     this.setState({ value })
     this.props.onChange({ name: this.props.name, value })
+    this.handleFontSize()
   }
 
   handleFontSize() {

--- a/src/stepper/index.tsx
+++ b/src/stepper/index.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 import { color, font, space } from '_utils/branding'
-import Stepper from './Stepper'
+import Stepper, { StepperDisplay, StepperButtonSize } from './Stepper'
 
 const StyledStepper = styled(Stepper)`
   & {
@@ -36,6 +36,11 @@ const StyledStepper = styled(Stepper)`
   & div .kirk-stepper-decrement,
   & div .kirk-stepper-increment {
     min-width: 24px;
+  }
+
+  &.kirk-stepper-large .kirk-stepper-value {
+    width: calc(100% - ${StepperButtonSize[StepperDisplay.LARGE]}px * 2);
+    flex-grow: 0;
   }
 `
 


### PR DESCRIPTION
Fix the following issue by preventing flex-grow on LARGE display (it's always displayed at 100% of its container).

![image-2019-11-14-17-21-31-451](https://user-images.githubusercontent.com/729186/69226406-62d3f980-0b80-11ea-987b-875ee1cd0b3c.png)

