### PR TITLE
Fix itinerary display with single step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Fix `Itinerary` component display with only one stopover
 - [...]
 
 # V17.0.0 (24/12/2019)

--- a/src/itinerary/index.tsx
+++ b/src/itinerary/index.tsx
@@ -107,6 +107,13 @@ const StyledItinerary = styled(Itinerary)`
     height: calc(6px + ${space.m} + ${gutterTopOffset});
   }
 
+  /* Only one step */
+  &
+    .kirk-itinerary-location.kirk-itinerary--departure.kirk-itinerary--arrival
+    .kirk-itinerary-location-city::before {
+    display: none;
+  }
+
   & .kirk-itinerary-fromAddon,
   & .kirk-itinerary-toAddon {
     height: ${distanceFromHeight};

--- a/src/itinerary/story.tsx
+++ b/src/itinerary/story.tsx
@@ -192,3 +192,18 @@ stories.add('with button tiles', () => {
     />
   )
 })
+
+stories.add('with single stopover', () => {
+  const fromAddon = text('From addon', 'Lille')
+  const toAddon = text('To addon', 'Biarritz')
+  const headline = text('Headline', 'Mon 11 December')
+  const stops = [
+    {
+      time: '09:00',
+      isoDate: '2017-12-11T09:00',
+      subLabel: 'Porte de Vincennes',
+      mainLabel: 'Paris',
+    },
+  ]
+  return <Itinerary fromAddon={fromAddon} toAddon={toAddon} places={stops} headline={headline} />
+})


### PR DESCRIPTION
Before:
<img width="255" alt="Capture d’écran 2020-01-03 à 16 12 15" src="https://user-images.githubusercontent.com/729186/71732003-785a6580-2e46-11ea-8146-7fe5b362a45c.png">

After:
<img width="239" alt="Capture d’écran 2020-01-03 à 16 18 54" src="https://user-images.githubusercontent.com/729186/71732008-7a242900-2e46-11ea-9308-67e79d3c5139.png">