### PR TITLE
Added scrolling snap on topTripCardList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- [...]
+- **[UPDATE]** Added scrolling snap on `topTripCardList`
 
 # v18.0.0 (22/01/2020)
 

--- a/src/topTripCardList/index.tsx
+++ b/src/topTripCardList/index.tsx
@@ -18,7 +18,13 @@ const StyledTopTripCardList = styled(TopTripCardList)`
     overflow: auto; /* Make TripCards scrollable horizontally */
     -ms-overflow-style: none; /* Remove scrollbar visually IE 10+ */
     scrollbar-width: none; /* Remove scrollbar visually Firefox */
+    scroll-snap-type: x mandatory;
   }
+
+  & .kirk-topTripCardList .kirk-tripCard {
+    scroll-snap-align: start;
+  }
+
   /* Remove scrollbar webkit */
   & .kirk-topTripCardList::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
![Kapture 2020-01-22 at 18 26 17](https://user-images.githubusercontent.com/1606624/72917767-ba3f4300-3d44-11ea-8346-672ba4acd201.gif)
When we stop scrolling, the cards will get placed so that it's always one full card in the viewport all handled by the browser.
Support is good: https://caniuse.com/#search=scroll-snap