### PR TITLE
Allow rendering of non-highlighted ItemAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[NEW]** Allow rendering of non-highlighted `ItemAction`.
 - [...]
 
 # v16.0.3 (09/12/2019)

--- a/src/itemAction/index.tsx
+++ b/src/itemAction/index.tsx
@@ -6,6 +6,7 @@ import Item, { ItemStatus } from '_utils/item'
 import prefix from '_utils'
 
 export interface ItemActionProps {
+  readonly highlighted?: boolean
   readonly tag?: JSX.Element
   readonly className?: Classcat.Class
   readonly href?: string | JSX.Element
@@ -22,6 +23,7 @@ export interface ItemActionProps {
 
 class ItemAction extends PureComponent<ItemActionProps> {
   static defaultProps: Partial<ItemActionProps> = {
+    highlighted: true,
     status: ItemStatus.DEFAULT,
   }
 
@@ -29,6 +31,7 @@ class ItemAction extends PureComponent<ItemActionProps> {
 
   render() {
     const {
+      highlighted,
       className,
       action,
       subLabel,
@@ -69,7 +72,7 @@ class ItemAction extends PureComponent<ItemActionProps> {
 
     return (
       <Item
-        highlighted
+        highlighted={highlighted}
         className={className}
         leftAddon={leftAddon}
         leftTitle={action}

--- a/src/itemAction/index.unit.tsx
+++ b/src/itemAction/index.unit.tsx
@@ -77,5 +77,17 @@ describe('ItemAction', () => {
       expect(wrapper.find(Loader).exists()).toBe(true)
       expect(wrapper.find(Loader).prop('done')).toBe(true)
     })
+
+    it('Should render an highlighted ItemAction by default', () => {
+      const props = { action: 'test' }
+      const wrapper = mount(<ItemAction {...props}>...</ItemAction>)
+      expect( wrapper.find('.kirk-item--highlighted').exists()).toBe(true)
+    })
+
+    it('Can render a non-highlighted ItemAction', () => {
+      const props = { action: 'test', highlighted: false }
+      const wrapper = mount(<ItemAction {...props}>...</ItemAction>)
+      expect( wrapper.find('.kirk-item--highlighted').exists()).toBe(false)
+    })
   })
 })

--- a/src/itemAction/story.tsx
+++ b/src/itemAction/story.tsx
@@ -71,3 +71,16 @@ stories.add('With loading state', () => (
     <ItemAction action="Action 2" subLabel="with subLabel" status={ItemAction.STATUS.CHECKED} />
   </div>
 ))
+
+stories.add('With/without highlight', () => (
+    <div>
+        <ItemAction
+            action={text('Action', 'Highlighted by default')}
+        />
+
+        <ItemAction
+            highlighted={boolean('Highlighted', false)}
+            action={text('Action', 'Not highlighted')}
+        />
+    </div>
+))


### PR DESCRIPTION
This is needed when rendering many ItemAction in the same page, they don't need to be all highlighted.

TESTED-Unit tests and locally in storybook