### PR TITLE
ensure activeTab is up-to-date when using the back navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [...]
+- **[FIX]** Fix `Tabs` state not updated in situations such as back navigation
 
 # v15.1.1 (21/11/2019)
 

--- a/src/tabs/Tabs.tsx
+++ b/src/tabs/Tabs.tsx
@@ -147,7 +147,11 @@ export class Tabs extends PureComponent<TabsProps, TabsState> {
     this.props.onChange(activeTabId)
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps: TabsProps) {
+    if (prevProps.activeTabId !== this.props.activeTabId) {
+      this.activateTabById(this.props.activeTabId)
+    }
+
     this.moveHighlight(this.state.activeTabId)
   }
 


### PR DESCRIPTION
When used in the website with a different url for each tab (with a "tab" query param), using the back button would not trigger an update.