### PR TITLE
add slider keyboard controls to Stepper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[UPDATE]** Add keyboard controls to `Stepper`
 - [...]
 
 # v16.2.0 (16/12/2019)

--- a/src/stepper/Stepper.unit.tsx
+++ b/src/stepper/Stepper.unit.tsx
@@ -34,7 +34,7 @@ it('Should have the default text & attributes', () => {
     </Stepper>,
   )
   expect(stepper.find('label span').text()).toBe('Amount of something')
-  expect(stepper.find('input').prop('value')).toBe(0)
+  expect(stepper.find('input[type="hidden"]').prop('value')).toBe(0)
   expect(stepper.prop('min')).toBe(Number.MIN_SAFE_INTEGER)
   expect(stepper.prop('max')).toBe(Number.MAX_SAFE_INTEGER)
   expect(stepper.prop('step')).toBe(1)
@@ -101,7 +101,7 @@ it('Be able to format the value', () => {
       Amount of something
     </Stepper>,
   )
-  expect(stepper.find('input').prop('value')).toBe('2 €')
+  expect(stepper.find('input[type="hidden"]').prop('value')).toBe('2 €')
 })
 
 it('Should be able to receive props and then update the value', () => {

--- a/src/stepper/index.tsx
+++ b/src/stepper/index.tsx
@@ -5,6 +5,7 @@ import Stepper, { StepperDisplay, StepperButtonSize } from './Stepper'
 const StyledStepper = styled(Stepper)`
   & {
     display: flex;
+    position: relative;
   }
 
   & button {
@@ -41,6 +42,39 @@ const StyledStepper = styled(Stepper)`
   &.kirk-stepper-large .kirk-stepper-value {
     width: calc(100% - ${StepperButtonSize[StepperDisplay.LARGE]}px * 2);
     flex-grow: 0;
+  }
+
+  /* https://css-tricks.com/styling-cross-browser-compatible-range-inputs-css/ */
+  & .kirk-stepper-range {
+    position: absolute;
+    top: 0;
+    left: 0;
+    display: block;
+    width: 100%;
+    height: 100%;
+    -webkit-appearance: none; /* Hides the slider so that custom slider can be made */
+    width: 100%; /* Specific width is required for Firefox. */
+    background: transparent; /* Otherwise white in Chrome */
+  }
+
+  & input[type='range'].kirk-stepper-range::-webkit-slider-thumb {
+    -webkit-appearance: none;
+  }
+
+  & input[type='range'].kirk-stepper-range::-moz-range-thumb {
+    background: transparent;
+    border-color: transparent;
+    color: transparent;
+  }
+
+  & .kirk-stepper-range::-ms-track {
+    width: 100%;
+    cursor: pointer;
+
+    /* Hides the slider so custom styles can be added */
+    background: transparent;
+    border-color: transparent;
+    color: transparent;
   }
 `
 


### PR DESCRIPTION
Stepper can now be controlled with keyboard (decrement with left/down, increment with right/up, min with Home, max with End).

It almost looks the same, except for the focus.
It looks like this now in Chrome and Safari:
<img width="543" alt="Screen Shot 2019-12-13 at 19 00 34" src="https://user-images.githubusercontent.com/373381/70821261-eaf19b80-1dda-11ea-9da7-9c95bf5b68eb.png">

Unfortunately, I can't get Firefox to show the focus.