### PR TITLE
Add default Tabs panel transition. Disabled by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[UPDATE]** Add new default transition to `Tabs` panel. Disabled by default.
 - [...]
 
 # v16.0.1 (28/11/2019)

--- a/src/tabs/Tabs.tsx
+++ b/src/tabs/Tabs.tsx
@@ -25,6 +25,7 @@ interface TabsProps {
   readonly className?: Classcat.Class
   readonly tablistWrapperClassName?: Classcat.Class
   readonly isWrapped?: boolean
+  readonly useDefaultPanelTransition?: boolean
 }
 
 interface TabsState {
@@ -162,7 +163,8 @@ export class Tabs extends PureComponent<TabsProps, TabsState> {
   }
 
   render() {
-    const { tabs, className, tablistWrapperClassName, isWrapped } = this.props
+    const { tabs, className, tablistWrapperClassName, isWrapped, useDefaultPanelTransition } =
+        this.props
 
     if (tabs.length === 0) {
       return null
@@ -176,8 +178,8 @@ export class Tabs extends PureComponent<TabsProps, TabsState> {
     }
 
     return (
-      <Fragment>
-        <div className={cc(['kirk-tabs', className, { 'kirk-tabs-fixed': isFixedTabs }])}>
+      <div className={cc([className])}>
+        <div className={cc(['kirk-tabs', { 'kirk-tabs-fixed': isFixedTabs }])}>
           <div className={cc(['kirk-tablist-wrapper', tablistWrapperClassName])}>
             <div className="kirk-tab-highlight" ref={this.highlightRef} />
             <div
@@ -234,17 +236,22 @@ export class Tabs extends PureComponent<TabsProps, TabsState> {
           return (
             <div
               role="tabpanel"
-              className="kirk-tab-panel"
+              className={cc(['kirk-tab-panel',
+                {
+                  'kirk-tab-panel-entered': isSelected,
+                },
+                {'kirk-use-default-tab-panel-transition': useDefaultPanelTransition,
+                }])}
               id={`${generateTabPanelId(tab)}`}
               key={tab.id}
               aria-labelledby={tab.id}
-              hidden={!isSelected}
+              aria-hidden={!isSelected}
             >
               {isSelected ? tab.panelContent : null}
             </div>
           )
         })}
-      </Fragment>
+      </div>
     )
   }
 }

--- a/src/tabs/__snapshots__/Tabs.unit.tsx.snap
+++ b/src/tabs/__snapshots__/Tabs.unit.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Rendering testing should render properly 1`] = `
-Array [
+<div
+  className=""
+>
   <div
     className="kirk-tabs"
   >
@@ -85,11 +87,11 @@ Array [
         </div>
       </div>
     </div>
-  </div>,
+  </div>
   <div
+    aria-hidden={false}
     aria-labelledby="tab1"
-    className="kirk-tab-panel"
-    hidden={false}
+    className="kirk-tab-panel kirk-tab-panel-entered"
     id="tab1_panel"
     role="tabpanel"
   >
@@ -102,27 +104,26 @@ Array [
     >
       Content for first tab
     </div>
-  </div>,
+  </div>
   <div
+    aria-hidden={true}
     aria-labelledby="tab2"
     className="kirk-tab-panel"
-    hidden={true}
     id="tab2_panel"
     role="tabpanel"
-  />,
+  />
   <div
+    aria-hidden={true}
     aria-labelledby="tab3"
     className="kirk-tab-panel"
-    hidden={true}
     id="tab3_panel"
     role="tabpanel"
-  />,
-]
+  />
+</div>
 `;
 
 exports[`Rendering testing should render properly with icons 1`] = `
-Array [
-  .c0.kirk-icon-wrapper {
+.c0.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -134,6 +135,9 @@ Array [
 }
 
 <div
+  className=""
+>
+  <div
     className="kirk-tabs"
   >
     <div
@@ -255,11 +259,11 @@ Array [
         </div>
       </div>
     </div>
-  </div>,
+  </div>
   <div
+    aria-hidden={false}
     aria-labelledby="iconTab1"
-    className="kirk-tab-panel"
-    hidden={false}
+    className="kirk-tab-panel kirk-tab-panel-entered"
     id="iconTab1_panel"
     role="tabpanel"
   >
@@ -272,20 +276,20 @@ Array [
     >
       Content for first tab
     </div>
-  </div>,
+  </div>
   <div
+    aria-hidden={true}
     aria-labelledby="iconTab2"
     className="kirk-tab-panel"
-    hidden={true}
     id="iconTab2_panel"
     role="tabpanel"
-  />,
+  />
   <div
+    aria-hidden={true}
     aria-labelledby="iconTab3"
     className="kirk-tab-panel"
-    hidden={true}
     id="iconTab3_panel"
     role="tabpanel"
-  />,
-]
+  />
+</div>
 `;

--- a/src/tabs/index.tsx
+++ b/src/tabs/index.tsx
@@ -5,6 +5,9 @@ import Tabs from './Tabs'
 
 const highlightHeight = '2px'
 
+// Some arbitrary delay to build the panel before starting the revealing transition.
+const delayBeforeShowingTabPanel = '450ms'
+
 const StyledTabs = styled(Tabs)`
   & {
     position: relative;
@@ -48,6 +51,15 @@ const StyledTabs = styled(Tabs)`
     white-space: nowrap;
   }
 
+  & .kirk-use-default-tab-panel-transition.kirk-tab-panel {
+    opacity: 0;
+    transition: opacity ${transition.duration.base} ${delayBeforeShowingTabPanel};
+  }
+  
+  & .kirk-use-default-tab-panel-transition.kirk-tab-panel.kirk-tab-panel-entered {
+    opacity: 1;
+  }
+  
   & .kirk-tab > .kirk-icon {
     flex-shrink: 0;
   }
@@ -69,17 +81,17 @@ const StyledTabs = styled(Tabs)`
     align-items: last baseline;
   }
 
-  &.kirk-tabs-fixed .kirk-tablist {
+  & .kirk-tabs-fixed .kirk-tablist {
     overflow: initial;
   }
 
-  &.kirk-tabs-fixed .kirk-tab-container {
+  & .kirk-tabs-fixed .kirk-tab-container {
     margin-left: 0;
     flex-grow: 1;
     text-align: center;
   }
 
-  &.kirk-tabs-fixed .kirk-tab {
+  & .kirk-tabs-fixed .kirk-tab {
     white-space: normal;
   }
 

--- a/src/tabs/story.tsx
+++ b/src/tabs/story.tsx
@@ -64,6 +64,45 @@ stories.add('default', () => {
   )
 })
 
+stories.add('with default panel transition', () => {
+  const defaultTabsConfig = {
+    activeTabId: 'tab1',
+    status: select('status', TabStatus, TabStatus.SCROLLABLE),
+    isWrapped: boolean('isWrapped', false),
+    tabs: [
+      {
+        id: 'tab1',
+        label: text('Tab label 1', 'Tab 1'),
+        panelContent: panels[0],
+        badgeContent: text('Badge content 1', ''),
+      },
+      {
+        id: 'tab2',
+        label: text('Tab label 2', 'Very Very Long Tab 2'),
+        panelContent: panels[1],
+        badgeContent: text('Badge content 2', '2'),
+        badgeAriaLabel: 'Unread Message',
+      },
+      {
+        id: 'tab3',
+        label: text('Tab label 3', 'Tab 3'),
+        panelContent: panels[2],
+        badgeContent: text('Badge content 3', ''),
+      },
+    ],
+  }
+  return (
+      <Tabs
+          onChange={action('onChange')}
+          tabs={defaultTabsConfig.tabs}
+          activeTabId={defaultTabsConfig.activeTabId}
+          status={defaultTabsConfig.status}
+          isWrapped={defaultTabsConfig.isWrapped}
+          useDefaultPanelTransition={true}
+      />
+  )
+})
+
 stories.add('with icons', () => {
   const iconTabsConfig = {
     activeTabId: 'tab1',


### PR DESCRIPTION
Add a new Tabs panel transition based on the current Tabs panel transition on the search result page.
This new transition is disabled by default.

Note for reviewers: I had to move the classname root to a parent div element (instead of fragment) to be able to target the tab panels in the Styled component. I think this should work with our current search and messaging use cases.

TESTED=Locally in storybook (new story added)