### PR TITLE
Fix the font size of TheVoice component on small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Unreleased
 
+- **[FIX]** Fix the font size of `TheVoice` component on small screens
 - [...]
 
 # v17.4.0 (15/01/2020)
+
 - **[NEW]** Add d.ts declaration and sourcemaps
-- **[NEW]** Export TypeScript interfaces :tada:
+- **[NEW]** Export TypeScript interfaces
 
 # v17.3.0 (09/01/2020)
 

--- a/src/theVoice/index.tsx
+++ b/src/theVoice/index.tsx
@@ -12,7 +12,6 @@ const StyledTheVoice = styled(TheVoice)`
 
   @media (max-width: ${responsiveBreakpoints.small}) {
     text-align: left;
-    font-size: ${font.l.size};
     margin: ${space.xl} 0;
   }
 `


### PR DESCRIPTION
In the Pixar spec `TheVoice` component have a 30px font size with the following rule:

> When screen width is less than 320px the font size moves down to 26px.

However we don't have a 320px breakpoint and we don't have a 26px font size either. So we will keep the 30px until the specification is clarified. 

| *Before* | *After* |
|-----------|--------|
| ![image](https://user-images.githubusercontent.com/2495124/72447418-95cbef80-37b5-11ea-8b55-6281ac87682b.png) |  ![image](https://user-images.githubusercontent.com/2495124/72447353-7d5bd500-37b5-11ea-8f81-af8cdb9a76c6.png) |
