### PR TITLE
Set initialMonth in DatePicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[NEW]** Show month corresponding to `initialDate` in `DatePicker`
 - [...]
 
 # v15.0.4 (20/11/2019)

--- a/src/datePicker/DatePicker.tsx
+++ b/src/datePicker/DatePicker.tsx
@@ -153,6 +153,7 @@ export class DatePicker extends PureComponent<DatePickerProps, DatePickerState> 
       weekdaysLong,
       months,
       firstDayOfWeek,
+      initialDate,
     } = this.props
     const { date } = this.state
     const layoutClassName = `months-grid-${numberOfMonths}`
@@ -180,6 +181,7 @@ export class DatePicker extends PureComponent<DatePickerProps, DatePickerState> 
           months={months}
           firstDayOfWeek={firstDayOfWeek}
           localeUtils={{ ...DayPicker.LocaleUtils, formatMonthTitle: this.formatMonthTitle }}
+          initialMonth={initialDate}
         />
       </div>
     )

--- a/src/datePicker/DatePicker.unit.tsx
+++ b/src/datePicker/DatePicker.unit.tsx
@@ -60,4 +60,25 @@ describe('DatePicker', () => {
       expect(onChange).toHaveBeenCalledWith({ name: 'datepicker', value: '2020-01-01' })
     })
   })
+
+  describe('react-day-picker', () => {
+    it('Should forward props to the DayPicker component', () => {
+      const now = new Date()
+      const wrapper = shallow(<DatePicker
+        name="datepicker"
+        initialDate={now}
+        numberOfMonths={12}
+      />)
+      const instance = wrapper.instance()
+
+      expect(wrapper.find(DayPicker).prop('numberOfMonths')).toEqual(12)
+      expect(wrapper.find(DayPicker).prop('selectedDays')).toEqual(now)
+      expect(wrapper.find(DayPicker).prop('initialMonth')).toEqual(now)
+      expect(wrapper.find(DayPicker).prop('onDayClick')).toEqual(instance.onDayClick)
+      expect(wrapper.find(DayPicker).prop('navbarElement')).toEqual(instance.renderNavbar)
+      expect(wrapper.find(DayPicker).prop('captionElement')).toEqual(instance.renderCaption)
+      expect(wrapper.find(DayPicker).prop('renderDay')).toEqual(instance.renderDay)
+      expect(wrapper.find(DayPicker).prop('firstDayOfWeek')).toEqual(0)
+    })
+  })
 })


### PR DESCRIPTION
In our publication flow, when selecting a date in a far future, we end up in the return date step with all next dates disabled. We have to either scroll down or click next months button until arriving to the first available date.

I'm using the `initialMonth` prop from `react-day-picker` to set it to the `initialDate`.

TESTED: in publication flow, desktop & mobile display