### PR TITLE
Fix alignment issues on Safari 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- [...]
+- **[FIX]** `Button` alignment issues on Safari 10
 
 # v15.1.1 (21/11/2019)
 

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -146,16 +146,10 @@ const StyledButton = styled(Button)`
   }
 
   &.kirk-button-bubble {
-    display: inline-flex;
+    display: inline-block;
+    text-align: center;
     padding: 0;
     line-height: 0;
-    width: ${componentSizes.buttonIconSize};
-    height: ${componentSizes.buttonIconSize};
-  }
-
-  /* Note: Safari 10 can not have flex context on <button> element */
-  &.kirk-button-bubble {
-    justify-content: center;
     width: ${componentSizes.buttonIconSize};
     height: ${componentSizes.buttonIconSize};
   }

--- a/src/datePicker/__snapshots__/DatePicker.unit.tsx.snap
+++ b/src/datePicker/__snapshots__/DatePicker.unit.tsx.snap
@@ -180,21 +180,10 @@ exports[`DatePicker renderNavbar Should render the previous/next buttons in hori
 }
 
 .c0.kirk-button-bubble {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: inline-block;
+  text-align: center;
   padding: 0;
   line-height: 0;
-  width: 48px;
-  height: 48px;
-}
-
-.c0.kirk-button-bubble {
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
   width: 48px;
   height: 48px;
 }

--- a/src/modal/__snapshots__/Modal.unit.tsx.snap
+++ b/src/modal/__snapshots__/Modal.unit.tsx.snap
@@ -209,21 +209,10 @@ exports[`Modal should not have changed 1`] = `
 }
 
 .c2.kirk-button-bubble {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: inline-block;
+  text-align: center;
   padding: 0;
   line-height: 0;
-  width: 48px;
-  height: 48px;
-}
-
-.c2.kirk-button-bubble {
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
   width: 48px;
   height: 48px;
 }

--- a/src/phoneField/__snapshots__/PhoneField.unit.tsx.snap
+++ b/src/phoneField/__snapshots__/PhoneField.unit.tsx.snap
@@ -225,21 +225,10 @@ exports[`PhoneField should have the expected markup in the DOM with custom setti
 }
 
 .c4.kirk-button-bubble {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: inline-block;
+  text-align: center;
   padding: 0;
   line-height: 0;
-  width: 48px;
-  height: 48px;
-}
-
-.c4.kirk-button-bubble {
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
   width: 48px;
   height: 48px;
 }

--- a/src/snackbar/__snapshots__/Snackbar.unit.tsx.snap
+++ b/src/snackbar/__snapshots__/Snackbar.unit.tsx.snap
@@ -164,21 +164,10 @@ exports[`Snackbar should not have changed 1`] = `
 }
 
 .c3.kirk-button-bubble {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+  display: inline-block;
+  text-align: center;
   padding: 0;
   line-height: 0;
-  width: 48px;
-  height: 48px;
-}
-
-.c3.kirk-button-bubble {
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
   width: 48px;
   height: 48px;
 }


### PR DESCRIPTION
Safari 10 do not support flexbox on `<button>` elements, which was causing alignment issues with icons (no visible issue with text buttons).
So bubble-style Button now use `display: inline-block` to fix the issue.

Tested on:
- Safari 10
- Safari 13
- Firefox (latest)
- Chrome (latest)