### PR TITLE
Removed z-index from itinerary bullets and use source order instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
-[...]
 - **[UPDATE]** Add `MAP_ACTIVE` and `MAP_INACTIVE` types for `Bullet` component
+- **[UPDATE]** Removed z-index rules from `Itinerary`
 
 # v18.0.1 (23/01/2020)
 

--- a/src/itinerary/Itinerary.tsx
+++ b/src/itinerary/Itinerary.tsx
@@ -83,8 +83,8 @@ const Itinerary = ({
             className="kirk-itinerary-location kirk-itinerary-addon kirk-itinerary-addon--from"
             aria-label={fromAddonAriaLabel}
           >
-            <Bullet type={BulletTypes.ADDON} />
             <div className="kirk-itinerary-road" aria-hidden="true" />
+            <Bullet type={BulletTypes.ADDON} />
             <div className="kirk-itinerary-location-city">
               <Text
                 tag={TextTagType.PARAGRAPH}
@@ -160,8 +160,8 @@ const Itinerary = ({
                   </time>
                 )}
                 <div className="kirk-itinerary-location-city">
-                  <Bullet />
                   <div className="kirk-itinerary-road" aria-hidden="true" />
+                  <Bullet />
                   <Text tag={TextTagType.PARAGRAPH} display={TextDisplayType.TITLESTRONG}>
                     {place.mainLabel}
                   </Text>

--- a/src/itinerary/index.tsx
+++ b/src/itinerary/index.tsx
@@ -70,7 +70,6 @@ const StyledItinerary = styled(Itinerary)`
 
   /* bullet */
   & .kirk-bullet {
-    z-index: 2;
     position: absolute;
     top: calc(${lineHeightAdjustment} + ${space.m} + ${gutterTopOffset});
     left: calc(${componentSizes.timeWidth} + (${bulletOuterSize} / 2));
@@ -109,7 +108,6 @@ const StyledItinerary = styled(Itinerary)`
 
   /* road */
   & .kirk-itinerary-road {
-    z-index: 1;
     position: absolute;
     top: calc(${bulletOuterSize} + ${space.m} + ${lineHeightAdjustment});
     left: calc(${gutterPaddingStart} + ${componentSizes.timeWidth});


### PR DESCRIPTION
No impact on Itinerary
![image](https://user-images.githubusercontent.com/1606624/73072613-b67efe00-3eb5-11ea-9b45-99d95483758d.png)
