### PR TITLE
Fix layout issue on TopTripCardList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-[...]
+- **[FIX]** Fix layout issue on `TopTripCardList`
 
 # v16.1.1 (12/12/2019)
 

--- a/src/topTripCardList/index.tsx
+++ b/src/topTripCardList/index.tsx
@@ -29,9 +29,10 @@ const StyledTopTripCardList = styled(TopTripCardList)`
   }
 
   & .kirk-tripCard {
-    flex-grow: 1;
+    flex: 1;
     margin-right: ${space.m};
     background-color: ${color.white};
+    position: relative;
   }
 
   & .kirk-tripCard:last-child {


### PR DESCRIPTION
2 issues fixed:
- The cards were not equal size on large device but dependent on content.
- The padding right scroll hack were not applying because the container didn't have a `position: relative`

See column issue:
![image](https://user-images.githubusercontent.com/1606624/70785677-43994800-1d8b-11ea-9d1a-28afede833a0.png)
