### PR TITLE
[prototype] Pixar layout normalization.

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -23,10 +23,10 @@ addParameters({
   },
 })
 
-const req = require.context('../stories', true)
+const widgetStories = require.context('../stories', true)
 
 function loadStories() {
-  req.keys().forEach(req)
+  widgetStories.keys().forEach(widgetStories)
 }
 
 configure(loadStories, module)

--- a/pages/messagingThreadStory.tsx
+++ b/pages/messagingThreadStory.tsx
@@ -1,0 +1,131 @@
+import React from 'react'
+
+import { storiesOf } from '@storybook/react'
+import { withKnobs, text, boolean, select } from '@storybook/addon-knobs'
+
+import ClockIcon from 'icon/clockIcon'
+import InfoIcon from 'icon/infoIcon'
+import SendIcon from 'icon/sendIcon'
+import { Column } from '_utils/layout'
+import ItemAction from 'itemAction'
+import TheVoice from 'theVoice'
+import Tabs from 'tabs'
+import MessagingSummaryItem from "messagingSummaryItem"
+import ItemChoice from 'itemChoice'
+import Disclaimer from 'disclaimer'
+import Textarea from 'textarea'
+import Message from 'message'
+import ItemInfo from 'itemInfo'
+import Avatar from 'avatar'
+
+export default {
+    title: 'Design System|Atoms/Button',
+}
+
+const stories = storiesOf('Pages|Messaging', module)
+stories.addDecorator(withKnobs)
+
+const messagingSummaryItemConfig = {
+    url: '#',
+    pictureUrl: 'https://pbs.twimg.com/profile_images/749446875162505218/6r6-9wDn.jpg',
+    label: 'Some conversation title',
+    subLabel: 'Paris vers Lyon',
+    timeLabel: 'Il y a 3 heures',
+    hasUnreadMessages: true,
+}
+
+const notificationConfig = {
+    leftAddon: <ClockIcon />,
+    action: 'Add a photo',
+        subLabel: 'People like to put a face to a name.',
+    href: '#',
+}
+
+const defaultTabsConfig = {
+    activeTabId: 'tab1',
+    tabs: [
+        {
+            id: 'tab1',
+            label: 'Messages',
+            panelContent: <ul>
+                <MessagingSummaryItem {...messagingSummaryItemConfig}/>
+                <MessagingSummaryItem {...messagingSummaryItemConfig}/>
+                <MessagingSummaryItem {...messagingSummaryItemConfig}/>
+                <MessagingSummaryItem {...messagingSummaryItemConfig}/>
+                <MessagingSummaryItem {...messagingSummaryItemConfig}/>
+                <MessagingSummaryItem {...messagingSummaryItemConfig}/>
+            </ul>,
+        },
+        {
+            id: 'tab2',
+            label: 'Notifications',
+            panelContent: <ul>
+                <ItemAction {...notificationConfig} />
+                <ItemAction {...notificationConfig} />
+                <ItemAction {...notificationConfig} />
+                <ItemAction {...notificationConfig} />
+                <ItemAction {...notificationConfig} />
+                <ItemAction {...notificationConfig} />
+                <ItemAction {...notificationConfig} />
+            </ul>,
+        }
+    ],
+}
+
+stories.add('Inbox', () => (
+    <div style={{width: '600px', margin: 'auto', border: 'lightgray 1px solid'}}>
+        <Column>
+            <TheVoice>Inbox</TheVoice>
+            <Tabs {...defaultTabsConfig}></Tabs>
+        </Column>
+    </div>
+))
+
+stories.add('Conversation view', () => (
+    <div style={{width: '600px', margin: 'auto', border: 'lightgray 1px solid'}}>
+        <Column>
+            <ItemChoice
+                label="Paris to Bordeaux"
+                labelInfo='Thu, 5 March 2020, 00:00'
+                leftAddon={<InfoIcon />} href="#" />
+
+            <Disclaimer useInfoIcon={false}>
+                We may moderate messages. You can also report
+                inappropriate ones from our guidelines.
+            </Disclaimer>
+
+            <div style={{minHeight: '300px'}}>
+                <ItemInfo
+                    mainInfo="Vince"
+                    icon={<Avatar />}
+                />
+                <ul>
+                    <Message active={false}>msg</Message>
+                    <Message active={false}>msg</Message>
+                    <Message active={false}>msg</Message>
+                    <Message active={false}>msg</Message>
+                    <Message active={false}>msg</Message>
+                </ul>
+                <ul>
+                    <Message active>msg</Message>
+                    <Message active>msg</Message>
+                </ul>
+                <ItemInfo
+                    mainInfo="Vince"
+                    icon={<Avatar />}
+                />
+                <ul>
+                    <Message active={false}>msg</Message>
+                </ul>
+            </div>
+            <Textarea
+                defaultValue=''
+                fitContent
+                placeholder='Your message'
+                buttonIcon={<SendIcon />}
+                buttonTitle='send'
+                onButtonClick={() => {}}
+            />
+        </Column>
+    </div>
+))

--- a/pages/rideDetailsStory.tsx
+++ b/pages/rideDetailsStory.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+
+import { storiesOf } from '@storybook/react'
+import {withKnobs, text, boolean, select} from '@storybook/addon-knobs'
+
+import { Column } from '_utils/layout'
+import ItemInfo from 'itemInfo'
+import ItemData from 'itemData'
+import Divider from 'divider'
+import TheVoice from 'theVoice'
+import BubbleIcon from 'icon/bubbleIcon'
+import SmokeIcon from 'icon/smokeIcon'
+import PetIcon from 'icon/petIcon'
+import { status } from '_utils/icon/status'
+import ItemAction from 'itemAction'
+import SubHeader from 'subHeader'
+import Itinerary from 'itinerary'
+import ItemChoice from 'itemChoice'
+import Avatar from 'avatar'
+
+const stories = storiesOf('Pages|Ride details', module)
+stories.addDecorator(withKnobs)
+
+stories.add('default', () => (
+    <div style={{width: '600px', margin: 'auto', border: 'lightgray 1px solid'}}>
+        <Column>
+            <TheVoice>Ven. 11 octobre</TheVoice>
+            <Itinerary
+                fromAddon='Paris'
+                toAddon='Marseille'
+                places={[
+                    {
+                        mainLabel: 'Paris',
+                        isoDate: '2017-12-11T09:00',
+                        time: '09:00',
+                        href: '#',
+                    },
+                    {
+                        mainLabel: 'Marseille',
+                        isoDate: '2017-12-11T12:00',
+                        time: '17:00',
+                    },
+                ]}
+                small={boolean('small', false)}
+            />
+            <ItemData data='17,50 €' dataInfo='Par place' mainInfo='3 places restantes'/>
+            <Divider />
+            <ItemChoice label="Vince" rightAddon={<Avatar  />} href="#" />
+            <ItemAction action='Contacter Vince' leftAddon={<BubbleIcon />} href="#"/>
+            <Divider />
+            <ul>
+                <ItemInfo
+                    mainInfo="Fumer nest pas autporisé dans la voiture."
+                    icon={<SmokeIcon  status={status.OFF} />}
+                />
+                <ItemInfo
+                    mainInfo="Pas d'animaux dans la voiture."
+                    icon={<PetIcon status={status.OFF} />}
+                />
+            </ul>
+            <Divider />
+            <SubHeader>Passagers</SubHeader>
+            <ul>
+                <ItemChoice
+                    label="Jessica"
+                    labelInfo="Paris - Rennes"
+                    rightAddon={<Avatar  />} href="#" />
+                <ItemChoice
+                    label="Joe"
+                    labelInfo="Paris - Lyon"
+                    rightAddon={<Avatar  />} href="#" />
+            </ul>
+            <Divider />
+            <ItemAction action='Signaler ce trajet' href="#"/>
+        </Column>
+    </div>
+))

--- a/pages/searchResultStory.tsx
+++ b/pages/searchResultStory.tsx
@@ -1,0 +1,164 @@
+import React, { Fragment } from 'react'
+
+import { storiesOf } from '@storybook/react'
+import {withKnobs, text, boolean, select} from '@storybook/addon-knobs'
+
+import { Column } from '_utils/layout'
+import SubHeader from 'subHeader'
+import UneditableTextField from 'uneditableTextField'
+import Text from 'text'
+import SearchIcon from 'icon/searchIcon'
+import Item from '_utils/item'
+import Button, { ButtonStatus } from 'button'
+import BlankSeparator from 'blankSeparator'
+import Disclaimer from 'disclaimer'
+import TopTripCardList from 'topTripCardList'
+import TripCard from 'tripCard'
+import Tabs, { TabStatus } from 'tabs'
+import CarpoolIcon from 'icon/carpoolIcon'
+import BusIcon from 'icon/busIcon'
+
+const stories = storiesOf('Pages|Search result page', module)
+stories.addDecorator(withKnobs)
+
+const tripCardConfig = ({highlighted = false} = {}) => ({
+    href: '/',
+    itinerary: [
+        {
+            mainLabel: 'Paris',
+            subLabel: 'Porte de Vincennes',
+            time: '09:00',
+            isoDate: '2017-12-11T09:00',
+            distanceFromPoint: '1,5km',
+        },
+        {
+            mainLabel: 'Bordeaux',
+            subLabel: 'Gare Bordeaux Saint-Jean',
+            time: '12:00',
+            isoDate: '2017-12-11T12:00',
+            distanceFromPoint: '8km',
+        },
+    ],
+    price: '8,00€',
+    flags: {
+        ladiesOnly: true,
+        maxTwo: true,
+        autoApproval: true,
+    },
+    highlighted: highlighted ? 'Closest match' : '',
+    metaUrl: 'Meta URL',
+    title: 'Sun march 8th, 18:00',
+})
+
+const tabPanel = <Fragment>
+    <Item
+        leftBody='930 trajets allant de Bordeaux à Toulouse publiés'
+        leftBodyAnnotation='101 trajets complets'
+        rightAddon={<Button status={ButtonStatus.UNSTYLED} href='#'>Filter</Button>}
+    />
+    <BlankSeparator />
+    <ul>
+        <TripCard {...tripCardConfig()}/>
+        <TripCard {...tripCardConfig()}/>
+    </ul>
+    <Disclaimer deprecatedHelpUrl='#'>
+        Recommandation basée sur vos critères de recherche.
+    </Disclaimer>
+    <ul>
+        <TripCard {...tripCardConfig()}/>
+        <TripCard {...tripCardConfig()}/>
+        <TripCard {...tripCardConfig()}/>
+        <TripCard {...tripCardConfig()}/>
+    </ul>
+    <SubHeader>Tomorrow</SubHeader>
+    <ul>
+        <TripCard {...tripCardConfig()}/>
+        <TripCard {...tripCardConfig()}/>
+        <TripCard {...tripCardConfig()}/>
+        <TripCard {...tripCardConfig()}/>
+        <TripCard {...tripCardConfig()}/>
+        <TripCard {...tripCardConfig()}/>
+        <TripCard {...tripCardConfig()}/>
+    </ul>
+</Fragment>
+
+const defaultTabsConfig = {
+    activeTabId: 'tab1',
+    status: TabStatus.FIXED,
+    tabs: [
+        {
+            id: 'tab1',
+            label: 'All',
+            panelContent: tabPanel,
+        },
+        {
+            id: 'tab2',
+            label: 'Car',
+            panelContent: tabPanel,
+            icon: <CarpoolIcon size="32" />,
+        },
+        {
+            id: 'tab3',
+            label: 'Bus',
+            panelContent: tabPanel,
+            icon: <BusIcon size="32" />,
+        }
+    ],
+}
+
+const topTripCardConfig = {
+    ariaLabel: 'Pick-up point: Paris, Drop-off point: Bordeaux, Departure time: 09:00, warning',
+    href: '/',
+    itinerary: [
+        {
+            mainLabel: 'Paris',
+            subLabel: 'Porte de Vincennes',
+            time: '09:00',
+            isoDate: '2017-12-11T09:00',
+            distanceFromPoint: '1,5km',
+        },
+        {
+            mainLabel: 'Bordeaux',
+            subLabel: 'Gare Bordeaux Saint-Jean',
+            time: '12:00',
+            isoDate: '2017-12-11T12:00',
+            distanceFromPoint: '8km',
+        },
+    ],
+    price: '8,00€',
+    flags: {
+        ladiesOnly: true,
+        maxTwo: true,
+        autoApproval: true,
+    },
+    metaUrl: 'Meta URL',
+    badge: 'Cheapest',
+    title: '',
+}
+
+stories.add('default', () => (
+    <div style={{width: '600px', margin: 'auto', border: 'lightgray 1px solid'}}>
+        <Column>
+            <UneditableTextField href='#' addOn={<SearchIcon />}>
+                <div>
+                    <Text>Top stuff</Text>
+                    <Text>Bottom stuff</Text>
+                </div>
+            </UneditableTextField>
+
+            <TopTripCardList isWrapped={boolean('isWrapped', false)}>
+                <TripCard
+                    enableColumnLayout={false}
+                    {...topTripCardConfig} badge="Closest"/>
+                <TripCard
+                    enableColumnLayout={false}
+                    {...topTripCardConfig} />
+            </TopTripCardList>
+
+            <Tabs {...defaultTabsConfig}></Tabs>
+      </Column>
+    </div>
+))
+
+
+

--- a/src/_utils/item/Item.tsx
+++ b/src/_utils/item/Item.tsx
@@ -4,6 +4,7 @@ import cc from 'classcat'
 import { color } from '_utils/branding'
 import Text, { TextTagType, TextDisplayType } from 'text'
 import ChevronIcon from 'icon/chevronIcon'
+import { KIRK_LAYOUT_FLUID_ITEM_CLASS } from '_utils/layout'
 
 export enum ItemStatus {
   DEFAULT = 'default',
@@ -96,6 +97,7 @@ const Item = ({
       onMouseDown={onMouseDown}
       className={cc([
         'kirk-item',
+        KIRK_LAYOUT_FLUID_ITEM_CLASS,
         {
           'kirk-item--highlighted': highlighted,
           'kirk-item--clickable': isClickable,

--- a/src/_utils/item/__snapshots__/Item.unit.tsx.snap
+++ b/src/_utils/item/__snapshots__/Item.unit.tsx.snap
@@ -174,7 +174,7 @@ button.c0 {
 }
 
 <div
-  className="kirk-item custom c0"
+  className="kirk-item kirk-layout-fluid-item custom c0"
 >
   <div
     className="kirk-item-leftText"

--- a/src/_utils/layout/index.tsx
+++ b/src/_utils/layout/index.tsx
@@ -1,0 +1,54 @@
+import styled from 'styled-components'
+import { space } from '_utils/branding'
+import cc from 'classcat'
+import React, { Fragment } from 'react'
+
+// Root class for a Column element.
+const KIRK_LAYOUT_COLUMN_CLASS = 'kirk-layout-column'
+
+// Class for a fluid column item.
+// The content of a fluid item will try to take all the hortizontal space of the column and will
+// overlap the left and right spacing of the column.
+// This class will be a noop if not contained inside a column with the class
+// KIRK_LAYOUT_COLUMN_CLASS. We use this particularity to enable on demand the column layout.
+export const KIRK_LAYOUT_FLUID_ITEM_CLASS = 'kirk-layout-fluid-item'
+
+// Class for a solid column item.
+// The content of a solid item has a visible frontier (a border, a shadow or delimiting background
+// color). This content will not overlap the left and right padding of a column container.
+// This class will be a noop if not contained inside a column with the class
+// KIRK_LAYOUT_COLUMN_CLASS. We use this particularity to enable on demand the column layout.
+export const KIRK_LAYOUT_SOLID_ITEM_CLASS = 'kirk-layout-solid-item'
+
+// Helpers to make CSS below more concise.
+const FLUID_COLUMN_ITEM = `.${KIRK_LAYOUT_FLUID_ITEM_CLASS}`
+const SOLID_COLUMN_ITEM = `.${KIRK_LAYOUT_SOLID_ITEM_CLASS}`
+
+const gutterWidth = space.l
+const internalHorizontalPadding = space.m
+export const columnItemHorizontalSpacing = `calc(${gutterWidth} + ${internalHorizontalPadding})`
+
+const UnstyledColumn = ({className, children} : {className?: Classcat.Class, children: any}) =>
+    <div className={cc([KIRK_LAYOUT_COLUMN_CLASS, className])}>
+        <Fragment>{children}</Fragment>
+    </div>
+export const Column = styled(UnstyledColumn)`
+  & ${FLUID_COLUMN_ITEM} {
+    padding-left: ${columnItemHorizontalSpacing} !important;
+    padding-right: ${columnItemHorizontalSpacing} !important;
+  }
+  
+  & ${SOLID_COLUMN_ITEM} {
+    margin-top: 8px;
+    margin-bottom: 8px;
+  }
+  
+  & ${SOLID_COLUMN_ITEM} + ${SOLID_COLUMN_ITEM} {
+    margin-top: 16px;
+  }
+  
+  & ${SOLID_COLUMN_ITEM} {
+    margin-left: ${columnItemHorizontalSpacing} !important;
+    margin-right: ${columnItemHorizontalSpacing} !important;
+  }
+`

--- a/src/_utils/story.tsx
+++ b/src/_utils/story.tsx
@@ -4,7 +4,7 @@ import { withKnobs, text } from '@storybook/addon-knobs'
 
 import { color, space, font } from '_utils/branding'
 
-const stories = storiesOf('Brand', module)
+const stories = storiesOf('Widgets|Brand', module)
 stories.addDecorator(withKnobs)
 
 const styles: { [name: string]: React.CSSProperties } = {

--- a/src/autoComplete/story.tsx
+++ b/src/autoComplete/story.tsx
@@ -7,7 +7,7 @@ import { withKnobs, number, text, boolean, select } from '@storybook/addon-knobs
 import AutoComplete from '.'
 import ComfortIcon from 'icon/comfortIcon'
 
-const stories = storiesOf('AutoComplete', module)
+const stories = storiesOf('Widgets|AutoComplete', module)
 stories.addDecorator(withKnobs)
 
 const places: AutocompleteItem[] = [

--- a/src/avatar/story.tsx
+++ b/src/avatar/story.tsx
@@ -11,7 +11,7 @@ const sizes = {
   isLarge: 'isLarge',
 }
 
-const stories = storiesOf('Avatar', module)
+const stories = storiesOf('Widgets|Avatar', module)
 stories.addDecorator(withKnobs)
 
 stories.add('Basic', () => {

--- a/src/badge/story.tsx
+++ b/src/badge/story.tsx
@@ -4,7 +4,7 @@ import { storiesOf } from '@storybook/react'
 import { withKnobs, text } from '@storybook/addon-knobs'
 import Badge from './index'
 
-const stories = storiesOf('Badge', module)
+const stories = storiesOf('Widgets|Badge', module)
 stories.addDecorator(withKnobs)
 
 stories.add('Basic', () => (

--- a/src/blankSeparator/BlankSeparator.tsx
+++ b/src/blankSeparator/BlankSeparator.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import cc from 'classcat'
+import { KIRK_LAYOUT_SOLID_ITEM_CLASS } from '_utils/layout'
 
 interface BlankSeparatorProps {
   readonly className?: Classcat.Class
@@ -13,7 +14,7 @@ export enum BlankSeparatorSize {
 }
 
 const BlankSeparator = ({ className }: BlankSeparatorProps) => (
-  <div className={cc(className)} aria-hidden="true" />
+  <div className={cc([KIRK_LAYOUT_SOLID_ITEM_CLASS, className])} aria-hidden="true" />
 )
 
 export default BlankSeparator

--- a/src/blankSeparator/story.tsx
+++ b/src/blankSeparator/story.tsx
@@ -6,7 +6,7 @@ import spec from 'blankSeparator/specifications/blankSeparator.md'
 import BlankSeparator from 'blankSeparator'
 import { BlankSeparatorSize } from './BlankSeparator'
 
-const stories = storiesOf('BlankSeparator', module)
+const stories = storiesOf('Widgets|BlankSeparator', module)
 stories.addDecorator(withKnobs)
 stories.add('Specifications', () => <BlankSeparator />, { readme: spec })
 

--- a/src/button/story.tsx
+++ b/src/button/story.tsx
@@ -11,7 +11,7 @@ import primaryDoc from './specifications/primary.md'
 import secondaryDoc from './specifications/secondary.md'
 import tertiaryDoc from './specifications/tertiary.md'
 
-const stories = storiesOf('Button', module).addDecorator(withKnobs)
+const stories = storiesOf('Widgets|Button', module).addDecorator(withKnobs)
 
 const label = (defaultValue: string) => text('Label', defaultValue)
 const hasIcon = () => boolean('icon', false)
@@ -129,6 +129,7 @@ stories.add('anchor button with link element', () => (
     {label('Anchor button')}
   </Button>
 ))
+
 
 stories.add('anchor button unstyled', () => (
   <Button status={ButtonStatus.UNSTYLED} isBubble={hasIcon()} {...commonProps}>

--- a/src/buttonGroup/story.tsx
+++ b/src/buttonGroup/story.tsx
@@ -8,7 +8,7 @@ import Button, { ButtonStatus } from 'button'
 
 import spec from './specifications/index.md'
 
-const stories = storiesOf('ButtonGroup', module)
+const stories = storiesOf('Widgets|ButtonGroup', module)
 stories.addDecorator(withKnobs)
 
 stories.add(

--- a/src/caption/story.tsx
+++ b/src/caption/story.tsx
@@ -5,7 +5,7 @@ import { withKnobs, text } from '@storybook/addon-knobs'
 
 import Caption from 'caption'
 
-const stories = storiesOf('Caption', module)
+const stories = storiesOf('Widgets|Caption', module)
 stories.addDecorator(withKnobs)
 
 stories.add('A basic caption', () => (

--- a/src/confirmationModal/story.tsx
+++ b/src/confirmationModal/story.tsx
@@ -9,7 +9,7 @@ import { ConfirmationModalProps, ConfirmationModalSize } from './ConfirmationMod
 import ConfirmationModal, { ConfirmationModalStatus } from 'confirmationModal'
 import confirmationModalDoc from './specifications/confirmationModal.md'
 
-const stories = storiesOf('ConfirmationModal', module)
+const stories = storiesOf('Widgets|ConfirmationModal', module)
 stories.addDecorator(withKnobs)
 
 class ConfirmationModalOpener extends Component<ConfirmationModalProps> {

--- a/src/datePicker/story.tsx
+++ b/src/datePicker/story.tsx
@@ -7,7 +7,7 @@ import { withKnobs, select, number } from '@storybook/addon-knobs'
 import DatePicker, { DatePickerOrientation } from 'datePicker'
 import readme from 'datePicker/specifications/datepicker.md'
 
-const stories = storiesOf('DatePicker', module)
+const stories = storiesOf('Widgets|DatePicker', module)
 stories.addDecorator(withKnobs)
 
 const weekdaysShort = (locale: string): string[] => {

--- a/src/disclaimer/story.tsx
+++ b/src/disclaimer/story.tsx
@@ -6,7 +6,7 @@ import spec from 'disclaimer/specifications/disclaimer.md'
 import Disclaimer from 'disclaimer'
 import Button, { ButtonStatus } from 'button'
 
-const stories = storiesOf('Disclaimer', module)
+const stories = storiesOf('Widgets|Disclaimer', module)
 stories.addDecorator(withKnobs)
 
 stories.add('Specifications', () => <Disclaimer useInfoIcon>My disclaimer text here</Disclaimer>, {

--- a/src/divider/Divider.tsx
+++ b/src/divider/Divider.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import cc from 'classcat'
+import { KIRK_LAYOUT_SOLID_ITEM_CLASS } from '_utils/layout'
 
 interface DividerProps {
   readonly className?: Classcat.Class
 }
 
 const Divider = ({ className }: DividerProps) => (
-  <div className={cc(className)} aria-hidden="true" />
-)
+    <div className={cc([KIRK_LAYOUT_SOLID_ITEM_CLASS, className])} aria-hidden='true'>
+    </div>)
 
 export default Divider

--- a/src/divider/index.tsx
+++ b/src/divider/index.tsx
@@ -15,7 +15,8 @@ const StyledDivider = styled(Divider)`
     top: ${space.m};
     content: ' ';
     border-top: solid ${color.divider} 1px;
-    width: 100%;
+    left: 0;
+    right: 0;
   }
 `
 export default StyledDivider

--- a/src/divider/story.tsx
+++ b/src/divider/story.tsx
@@ -5,7 +5,7 @@ import { withKnobs, text, boolean } from '@storybook/addon-knobs'
 import spec from 'divider/specifications/divider.md'
 import Divider from 'divider'
 
-const stories = storiesOf('Divider', module)
+const stories = storiesOf('Widgets|Divider', module)
 stories.addDecorator(withKnobs)
 stories.add('Specifications', () => <Divider />, { readme: spec })
 

--- a/src/drawer/story.tsx
+++ b/src/drawer/story.tsx
@@ -7,7 +7,7 @@ import { BellIcon, BubbleIcon, HomeIcon, NewspaperIcon, TicketIcon } from 'icon'
 import Drawer from 'drawer'
 import HamburgerButton from 'hamburgerButton'
 
-const stories = storiesOf('Drawer', module)
+const stories = storiesOf('Widgets|Drawer', module)
 stories.addDecorator(withKnobs)
 
 class DrawerDemo extends Component {

--- a/src/dropdownButton/story.tsx
+++ b/src/dropdownButton/story.tsx
@@ -7,7 +7,7 @@ import { action } from '@storybook/addon-actions'
 import DropdownButton from 'dropdownButton'
 import Avatar from 'avatar'
 
-const stories = storiesOf('DropdownButton', module)
+const stories = storiesOf('Widgets|DropdownButton', module)
 stories.addDecorator(withKnobs)
 
 stories.add('default', () => (

--- a/src/emptyState/story.tsx
+++ b/src/emptyState/story.tsx
@@ -7,7 +7,7 @@ import spec from 'emptyState/specifications/emptystate.md'
 import EmptyState from 'emptyState'
 import Button from 'button'
 
-const stories = storiesOf('EmptyState', module)
+const stories = storiesOf('Widgets|EmptyState', module)
 stories.addDecorator(withKnobs)
 
 const button = <Button>Do something</Button>

--- a/src/hamburgerButton/story.tsx
+++ b/src/hamburgerButton/story.tsx
@@ -5,7 +5,7 @@ import { action } from '@storybook/addon-actions'
 
 import HamburgerButton from 'hamburgerButton'
 
-const stories = storiesOf('HamburgerButton', module)
+const stories = storiesOf('Widgets|HamburgerButton', module)
 stories.addDecorator(withKnobs)
 
 stories.add('default', () => (

--- a/src/icon/story.tsx
+++ b/src/icon/story.tsx
@@ -20,7 +20,7 @@ const styles: { [name: string]: React.CSSProperties } = {
   },
 }
 
-const stories = storiesOf('Icons', module)
+const stories = storiesOf('Widgets|Icons', module)
 stories.addDecorator(withKnobs)
 
 const c = Object.keys(color).reduce(

--- a/src/itemAction/story.tsx
+++ b/src/itemAction/story.tsx
@@ -8,7 +8,7 @@ import ItemAction from 'itemAction'
 import BubbleIcon from 'icon/bubbleIcon'
 import spec from './specifications/index.md'
 
-const stories = storiesOf('ItemAction', module)
+const stories = storiesOf('Widgets|ItemAction', module)
 stories.addDecorator(withKnobs)
 
 stories.add(

--- a/src/itemCheckbox/__snapshots__/ItemCheckbox.unit.tsx.snap
+++ b/src/itemCheckbox/__snapshots__/ItemCheckbox.unit.tsx.snap
@@ -196,7 +196,7 @@ button.c0 {
 }
 
 <label
-  className="kirk-item kirk-item--clickable kirk-item-checkbox custom-class-name c0"
+  className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-checkbox custom-class-name c0"
 >
   <div
     className="kirk-item-leftText"
@@ -497,7 +497,7 @@ button.c0 {
 }
 
 <label
-  className="kirk-item kirk-item--clickable kirk-item-checkbox custom-class-name c0"
+  className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-checkbox custom-class-name c0"
 >
   <div
     className="kirk-item-leftText"
@@ -775,7 +775,7 @@ button.c0 {
 }
 
 <label
-  className="kirk-item kirk-item--clickable kirk-item-checkbox custom-class-name c0"
+  className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-checkbox custom-class-name c0"
 >
   <div
     className="kirk-item-leftText"

--- a/src/itemCheckbox/story.tsx
+++ b/src/itemCheckbox/story.tsx
@@ -8,7 +8,7 @@ import ItemCheckbox, { ItemCheckboxStatus } from 'itemCheckbox'
 
 import specs from './specifications/index.md'
 
-const stories = storiesOf('ItemCheckbox', module)
+const stories = storiesOf('Widgets|ItemCheckbox', module)
 stories.addDecorator(withKnobs)
 
 stories.add(

--- a/src/itemChoice/__snapshots__/index.unit.tsx.snap
+++ b/src/itemChoice/__snapshots__/index.unit.tsx.snap
@@ -237,7 +237,7 @@ button.c0 {
 }
 
 <a
-  className="kirk-item kirk-item--clickable kirk-item-choice custom-class-name c0"
+  className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-choice custom-class-name c0"
   disabled={false}
   href="#"
   onClick={[Function]}
@@ -587,7 +587,7 @@ button.c0 {
 }
 
 <a
-  className="kirk-item kirk-item--clickable kirk-item-choice custom-class-name c0"
+  className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-choice custom-class-name c0"
   disabled={false}
   href="#"
   onClick={[Function]}
@@ -886,7 +886,7 @@ button.c0 {
 }
 
 <a
-  className="kirk-item kirk-item--clickable kirk-item-choice custom-class-name c0"
+  className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-choice custom-class-name c0"
   disabled={false}
   href="#"
   onClick={[Function]}
@@ -1209,7 +1209,7 @@ button.c0 {
 }
 
 <button
-  className="kirk-item kirk-item-choice custom-class-name c0"
+  className="kirk-item kirk-layout-fluid-item kirk-item-choice custom-class-name c0"
   disabled={true}
   onBlur={null}
   onClick={null}
@@ -1534,7 +1534,7 @@ button.c0 {
 }
 
 <button
-  className="kirk-item kirk-item--clickable kirk-item-choice custom-class-name c0"
+  className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-choice custom-class-name c0"
   disabled={false}
   onClick={[Function]}
   type="button"

--- a/src/itemChoice/story.tsx
+++ b/src/itemChoice/story.tsx
@@ -9,7 +9,7 @@ import ComfortIcon from 'icon/comfortIcon'
 
 import specs from './specifications/index.md'
 
-const stories = storiesOf('ItemChoice', module)
+const stories = storiesOf('Widgets|ItemChoice', module)
 stories.addDecorator(withKnobs)
 
 stories.add(

--- a/src/itemData/story.tsx
+++ b/src/itemData/story.tsx
@@ -5,7 +5,7 @@ import { boolean, text, withKnobs } from '@storybook/addon-knobs'
 
 import ItemData from 'itemData'
 
-const stories = storiesOf('ItemData', module)
+const stories = storiesOf('Widgets|ItemData', module)
 stories.addDecorator(withKnobs)
 
 stories.add('Default', () => {

--- a/src/itemInfo/story.tsx
+++ b/src/itemInfo/story.tsx
@@ -6,7 +6,7 @@ import { boolean, text, withKnobs } from '@storybook/addon-knobs'
 import ItemInfo from 'itemInfo'
 import ClockIcon from 'icon/clockIcon'
 
-const stories = storiesOf('ItemInfo', module)
+const stories = storiesOf('Widgets|ItemInfo', module)
 stories.addDecorator(withKnobs)
 
 stories.add('ItemInfo', () => {

--- a/src/itemRadio/__snapshots__/ItemRadio.unit.tsx.snap
+++ b/src/itemRadio/__snapshots__/ItemRadio.unit.tsx.snap
@@ -206,7 +206,7 @@ button.c0 {
 }
 
 <label
-  className="kirk-item kirk-item--clickable kirk-item-radio custom-class-name c0"
+  className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-radio custom-class-name c0"
 >
   <div
     className="kirk-item-leftText"
@@ -516,7 +516,7 @@ button.c0 {
 }
 
 <label
-  className="kirk-item kirk-item--clickable kirk-item-radio custom-class-name c0"
+  className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-radio custom-class-name c0"
 >
   <div
     className="kirk-item-leftText"
@@ -798,7 +798,7 @@ button.c0 {
 }
 
 <label
-  className="kirk-item kirk-item--clickable kirk-item-radio custom-class-name c0"
+  className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-radio custom-class-name c0"
 >
   <div
     className="kirk-item-leftText"

--- a/src/itemRadio/story.tsx
+++ b/src/itemRadio/story.tsx
@@ -12,7 +12,7 @@ import mainDoc from './specifications/doc.md'
 import groupDoc from './specifications/group.md'
 import { ItemRadioStatus } from './ItemRadio'
 
-const stories = storiesOf('ItemRadio', module)
+const stories = storiesOf('Widgets|ItemRadio', module)
 stories.addDecorator(withKnobs)
 
 stories.add(

--- a/src/itemRadioGroup/__snapshots__/index.unit.tsx.snap
+++ b/src/itemRadioGroup/__snapshots__/index.unit.tsx.snap
@@ -257,7 +257,7 @@ button.c2 {
     className="kirk-items-list-item"
   >
     <label
-      className="kirk-item kirk-item--clickable kirk-item-radio c1 c2"
+      className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-radio c1 c2"
     >
       <div
         className="kirk-item-leftText"
@@ -307,7 +307,7 @@ button.c2 {
     className="kirk-items-list-item"
   >
     <label
-      className="kirk-item kirk-item--clickable kirk-item-radio c1 c2"
+      className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-radio c1 c2"
     >
       <div
         className="kirk-item-leftText"
@@ -364,7 +364,7 @@ button.c2 {
     className="kirk-items-list-item"
   >
     <label
-      className="kirk-item kirk-item--clickable kirk-item-radio c1 c2"
+      className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-radio c1 c2"
     >
       <div
         className="kirk-item-leftText"

--- a/src/itemsList/__snapshots__/ItemsList.unit.tsx.snap
+++ b/src/itemsList/__snapshots__/ItemsList.unit.tsx.snap
@@ -208,7 +208,7 @@ button.c1 {
     className="kirk-items-list-item"
   >
     <a
-      className="kirk-item kirk-item--clickable kirk-item-choice c1"
+      className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-choice c1"
       href="#1"
     >
       <div
@@ -257,7 +257,7 @@ button.c1 {
     className="kirk-items-list-item"
   >
     <a
-      className="kirk-item kirk-item--clickable kirk-item-choice c1"
+      className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-choice c1"
       href="#2"
     >
       <div
@@ -306,7 +306,7 @@ button.c1 {
     className="kirk-items-list-item"
   >
     <a
-      className="kirk-item kirk-item--clickable kirk-item-choice c1"
+      className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-choice c1"
       href="#3"
     >
       <div
@@ -562,7 +562,7 @@ button.c1 {
     className="kirk-items-list-item"
   >
     <a
-      className="kirk-item kirk-item--clickable kirk-item-choice c1"
+      className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-choice c1"
       href="#1"
     >
       <div
@@ -611,7 +611,7 @@ button.c1 {
     className="kirk-items-list-item"
   >
     <a
-      className="kirk-item kirk-item--clickable kirk-item-choice c1"
+      className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-choice c1"
       href="#2"
     >
       <div
@@ -660,7 +660,7 @@ button.c1 {
     className="kirk-items-list-item kirk-items-list-item--withSeparator"
   >
     <a
-      className="kirk-item kirk-item--clickable kirk-item-choice c1"
+      className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-choice c1"
       href="#3"
     >
       <div
@@ -916,7 +916,7 @@ button.c1 {
     className="kirk-items-list-item"
   >
     <a
-      className="kirk-item kirk-item--clickable kirk-item-choice c1"
+      className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-choice c1"
       href="#1"
     >
       <div
@@ -965,7 +965,7 @@ button.c1 {
     className="kirk-items-list-item"
   >
     <a
-      className="kirk-item kirk-item--clickable kirk-item-choice c1"
+      className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-choice c1"
       href="#2"
     >
       <div
@@ -1014,7 +1014,7 @@ button.c1 {
     className="kirk-items-list-item"
   >
     <a
-      className="kirk-item kirk-item--clickable kirk-item-choice c1"
+      className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-item-choice c1"
       href="#3"
     >
       <div

--- a/src/itemsList/story.tsx
+++ b/src/itemsList/story.tsx
@@ -7,7 +7,7 @@ import ItemsList, { ItemsListDivider } from 'itemsList'
 
 import specs from './specifications/index.md'
 
-const stories = storiesOf('ItemsList', module)
+const stories = storiesOf('Widgets|ItemsList', module)
 
 stories.add(
   'With separators between each item',

--- a/src/itinerary/Itinerary.tsx
+++ b/src/itinerary/Itinerary.tsx
@@ -8,6 +8,7 @@ import Text, { TextDisplayType, TextTagType } from 'text'
 import ChevronIcon from 'icon/chevronIcon'
 import SubHeader from 'subHeader'
 import BlankSeparator from 'blankSeparator'
+import { KIRK_LAYOUT_FLUID_ITEM_CLASS } from '_utils/layout'
 
 interface ItineraryProps {
   readonly ariaLabelledBy?: string
@@ -79,7 +80,8 @@ const Itinerary = ({
       <ul className={cc([{ 'kirk-itinerary--small': isSmall }])}>
         {isNonEmptyString(fromAddon) && (
           <li className="kirk-itinerary-fromAddon" aria-label={fromAddonAriaLabel}>
-            <Text className="kirk-itinerary-addon-content"
+              <div className="kirk-itinerary-time-cell" aria-hidden='true'></div>
+              <Text className="kirk-itinerary-addon-content"
                   display={TextDisplayType.CAPTION}>{fromAddon}</Text>
           </li>
         )}
@@ -90,25 +92,27 @@ const Itinerary = ({
 
           const link = place.href
           const isLastPlace = places.length - 1 === index
+          const classes = [KIRK_LAYOUT_FLUID_ITEM_CLASS, 'kirk-itinerary-location-wrapper']
 
           if (!isEmpty(link) && typeof link !== 'string') {
             Component = link.type
             chevron = true
+            classes.push(link.props.className)
             hrefProps = {
               ...link.props,
-              className: cc(['kirk-itinerary-location-wrapper', link.props.className]),
+              className: cc(classes),
             }
           } else if (typeof link === 'string') {
             Component = 'a'
             chevron = true
             hrefProps = {
               href: place.href,
-              className: 'kirk-itinerary-location-wrapper',
+              className: cc(classes),
             }
           } else {
             Component = 'div'
             hrefProps = {
-              className: 'kirk-itinerary-location-wrapper',
+              className: cc(classes),
             }
           }
 
@@ -139,7 +143,7 @@ const Itinerary = ({
               />
               <Component {...hrefProps} aria-label={place.actionAriaLabel}>
                 {!isSmall && (
-                  <time dateTime={place.isoDate}>
+                  <time className="kirk-itinerary-time-cell" dateTime={place.isoDate}>
                     <Text tag={TextTagType.DIV} display={TextDisplayType.TITLESTRONG}>
                       {place.time}
                     </Text>
@@ -174,7 +178,8 @@ const Itinerary = ({
         })}
         {isNonEmptyString(toAddon) && (
           <li className="kirk-itinerary-toAddon" aria-label={toAddonAriaLabel}>
-            <Text className="kirk-itinerary-addon-content"
+              <div className="kirk-itinerary-time-cell" aria-hidden='true'></div>
+              <Text className="kirk-itinerary-addon-content"
                   display={TextDisplayType.CAPTION}>{toAddon}</Text>
           </li>
         )}

--- a/src/itinerary/index.tsx
+++ b/src/itinerary/index.tsx
@@ -44,8 +44,8 @@ const StyledItinerary = styled(Itinerary)`
     background-color: ${color.tapHighlight}};
   }
 
-  & .kirk-itinerary-location time {
-    min-width: calc(${gutterPaddingStart} + ${componentSizes.timeWidth});
+  & .kirk-itinerary-time-cell {
+    width: calc(${gutterPaddingStart} + ${componentSizes.timeWidth});
   }
 
   & .kirk-itinerary-location-city {

--- a/src/itinerary/story.tsx
+++ b/src/itinerary/story.tsx
@@ -6,7 +6,7 @@ import { boolean, select, text, withKnobs } from '@storybook/addon-knobs'
 import Itinerary from 'itinerary'
 import Proximity from 'proximity'
 
-const stories = storiesOf('Itinerary', module)
+const stories = storiesOf('Widgets|Itinerary', module)
 stories.addDecorator(withKnobs)
 
 const places = [

--- a/src/loader/story.tsx
+++ b/src/loader/story.tsx
@@ -5,7 +5,7 @@ import { withKnobs, boolean, number } from '@storybook/addon-knobs'
 
 import Loader from './index'
 
-const stories = storiesOf('Loader', module)
+const stories = storiesOf('Widgets|Loader', module)
 stories.addDecorator(withKnobs)
 
 stories.add('default', () => (

--- a/src/marketingMessage/story.tsx
+++ b/src/marketingMessage/story.tsx
@@ -9,7 +9,7 @@ import BlankSeparator, { BlankSeparatorSize } from 'blankSeparator'
 import MarketingMessage from 'marketingMessage'
 import SubHeader from 'subHeader'
 
-const stories = storiesOf('MarketingMessage', module)
+const stories = storiesOf('Widgets|MarketingMessage', module)
 stories.addDecorator(withKnobs)
 
 const longContent = 'Long content.'.repeat(50)

--- a/src/menu/story.tsx
+++ b/src/menu/story.tsx
@@ -8,7 +8,7 @@ import Text from 'text'
 import Menu from 'menu'
 import ItemChoice, { ItemChoiceStatus } from 'itemChoice'
 
-const stories = storiesOf('Menu', module)
+const stories = storiesOf('Widgets|Menu', module)
 stories.addDecorator(withKnobs)
 
 stories.add('With all separators', () => (

--- a/src/message/Message.tsx
+++ b/src/message/Message.tsx
@@ -2,9 +2,9 @@ import React, { Fragment } from 'react'
 import cc from 'classcat'
 
 import prefix from '_utils'
-
 import BlankSeparator, { BlankSeparatorSize } from "blankSeparator"
 import Text, { TextDisplayType } from "text"
+import { KIRK_LAYOUT_SOLID_ITEM_CLASS } from '_utils/layout'
 
 export interface MessageProps {
   readonly children: string
@@ -22,24 +22,23 @@ const Message = ({
   messageAnnotation,
   className,
 }: MessageProps) => (
-  <div className={cc(['kirk-message', prefix({ active }), className])}>
-    <div className="kirk-message-content">
-      <blockquote>
-        <div className="kirk-label">
-          <p>{children}</p>
-        </div>
-      </blockquote>
+    <div className={cc([KIRK_LAYOUT_SOLID_ITEM_CLASS, 'kirk-message', prefix({ active }), className])}>
+      <div className="kirk-message-content">
+        <blockquote>
+          <div className="kirk-label">
+            <p>{children}</p>
+          </div>
+        </blockquote>
+      </div>
+      {messageAnnotation &&
+        <Fragment>
+          <Text className='kirk-message-annotation' display={TextDisplayType.CAPTION}>
+            {messageAnnotation}
+          </Text>
+          <BlankSeparator size={BlankSeparatorSize.MEDIUM} />
+        </Fragment>
+      }
     </div>
-    {messageAnnotation &&
-      <Fragment>
-        <Text className='kirk-message-annotation' display={TextDisplayType.CAPTION}>
-          {messageAnnotation}
-        </Text>
-        <BlankSeparator size={BlankSeparatorSize.MEDIUM} />
-      </Fragment>
-    }
-  </div>
-
 )
 
 export default Message

--- a/src/message/story.tsx
+++ b/src/message/story.tsx
@@ -6,7 +6,7 @@ import { withKnobs, text, boolean } from '@storybook/addon-knobs'
 import Message from 'message'
 import {JSXElement} from "@babel/types"
 
-const stories = storiesOf('Message', module)
+const stories = storiesOf('Widgets|Message', module)
 stories.addDecorator(withKnobs)
 
 const wrapInContainer = (content: JSX.Element) => {

--- a/src/messagingSummaryItem/__snapshots__/MessagingSummaryItem.unit.tsx.snap
+++ b/src/messagingSummaryItem/__snapshots__/MessagingSummaryItem.unit.tsx.snap
@@ -260,7 +260,7 @@ button.c0 {
 }
 
 <a
-  className="kirk-item kirk-item--clickable kirk-messaging-summary-item c0"
+  className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-messaging-summary-item c0"
   href="http_test.url"
 >
   <div
@@ -595,7 +595,7 @@ button.c0 {
 }
 
 <a
-  className="kirk-item kirk-item--clickable kirk-messaging-summary-item c0"
+  className="kirk-item kirk-layout-fluid-item kirk-item--clickable kirk-messaging-summary-item c0"
   href="http_test.url"
 >
   <div

--- a/src/messagingSummaryItem/story.tsx
+++ b/src/messagingSummaryItem/story.tsx
@@ -6,7 +6,7 @@ import { withKnobs, text, boolean } from '@storybook/addon-knobs'
 import ChevronIcon from 'icon/chevronIcon'
 import MessagingSummaryItem from './index'
 
-const stories = storiesOf('MessagingSummaryItem', module)
+const stories = storiesOf('Widgets|MessagingSummaryItem', module)
 stories.addDecorator(withKnobs)
 
 const pictureUrl = 'https://pbs.twimg.com/profile_images/749446875162505218/6r6-9wDn.jpg'

--- a/src/modal/story.tsx
+++ b/src/modal/story.tsx
@@ -8,7 +8,7 @@ import { ModalProps } from './Modal'
 
 import modalDoc from './specifications/modal.md'
 
-const stories = storiesOf('Modal', module)
+const stories = storiesOf('Widgets|Modal', module)
 stories.addDecorator(withKnobs)
 
 class ModalOpener extends Component<ModalProps> {

--- a/src/phoneField/story.tsx
+++ b/src/phoneField/story.tsx
@@ -8,7 +8,7 @@ import defaultDoc from './specifications/default.md'
 import customDoc from './specifications/custom.md'
 import PhoneField from '.'
 
-const stories = storiesOf('PhoneField', module)
+const stories = storiesOf('Widgets|PhoneField', module)
 stories.addDecorator(withKnobs)
 
 const countryWhitelist = ['FR', 'ES']

--- a/src/profile/story.tsx
+++ b/src/profile/story.tsx
@@ -5,7 +5,7 @@ import { withKnobs, text, boolean, number } from '@storybook/addon-knobs'
 
 import Profile from 'profile'
 
-const stories = storiesOf('Profile', module)
+const stories = storiesOf('Widgets|Profile', module)
 stories.addDecorator(withKnobs)
 
 stories.add('default', () => (

--- a/src/proximity/story.tsx
+++ b/src/proximity/story.tsx
@@ -5,7 +5,7 @@ import { withKnobs, text, select } from '@storybook/addon-knobs'
 
 import Proximity, { Distances } from './index'
 
-const stories = storiesOf('Proximity', module)
+const stories = storiesOf('Widgets|Proximity', module)
 stories.addDecorator(withKnobs)
 
 stories.add('default', () => (

--- a/src/pushInfo/story.tsx
+++ b/src/pushInfo/story.tsx
@@ -7,7 +7,7 @@ import { color } from '_utils/branding'
 import ProximityIcon from 'icon/proximityIcon'
 import PushInfo from './index'
 
-const stories = storiesOf('PushInfo', module)
+const stories = storiesOf('Widgets|PushInfo', module)
 stories.addDecorator(withKnobs)
 
 stories.add('default', () => (

--- a/src/rating/story.tsx
+++ b/src/rating/story.tsx
@@ -5,7 +5,7 @@ import { withKnobs, text, number } from '@storybook/addon-knobs'
 
 import Rating from 'rating'
 
-const stories = storiesOf('Rating', module)
+const stories = storiesOf('Widgets|Rating', module)
 stories.addDecorator(withKnobs)
 
 stories.add('Rating', () => (

--- a/src/selectField/story.tsx
+++ b/src/selectField/story.tsx
@@ -6,7 +6,7 @@ import { action } from '@storybook/addon-actions'
 
 import SelectField from 'selectField'
 
-const stories = storiesOf('SelectField', module)
+const stories = storiesOf('Widgets|SelectField', module)
 stories.addDecorator(withKnobs)
 
 const phonePrefixOptions = [

--- a/src/snackbar/story.tsx
+++ b/src/snackbar/story.tsx
@@ -5,7 +5,7 @@ import { withKnobs, text } from '@storybook/addon-knobs'
 
 import Snackbar from 'snackbar'
 
-const stories = storiesOf('Snackbar', module)
+const stories = storiesOf('Widgets|Snackbar', module)
 stories.addDecorator(withKnobs)
 
 interface ErrorOpenerState {

--- a/src/stars/story.tsx
+++ b/src/stars/story.tsx
@@ -5,7 +5,7 @@ import { withKnobs, number } from '@storybook/addon-knobs'
 
 import Stars from 'stars'
 
-const stories = storiesOf('Stars', module)
+const stories = storiesOf('Widgets|Stars', module)
 stories.addDecorator(withKnobs)
 
 stories.add('Stars', () => <Stars stars={number('amount of stars', 0)} />)

--- a/src/stepper/story.tsx
+++ b/src/stepper/story.tsx
@@ -7,7 +7,7 @@ import { withKnobs, text, number, select } from '@storybook/addon-knobs'
 import spec from './specifications/stepper.md'
 import Stepper, { StepperDisplay } from 'stepper'
 
-const stories = storiesOf('Stepper', module)
+const stories = storiesOf('Widgets|Stepper', module)
 stories.addDecorator(withKnobs)
 
 stories.add('Default stepper', () => (

--- a/src/subHeader/story.tsx
+++ b/src/subHeader/story.tsx
@@ -5,7 +5,7 @@ import { withKnobs, text, boolean } from '@storybook/addon-knobs'
 import spec from 'subHeader/specifications/subHeader.md'
 import SubHeader from 'subHeader'
 
-const stories = storiesOf('SubHeader', module)
+const stories = storiesOf('Widgets|SubHeader', module)
 stories.addDecorator(withKnobs)
 const specTemplateFn = () => <SubHeader>SubHeader content</SubHeader>
 stories.add('Specifications', specTemplateFn, { readme: spec })

--- a/src/successModal/story.tsx
+++ b/src/successModal/story.tsx
@@ -8,7 +8,7 @@ import SuccessModal from 'successModal'
 import { SuccessModalProps, SuccessModalSize } from './SuccessModal'
 import successModalDoc from './specifications/successModal.md'
 
-const stories = storiesOf('SuccessModal', module)
+const stories = storiesOf('Widgets|SuccessModal', module)
 stories.addDecorator(withKnobs)
 
 class SuccessModalOpener extends Component<SuccessModalProps> {

--- a/src/tabs/Tabs.tsx
+++ b/src/tabs/Tabs.tsx
@@ -1,6 +1,7 @@
 import React, { createRef, PureComponent, RefObject, Fragment } from 'react'
 import cc from 'classcat'
 import Badge from 'badge'
+import { KIRK_LAYOUT_SOLID_ITEM_CLASS } from '_utils/layout'
 
 export enum TabStatus {
   SCROLLABLE = 'scrollable',
@@ -177,7 +178,8 @@ export class Tabs extends PureComponent<TabsProps, TabsState> {
 
     return (
       <Fragment>
-        <div className={cc(['kirk-tabs', className, { 'kirk-tabs-fixed': isFixedTabs }])}>
+        <div className={cc([
+            KIRK_LAYOUT_SOLID_ITEM_CLASS, 'kirk-tabs', className, { 'kirk-tabs-fixed': isFixedTabs }])}>
           <div className={cc(['kirk-tablist-wrapper', tablistWrapperClassName])}>
             <div className="kirk-tab-highlight" ref={this.highlightRef} />
             <div
@@ -232,16 +234,16 @@ export class Tabs extends PureComponent<TabsProps, TabsState> {
         {tabs.map(tab => {
           const isSelected = selectedTab.id === tab.id
           return (
-            <div
-              role="tabpanel"
-              className="kirk-tab-panel"
-              id={`${generateTabPanelId(tab)}`}
-              key={tab.id}
-              aria-labelledby={tab.id}
-              hidden={!isSelected}
-            >
-              {isSelected ? tab.panelContent : null}
-            </div>
+              <div
+                  role="tabpanel"
+                  className="kirk-tab-panel"
+                  id={`${generateTabPanelId(tab)}`}
+                  key={tab.id}
+                  aria-labelledby={tab.id}
+                  hidden={!isSelected}
+              >
+                {isSelected ? tab.panelContent : null}
+              </div>
           )
         })}
       </Fragment>

--- a/src/tabs/__snapshots__/Tabs.unit.tsx.snap
+++ b/src/tabs/__snapshots__/Tabs.unit.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Rendering testing should render properly 1`] = `
 Array [
   <div
-    className="kirk-tabs"
+    className="kirk-layout-solid-item kirk-tabs"
   >
     <div
       className="kirk-tablist-wrapper"
@@ -134,7 +134,7 @@ Array [
 }
 
 <div
-    className="kirk-tabs"
+    className="kirk-layout-solid-item kirk-tabs"
   >
     <div
       className="kirk-tablist-wrapper"

--- a/src/tabs/story.tsx
+++ b/src/tabs/story.tsx
@@ -9,7 +9,7 @@ import BusIcon from 'icon/busIcon'
 
 import Tabs, { TabStatus } from 'tabs'
 
-const stories = storiesOf('Tabs', module)
+const stories = storiesOf('Widgets|Tabs', module)
 stories.addDecorator(withKnobs)
 
 const panels = [

--- a/src/text/story.tsx
+++ b/src/text/story.tsx
@@ -6,7 +6,7 @@ import { select, text, withKnobs, boolean } from '@storybook/addon-knobs'
 import { color } from '_utils/branding'
 import Text, { TextTagType, TextDisplayType } from 'text'
 
-const stories = storiesOf('Text', module)
+const stories = storiesOf('Widgets|Text', module)
 stories.addDecorator(withKnobs)
 
 stories.add('basic', () => (

--- a/src/textField/story.tsx
+++ b/src/textField/story.tsx
@@ -9,7 +9,7 @@ import ArrowIcon from 'icon/arrowIcon'
 import Button, { ButtonStatus } from 'button'
 import readme from 'textField/specifications/textField.md'
 
-const stories = storiesOf('TextField', module)
+const stories = storiesOf('Widgets|TextField', module)
 stories.addDecorator(withKnobs)
 
 stories.add(

--- a/src/textarea/Textarea.tsx
+++ b/src/textarea/Textarea.tsx
@@ -4,6 +4,7 @@ import cc from 'classcat'
 import prefix from '_utils'
 import Button, { ButtonStatus } from 'button'
 import isEmpty from 'lodash.isempty'
+import { KIRK_LAYOUT_SOLID_ITEM_CLASS } from '_utils/layout'
 
 export interface CommonFormFields {
   name: string
@@ -244,7 +245,9 @@ export default class Textarea extends PureComponent<TextAreaProps, TextAreaState
     attributes.className = cc(textareaFieldClassNames)
 
     return (
-      <div className={cc(['kirk-textarea', prefix({ error: !!error, disabled }), className])}>
+      <div className={cc([
+          KIRK_LAYOUT_SOLID_ITEM_CLASS,
+          'kirk-textarea', prefix({ error: !!error, disabled }), className])}>
         {label && <label htmlFor={id}>{label}</label>}
         <div
           onClick={this.onWrapperClick}

--- a/src/textarea/story.tsx
+++ b/src/textarea/story.tsx
@@ -7,7 +7,7 @@ import SendMessageIcon from 'icon/sendMessageIcon'
 
 import TextArea from 'textarea'
 
-const stories = storiesOf('Textarea', module)
+const stories = storiesOf('Widgets|Textarea', module)
 stories.addDecorator(withKnobs)
 
 stories.add('Basic text area', () => (

--- a/src/theVoice/story.tsx
+++ b/src/theVoice/story.tsx
@@ -6,7 +6,7 @@ import { action } from '@storybook/addon-actions'
 import TheVoice from '.'
 import readme from 'theVoice/specifications/theVoice.md'
 
-const stories = storiesOf('TheVoice', module)
+const stories = storiesOf('Widgets|TheVoice', module)
 stories.addDecorator(withKnobs)
 
 stories.add('Specifications', () => null, {

--- a/src/timePicker/story.tsx
+++ b/src/timePicker/story.tsx
@@ -6,7 +6,7 @@ import { action } from '@storybook/addon-actions'
 
 import TimePicker from '.'
 
-const stories = storiesOf('TimePicker', module)
+const stories = storiesOf('Widgets|TimePicker', module)
 stories.addDecorator(withKnobs)
 
 stories.add('default', () => (

--- a/src/title/Title.tsx
+++ b/src/title/Title.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react'
 import cc from 'classcat'
+import { KIRK_LAYOUT_FLUID_ITEM_CLASS } from '_utils/layout'
 
 interface TitleProps {
   readonly id?: string
@@ -15,12 +16,12 @@ const Title = ({ id, className, children, headingLevel = 1 }: TitleProps) => {
     return null
   }
   return React.createElement(
-    `h${headingLevel}`,
-    {
-      id,
-      className: cc(['kirk-title', className]),
-    },
-    <Fragment>{children}</Fragment>,
+      `h${headingLevel}`,
+      {
+        id,
+        className: cc([KIRK_LAYOUT_FLUID_ITEM_CLASS, 'kirk-title', className]),
+      },
+      <Fragment>{children}</Fragment>,
   )
 }
 export default Title

--- a/src/title/story.tsx
+++ b/src/title/story.tsx
@@ -5,7 +5,7 @@ import { withKnobs, text, select } from '@storybook/addon-knobs'
 
 import Title from 'title'
 
-const stories = storiesOf('Title', module)
+const stories = storiesOf('Widgets|Title', module)
 const optionHeading = {
   1: '1',
   2: '2',

--- a/src/toggleButton/story.tsx
+++ b/src/toggleButton/story.tsx
@@ -6,7 +6,7 @@ import { withKnobs, text, boolean, select } from '@storybook/addon-knobs'
 
 import ToggleButton, { ToggleButtonStatus } from '.'
 
-const stories = storiesOf('ToggleButton', module)
+const stories = storiesOf('Widgets|ToggleButton', module)
 stories.addDecorator(withKnobs)
 
 stories.add('ToggleButton', () => (

--- a/src/topBar/story.tsx
+++ b/src/topBar/story.tsx
@@ -8,7 +8,7 @@ import TopBar from 'topBar'
 import Button, { ButtonStatus } from 'button'
 import ArrowIcon from 'icon/arrowIcon'
 
-const stories = storiesOf('TopBar', module)
+const stories = storiesOf('Widgets|TopBar', module)
 stories.addDecorator(withKnobs)
 
 const leftAction = (

--- a/src/topTripCardList/TopTripCardList.tsx
+++ b/src/topTripCardList/TopTripCardList.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import cc from 'classcat'
 
 import { TripCardProps } from 'tripCard/TripCard'
+import {KIRK_LAYOUT_FLUID_ITEM_CLASS} from "../_utils/layout"
 
 interface TopTripCardListProps {
   readonly children: React.ReactElement<TripCardProps>[]

--- a/src/topTripCardList/index.tsx
+++ b/src/topTripCardList/index.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
 import { color, space, responsiveBreakpoints, componentSizes } from '_utils/branding'
+import { columnItemHorizontalSpacing } from '_utils/layout'
 
 import TopTripCardList from './TopTripCardList'
 
@@ -13,7 +14,7 @@ const StyledTopTripCardList = styled(TopTripCardList)`
   & .kirk-topTripCardList {
     margin: auto;
     display: flex;
-    padding: ${space.l} ${wrapperHorizontalPadding};
+    padding: ${columnItemHorizontalSpacing} ${wrapperHorizontalPadding};
     box-sizing: border-box;
     overflow: auto; /* Make TripCards scrollable horizontally */
     -ms-overflow-style: none; /* Remove scrollbar visually IE 10+ */

--- a/src/topTripCardList/story.tsx
+++ b/src/topTripCardList/story.tsx
@@ -6,7 +6,7 @@ import { withKnobs, boolean } from '@storybook/addon-knobs'
 import TopTripCardList from 'topTripCardList'
 import TripCard from 'tripCard'
 
-const stories = storiesOf('TopTripCardList', module)
+const stories = storiesOf('Widgets|TopTripCardList', module)
 stories.addDecorator(withKnobs)
 
 const tripCardConfig = {

--- a/src/tripCard/TripCard.tsx
+++ b/src/tripCard/TripCard.tsx
@@ -8,6 +8,7 @@ import LightningIcon from 'icon/lightningIcon'
 import LadyIcon from 'icon/ladyIcon'
 import Itinerary from 'itinerary'
 import Item from '_utils/item'
+import { KIRK_LAYOUT_SOLID_ITEM_CLASS } from '_utils/layout'
 import Text, { TextDisplayType } from 'text'
 import { color } from '_utils/branding'
 
@@ -53,6 +54,9 @@ export interface TripCardProps {
   }
   badge?: string
   title?: string
+  // Whether the trip card should behave as a column item if nested in a <column> element.
+  // This is useful when nesting column item inside other column items like the topTripList.
+  enableColumnLayout?: boolean
 }
 
 const renderPassenger = (passenger: User) => (
@@ -84,6 +88,7 @@ const TripCard = ({
   statusInformation = null,
   badge = null,
   title = null,
+  enableColumnLayout = true,
 }: TripCardProps) => {
   const departure = itinerary[0]
   const arrival = itinerary[itinerary.length - 1]
@@ -115,6 +120,7 @@ const TripCard = ({
       className={cc([
         'kirk-tripCard',
         {
+          [KIRK_LAYOUT_SOLID_ITEM_CLASS]: enableColumnLayout,
           'kirk-tripCard--highlighted': !!highlighted,
           'kirk-tripCard--with-badge': badge && badge.length,
         },

--- a/src/tripCard/TripCard.unit.tsx
+++ b/src/tripCard/TripCard.unit.tsx
@@ -39,7 +39,7 @@ const mockedProps = {
   price: '8,00€',
 }
 
-const createPassengers = count => {
+const createPassengers = (count: number) => {
   let passengerIdx = 1
   return Array(count).fill({
     avatarUrl: '//placehold.it/500x500',

--- a/src/tripCard/story.tsx
+++ b/src/tripCard/story.tsx
@@ -7,7 +7,7 @@ import WarningIcon from 'icon/warningIcon'
 import TripCard from './index'
 import specs from './specifications/index.md'
 
-const stories = storiesOf('TripCard', module)
+const stories = storiesOf('Widgets|TripCard', module)
 stories.addDecorator(withKnobs)
 
 const tripCardConfig = () => ({

--- a/src/uneditableTextField/UneditableTextField.tsx
+++ b/src/uneditableTextField/UneditableTextField.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react'
 import cc from 'classcat'
 import isEmpty from 'lodash.isempty'
+import { KIRK_LAYOUT_SOLID_ITEM_CLASS } from '_utils/layout'
 
 export interface UneditableTextFieldProps {
   readonly children: JSX.Element | string
@@ -32,7 +33,11 @@ export const UneditableTextField = ({
   return React.createElement(
     componentType,
     {
-      className: cc(['uneditableTextField', className]),
+      className: cc([
+        KIRK_LAYOUT_SOLID_ITEM_CLASS,
+        'uneditableTextField',
+        className
+      ]),
       ...props,
     },
     <Fragment>

--- a/src/uneditableTextField/__snapshots__/UneditableTextField.unit.tsx.snap
+++ b/src/uneditableTextField/__snapshots__/UneditableTextField.unit.tsx.snap
@@ -36,7 +36,7 @@ exports[`UneditableTextField Should have the proper default props 1`] = `
 }
 
 <div
-  className="uneditableTextField c0"
+  className="kirk-layout-solid-item uneditableTextField c0"
 >
   <div
     className="uneditableTextField-label"
@@ -82,7 +82,7 @@ exports[`UneditableTextField Should have the text ellipsed 1`] = `
 }
 
 <div
-  className="uneditableTextField c0"
+  className="kirk-layout-solid-item uneditableTextField c0"
 >
   <div
     className="uneditableTextField-label uneditableTextField-label--ellipsis"
@@ -128,7 +128,7 @@ exports[`UneditableTextField Should support add-ons 1`] = `
 }
 
 <div
-  className="uneditableTextField c0"
+  className="kirk-layout-solid-item uneditableTextField c0"
 >
   <div>
     Add-on
@@ -177,7 +177,7 @@ exports[`UneditableTextField Should support component links 1`] = `
 }
 
 <a
-  className="uneditableTextField c0"
+  className="kirk-layout-solid-item uneditableTextField c0"
   href="#bar"
 >
   <div
@@ -224,7 +224,7 @@ exports[`UneditableTextField Should support simple links 1`] = `
 }
 
 <a
-  className="uneditableTextField c0"
+  className="kirk-layout-solid-item uneditableTextField c0"
   href="#foo"
 >
   <div

--- a/src/uneditableTextField/story.tsx
+++ b/src/uneditableTextField/story.tsx
@@ -6,7 +6,7 @@ import { withKnobs, boolean, text } from '@storybook/addon-knobs'
 import UneditableTextField from 'uneditableTextField'
 import IconSearch from 'icon/searchIcon'
 
-const stories = storiesOf('UneditableTextField', module)
+const stories = storiesOf('Widgets|UneditableTextField', module)
 stories.addDecorator(withKnobs)
 
 stories.add('Basic', () => (

--- a/src/why/story.tsx
+++ b/src/why/story.tsx
@@ -6,7 +6,7 @@ import { action } from '@storybook/addon-actions'
 
 import Why from 'why'
 
-const stories = storiesOf('Why', module)
+const stories = storiesOf('Widgets|Why', module)
 stories.addDecorator(withKnobs)
 
 stories.add('default', () => (

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -1,5 +1,9 @@
 import './stories.css'
 
+import '../pages/searchResultStory'
+import '../pages/rideDetailsStory'
+import '../pages/messagingThreadStory'
+
 import '../src/_utils/story'
 import '../src/autoComplete/story'
 import '../src/avatar/story'


### PR DESCRIPTION
This PR introduces a < Column > wrapper and some utility CSS classes for solid and fluid column items.
UI widgets will be annotated with these classes to decide if they should spread over the column left/right spacing or not (see _utils/layout/index.jsx).
By default these classes are noop sand it's safe to have them on all the widgets. It's only when the widgets are nested inside a < Column > element that the new behaviors are activated. Currently
the < Column > is not used (beside some storybook pages) and will be used to migrate page by page or section by section the new behavior.

I created new pages storybook pages (SRP, messaging, ridedetails) that uses this layout. Ultimately all pages could be in the storybook too.

Note that some widgets are currently broken when the new behavior is activated (the Itinerary for instance). This will be fixed as follow tasks after the initial commit.

![image](https://user-images.githubusercontent.com/46651/71096413-89e90f80-21ae-11ea-84ed-db022680229a.png)

TESTED=Storybook that widgets are not broken when not wrapped in a <Column>