### PR TITLE
Fix click behavior on textarea to set focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Fix focus behavior for`Textarea` when clicking its margins.
 - [...]
 
 # v16.0.0 (25/11/2019)

--- a/src/textarea/Textarea.tsx
+++ b/src/textarea/Textarea.tsx
@@ -105,6 +105,16 @@ export default class Textarea extends PureComponent<TextAreaProps, TextAreaState
     this.maybeAdaptHeightToContent()
   }
 
+  // To ensure a proper scrolling behavior for the textarea when growing with content, we need to
+  // have a wrapper independent from the native textarea. This wrapper is bigger that the
+  // the textarea but still looks like the textarea (same background color). When activating the
+  // wrapper, the focus should set the focus on the native textarea.
+  onWrapperClick = () => {
+    if (this.textareaRef && this.textareaRef.current) {
+      this.textareaRef.current.focus()
+    }
+  }
+
   onFocus = (event: React.FocusEvent<HTMLTextAreaElement>) => {
     this.setState({
       hasFocus: true,
@@ -237,6 +247,7 @@ export default class Textarea extends PureComponent<TextAreaProps, TextAreaState
       <div className={cc(['kirk-textarea', prefix({ error: !!error, disabled }), className])}>
         {label && <label htmlFor={id}>{label}</label>}
         <div
+          onClick={this.onWrapperClick}
           className={cc([
             'kirk-textarea-wrapper',
             {


### PR DESCRIPTION
The textarea has margins that look like the textarea but won't focus the textarea if clicked.
A click handler was added to  make sure we focus the textarea when clicking these margins.

TESTED=Locally in storybook