### PR TITLE
Fix visible input range track on Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [...]
+- **[FIX]** Hide input range track on Safari for `Stepper` component
 
 # v17.2.0 (07/01/2020)
 

--- a/src/stepper/index.tsx
+++ b/src/stepper/index.tsx
@@ -55,10 +55,15 @@ const StyledStepper = styled(Stepper)`
     -webkit-appearance: none; /* Hides the slider so that custom slider can be made */
     width: 100%; /* Specific width is required for Firefox. */
     background: transparent; /* Otherwise white in Chrome */
+    border: transparent;
   }
 
-  & input[type='range'].kirk-stepper-range::-webkit-slider-thumb {
+  & input[type='range'].kirk-stepper-range::-webkit-slider-thumb,
+  & input[type='range'].kirk-stepper-range::-webkit-slider-runnable-track {
     -webkit-appearance: none;
+    background: transparent;
+    border-color: transparent;
+    color: transparent;
   }
 
   & input[type='range'].kirk-stepper-range::-moz-range-thumb {

--- a/src/stepper/index.tsx
+++ b/src/stepper/index.tsx
@@ -55,7 +55,6 @@ const StyledStepper = styled(Stepper)`
     -webkit-appearance: none; /* Hides the slider so that custom slider can be made */
     width: 100%; /* Specific width is required for Firefox. */
     background: transparent; /* Otherwise white in Chrome */
-    border: transparent;
   }
 
   & input[type='range'].kirk-stepper-range::-webkit-slider-thumb,


### PR DESCRIPTION
### Before:
![IMG-1028](https://user-images.githubusercontent.com/14176147/71996231-2a75a100-323c-11ea-81ad-4d4013e33fd7.png)

### After:
![Image from iOS (2)](https://user-images.githubusercontent.com/14176147/71996281-395c5380-323c-11ea-86da-1da6416400f1.png)
