### PR TITLE
Fix margin in itinerary if we want to display content without time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Fix `Itinerary` component display without time
 - [...]
 
 # V17.0.0 (24/12/2019)

--- a/src/itinerary/Itinerary.tsx
+++ b/src/itinerary/Itinerary.tsx
@@ -63,8 +63,9 @@ const Itinerary = ({
   small = false,
   headline = null,
 }: ItineraryProps) => {
-  // Dislay itinerary as small if required or if we don't have time or subLabel for provided places
-  const isSmall = small || places.filter(p => !isEmpty(p.time) || !isEmpty(p.subLabel)).length === 0
+  // Add the small class if we don't have times to prevent empty content
+  const withTime = places.filter(p => !isEmpty(p.time)).length > 0
+
   // Remove aria-labelledby attribute if aria-label already used
   const rootA11yProps = computeRootA11yProps(ariaLabel, ariaLabelledBy)
   return (
@@ -75,7 +76,7 @@ const Itinerary = ({
           <BlankSeparator />
         </Fragment>
       )}
-      <ul className={cc([{ 'kirk-itinerary--small': isSmall }])}>
+      <ul className={cc([{ 'kirk-itinerary--noTime': small || !withTime }])}>
         {isNonEmptyString(fromAddon) && (
           <li className="kirk-itinerary-fromAddon" aria-label={fromAddonAriaLabel}>
             <Text className="kirk-itinerary-addon-content" display={TextDisplayType.CAPTION}>
@@ -138,7 +139,7 @@ const Itinerary = ({
                 }
               />
               <Component {...hrefProps} aria-label={place.actionAriaLabel}>
-                {!isSmall && (
+                {!small && withTime && (
                   <time dateTime={place.isoDate}>
                     <Text tag={TextTagType.DIV} display={TextDisplayType.TITLESTRONG}>
                       {place.time}
@@ -149,7 +150,7 @@ const Itinerary = ({
                   <Text tag={TextTagType.DIV} display={TextDisplayType.TITLESTRONG}>
                     {place.mainLabel}
                   </Text>
-                  {!isSmall &&
+                  {!small &&
                     place.subLabel &&
                     (typeof place.subLabel === 'string' ? (
                       <Text

--- a/src/itinerary/Itinerary.unit.tsx
+++ b/src/itinerary/Itinerary.unit.tsx
@@ -252,20 +252,21 @@ describe('Itinerary component', () => {
     it('Should be displayed as small if required in props', () => {
       const itinerary = shallow(<Itinerary places={places} small />)
       const ul = itinerary.find('ul')
-      expect(ul.hasClass('kirk-itinerary--small')).toBe(true)
+      expect(ul.hasClass('kirk-itinerary--noTime')).toBe(true)
     })
 
-    it('Should not be displayed as small if not in props and time or sublabel exists', () => {
+    it('Should not be displayed as small if not in props and time exists', () => {
       const itinerary = shallow(<Itinerary places={places} />)
       const ul = itinerary.find('ul')
-      expect(ul.hasClass('kirk-itinerary--small')).toBe(false)
+      expect(ul.hasClass('kirk-itinerary--noTime')).toBe(false)
     })
 
-    it('Should be displayed as small if no time nor subLabel', () => {
+    it('Should be displayed as small if no time', () => {
       const placesList = [
         {
           isoDate: '2017-12-11T09:00',
           mainLabel: 'Paris',
+          subLabel: 'Place de Clichy',
           key: 'route-start-paris',
         },
         {
@@ -277,7 +278,7 @@ describe('Itinerary component', () => {
 
       const itinerary = shallow(<Itinerary places={placesList} />)
       const ul = itinerary.find('ul')
-      expect(ul.hasClass('kirk-itinerary--small')).toBe(true)
+      expect(ul.hasClass('kirk-itinerary--noTime')).toBe(true)
     })
   })
 })

--- a/src/itinerary/index.tsx
+++ b/src/itinerary/index.tsx
@@ -53,7 +53,7 @@ const StyledItinerary = styled(Itinerary)`
   }
 
   &
-    .kirk-itinerary--small
+    .kirk-itinerary--noTime
     .kirk-itinerary-location:not(.kirk-itinerary--arrival)
     .kirk-itinerary-location-city {
     padding-bottom: 0;
@@ -75,7 +75,7 @@ const StyledItinerary = styled(Itinerary)`
     left: calc(${gutterPaddingStart} + ${componentSizes.timeWidth});
   }
 
-  & .kirk-itinerary--small .kirk-itinerary-location .kirk-itinerary-location-city::before {
+  & .kirk-itinerary--noTime .kirk-itinerary-location .kirk-itinerary-location-city::before {
     left: 2px;
   }
 
@@ -94,7 +94,7 @@ const StyledItinerary = styled(Itinerary)`
     top: calc(4px + ${space.m} + ${gutterTopOffset});
   }
 
-  & .kirk-itinerary--small .kirk-itinerary-location .kirk-itinerary-location-city::after {
+  & .kirk-itinerary--noTime .kirk-itinerary-location .kirk-itinerary-location-city::after {
     left: 0;
   }
 
@@ -129,8 +129,8 @@ const StyledItinerary = styled(Itinerary)`
     bottom: -4px;
   }
 
-  & .kirk-itinerary--small .kirk-itinerary-fromAddon::before,
-  & .kirk-itinerary--small .kirk-itinerary-location.kirk-itinerary-location--toAddon::before {
+  & .kirk-itinerary--noTime .kirk-itinerary-fromAddon::before,
+  & .kirk-itinerary--noTime .kirk-itinerary-location.kirk-itinerary-location--toAddon::before {
     left: 2px;
   }
 
@@ -154,8 +154,8 @@ const StyledItinerary = styled(Itinerary)`
     left: calc(${gutterPaddingStart} + ${componentSizes.timeWidth} - 2px);
   }
 
-  & .kirk-itinerary--small .kirk-itinerary-fromAddon::after,
-  & .kirk-itinerary--small .kirk-itinerary-location.kirk-itinerary-location--toAddon::after {
+  & .kirk-itinerary--noTime .kirk-itinerary-fromAddon::after,
+  & .kirk-itinerary--noTime .kirk-itinerary-location.kirk-itinerary-location--toAddon::after {
     left: 0;
   }
 
@@ -176,8 +176,8 @@ const StyledItinerary = styled(Itinerary)`
     left: calc(${gutterPaddingStart} + ${componentSizes.timeWidth});
   }
 
-  & .kirk-itinerary--small .kirk-itinerary-fromAddon .kirk-itinerary-addon-content,
-  & .kirk-itinerary--small .kirk-itinerary-toAddon .kirk-itinerary-addon-content {
+  & .kirk-itinerary--noTime .kirk-itinerary-fromAddon .kirk-itinerary-addon-content,
+  & .kirk-itinerary--noTime .kirk-itinerary-toAddon .kirk-itinerary-addon-content {
     left: 0;
   }
 

--- a/src/itinerary/story.tsx
+++ b/src/itinerary/story.tsx
@@ -56,7 +56,7 @@ const placesWithStopover = [
     href: '#',
   },
   {
-    time: '19 :00',
+    time: '19:00',
     isoDate: '2017-12-11T19:00',
     stepAriaLabel: 'Pick up/drop off location',
     subLabel: 'Gare Bordeaux Saint-Jean',
@@ -188,6 +188,33 @@ stories.add('with button tiles', () => {
       toAddon={toAddon}
       places={placesWithButton}
       small={boolean('small', false)}
+      headline={headline}
+    />
+  )
+})
+
+stories.add('without time', () => {
+  const fromAddon = text('From addon', 'Lille')
+  const toAddon = text('To addon', 'Biarritz')
+  const headline = text('Headline', 'Mon 11 December')
+  const placesWithButton = [
+    {
+      isoDate: '2017-12-11T09:00',
+      subLabel: 'Porte de Vincennes',
+      mainLabel: 'Paris',
+    },
+    {
+      isoDate: '2017-12-11T15:00',
+      subLabel: 'Gare Bordeaux Saint-Jean',
+      mainLabel: 'Bordeaux',
+    },
+  ]
+  return (
+    <Itinerary
+      fromAddon={fromAddon}
+      toAddon={toAddon}
+      places={placesWithButton}
+      small={false}
       headline={headline}
     />
   )


### PR DESCRIPTION
Before:
<img width="449" alt="Capture d’écran 2020-01-03 à 17 29 01" src="https://user-images.githubusercontent.com/729186/71735598-2964fe00-2e4f-11ea-8861-161ede030b2c.png">

After:
<img width="449" alt="Capture d’écran 2020-01-03 à 17 29 27" src="https://user-images.githubusercontent.com/729186/71735610-3124a280-2e4f-11ea-8cab-8c975fe3440b.png">

Context: 
6 months ago, we needed to display small itineraries in Your Rides, but the component is rendered through `TripCard`, so we didn't have lot of room to customize the thing. So I naively assumed that we should display the component as small if we don't have time nor subLabel (that's what the small prop was doing).

Except... that if we want to render itineraries with subLabel but without time, it breaks. 
Initial commit: https://github.com/blablacar/ui-library/commit/b5f58202d1e28ced0dd888476d003e132e084d29

