### PR TITLE
Refacto Itinerary with ItineraryLocation + ItineraryCollapsible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Unreleased
 
-- [...]
+- **[UPDATE]** Refactored `Itinerary` to use `ItineraryLocation` and `ItineraryCollapsible`
+- **[UPDATE]** `Bullet` component size is no longer based on 'content-box' but 'border-box'
 - **[NEW]** Added `ClockMapIcon`
+- [...]
 
 # v18.2.0 (03/02/2020)
+
 - **[NEW]** Create new `HeroSection` section.
 
 # v18.1.0 (30/01/2020)

--- a/src/_utils/branding.ts
+++ b/src/_utils/branding.ts
@@ -102,6 +102,10 @@ export const componentSizes = {
   buttonIconSize: '48px',
   wrapper: '662px',
   largeWrapper: '1016px',
+  bulletSize: '10px',
+  bulletSizeSmall: '8px',
+  bulletSizeMap: '18px',
+  roadWidth: '4px',
 }
 
 export const modalSize = {

--- a/src/_utils/itineraryCollapsible/ItineraryCollapsible.tsx
+++ b/src/_utils/itineraryCollapsible/ItineraryCollapsible.tsx
@@ -1,0 +1,115 @@
+import React, { PureComponent } from 'react'
+import cc from 'classcat'
+import { canUseEventListeners } from 'exenv'
+
+import { color } from '_utils/branding'
+import KEYCODES from '_utils/keycodes'
+import Text, { TextDisplayType, TextTagType } from 'text'
+import Bullet, { BulletTypes } from 'bullet'
+import ItineraryLocation, { computeKeyFromPlace } from '_utils/itineraryLocation'
+
+export interface ItineraryCollapsibleProps {
+  readonly places: Place[]
+  readonly className?: Classcat.Class
+  readonly label?: string
+  readonly ariaLabel?: string
+}
+
+interface ItineraryCollapsibleState {
+  readonly collapsed: boolean
+}
+
+const collapsibleLocationSize = 36 // default size of a collapsible ItineraryLocation
+
+export default class ItineraryCollapsible extends PureComponent<ItineraryCollapsibleProps> {
+  static defaultProps: Partial<ItineraryCollapsibleProps> = {
+    className: '',
+    label: '',
+    ariaLabel: '',
+  }
+
+  state: ItineraryCollapsibleState = {
+    collapsed: true,
+  }
+
+  componentDidMount() {
+    this.addListeners()
+  }
+
+  componentWillUnmount() {
+    this.removeListeners()
+  }
+
+  addListeners() {
+    if (canUseEventListeners) {
+      document.addEventListener('keydown', this.handleKeydown)
+    }
+  }
+
+  removeListeners() {
+    if (canUseEventListeners) {
+      document.removeEventListener('keydown', this.handleKeydown)
+    }
+  }
+
+  handleKeydown = (event: KeyboardEvent) => {
+    if (event.keyCode === KEYCODES.ENTER || event.keyCode === KEYCODES.SPACEBAR) {
+      this.onClick()
+    }
+  }
+
+  onClick = () => {
+    const prevState = this.state.collapsed
+    this.setState({ collapsed: !prevState })
+  }
+
+  render() {
+    const { places, className, label, ariaLabel } = this.props
+    const baseClassName = 'kirk-itineraryCollapsible'
+    const classNames = cc([
+      baseClassName,
+      {
+        [`${baseClassName}--collapsed`]: this.state.collapsed,
+        [`${baseClassName}--extended`]: !this.state.collapsed,
+      },
+      className,
+    ])
+
+    return (
+      <li
+        className={classNames}
+        onClick={this.onClick}
+        aria-pressed={!this.state.collapsed}
+        aria-expanded={!this.state.collapsed}
+        aria-label={ariaLabel}
+        role="button"
+      >
+        <div aria-hidden={!this.state.collapsed} className="kirk-itineraryCollapsible-collapsed">
+          <Bullet type={BulletTypes.SMALL} />
+          <Text
+            tag={TextTagType.PARAGRAPH}
+            display={TextDisplayType.CAPTION}
+            textColor={color.link}
+          >
+            {label}
+          </Text>
+        </div>
+        <ul
+          aria-hidden={this.state.collapsed}
+          className="kirk-itineraryCollapsible-extended"
+          style={{
+            height: `${places.length * collapsibleLocationSize}px`, // used for the animation
+          }}
+        >
+          {places.map(place => (
+            <ItineraryLocation
+              place={place}
+              isSmall
+              key={`${computeKeyFromPlace(place)}-collapsible`}
+            />
+          ))}
+        </ul>
+      </li>
+    )
+  }
+}

--- a/src/_utils/itineraryCollapsible/ItineraryCollapsible.unit.tsx
+++ b/src/_utils/itineraryCollapsible/ItineraryCollapsible.unit.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import ItineraryCollapsible from './ItineraryCollapsible'
+
+const places = [
+  {
+    distanceFromPoint: '1,5km',
+    time: '09:00',
+    isoDate: '2017-12-11T09:00',
+    stepAriaLabel: 'Pick up/drop off location',
+    mainLabel: 'Paris',
+  },
+  {
+    time: '12:00',
+    isoDate: '2017-12-11T12:00',
+    stepAriaLabel: 'Pick up/drop off location',
+    subLabel: '21 Jump Street',
+    mainLabel: 'Tours',
+  },
+  {
+    distanceFromPoint: '8km',
+    time: '15:00',
+    isoDate: '2017-12-11T15:00',
+    stepAriaLabel: 'Pick up/drop off location',
+    mainLabel: 'Bordeaux',
+  },
+]
+describe('ItineraryCollapsible component', () => {
+  it('Should render with a label if provided', () => {
+    const wrapper = shallow(<ItineraryCollapsible places={places} label="unit test" />)
+    expect(wrapper.find('.kirk-itineraryCollapsible-collapsed').text()).toBe('unit test')
+  })
+
+  it('Should rendered as collapsed, extend on click, collapse on click again', () => {
+    const wrapper = shallow(<ItineraryCollapsible places={places} />)
+    expect(wrapper.hasClass('kirk-itineraryCollapsible--collapsed')).toBe(true)
+    expect(wrapper.hasClass('kirk-itineraryCollapsible--extended')).toBe(false)
+    wrapper.simulate('click')
+    expect(wrapper.hasClass('kirk-itineraryCollapsible--collapsed')).toBe(false)
+    expect(wrapper.hasClass('kirk-itineraryCollapsible--extended')).toBe(true)
+    wrapper.simulate('click')
+    expect(wrapper.hasClass('kirk-itineraryCollapsible--collapsed')).toBe(true)
+    expect(wrapper.hasClass('kirk-itineraryCollapsible--extended')).toBe(false)
+  })
+})

--- a/src/_utils/itineraryCollapsible/index.tsx
+++ b/src/_utils/itineraryCollapsible/index.tsx
@@ -1,0 +1,100 @@
+import styled from 'styled-components'
+import { color, font, radius, space, componentSizes, transition } from '_utils/branding'
+
+import ItineraryCollapsible from './ItineraryCollapsible'
+
+const minHeight = '32px' // space.l for the minimum content + 2*space.m for vertical padding
+
+const StyledItineraryCollapsible = styled(ItineraryCollapsible)`
+  & {
+    position: relative;
+    display: block;
+    list-style-type: none;
+    cursor: pointer;
+    min-height: ${minHeight};
+  }
+
+  &.kirk-itineraryCollapsible--extended .kirk-itineraryCollapsible-collapsed,
+  &.kirk-itineraryCollapsible--collapsed .kirk-itineraryCollapsible-extended {
+    opacity: 0;
+    height: ${minHeight} !important; /* must take priority over the real height specified inline */
+    overflow: hidden;
+  }
+
+  .kirk-itineraryCollapsible-collapsed,
+  .kirk-itineraryCollapsible-extended {
+    opacity: 1;
+    transition: height ${transition.duration.base} ease-in-out,
+      opacity ${transition.duration.base} linear;
+  }
+
+  & .kirk-itineraryCollapsible-collapsed {
+    display: flex;
+    position: absolute;
+    top: 0;
+    left: 0;
+    padding: ${space.m} 0;
+    height: ${minHeight};
+    background-color: ${color.white};
+  }
+
+  & .kirk-itineraryCollapsible-collapsed::before,
+  & .kirk-itineraryCollapsible-collapsed::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 2px;
+    width: ${componentSizes.roadWidth};
+    height: 4px;
+    background-color: ${color.primaryText};
+    border-radius: ${radius.s};
+  }
+
+  & .kirk-itineraryCollapsible-collapsed::before {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+
+  & .kirk-itineraryCollapsible-collapsed::after {
+    top: 30px;
+    height: 16px;
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  & .kirk-itineraryCollapsible-collapsed .kirk-bullet {
+    position: relative;
+    top: 6px;
+    left: 0;
+  }
+
+  & .kirk-itineraryCollapsible-collapsed .kirk-text {
+    padding-left: ${space.m};
+    height: ${font.m.lineHeight};
+  }
+
+  & .kirk-itineraryLocation-label .kirk-text,
+  & .kirk-itineraryCollapsible-collapsed .kirk-text {
+    font-size: ${font.s.size};
+    line-height: ${font.m.lineHeight};
+  }
+
+  & .kirk-itineraryLocation-wrapper .kirk-itineraryLocation-road {
+    height: calc(
+      100% - ${componentSizes.bulletSizeSmall} + 4px
+    ); /* +4px to better hide behind small Bullets */
+  }
+  & .kirk-itineraryLocation-label {
+    padding-bottom: ${space.m};
+  }
+
+  & .kirk-itineraryLocation-roadContainer {
+    margin-top: 0;
+  }
+
+  & .kirk-itineraryLocation-wrapper {
+    padding: 0;
+  }
+`
+export { ItineraryCollapsibleProps } from './ItineraryCollapsible'
+export default StyledItineraryCollapsible

--- a/src/_utils/itineraryLocation/ItineraryLocation.tsx
+++ b/src/_utils/itineraryLocation/ItineraryLocation.tsx
@@ -1,0 +1,152 @@
+import React, { Fragment, ReactNode } from 'react'
+import cc from 'classcat'
+import isEmpty from 'lodash.isempty'
+
+import { color } from '_utils/branding'
+import Bullet, { BulletTypes } from 'bullet'
+import ChevronIcon from 'icon/chevronIcon'
+import Text, { TextDisplayType, TextTagType } from 'text'
+
+export interface ItineraryLocationProps {
+  readonly place: Place
+  readonly className?: Classcat.Class
+  readonly isSmall?: boolean
+  readonly isArrival?: boolean
+  readonly hasBottomAddon?: boolean
+  readonly hasTime?: boolean
+  readonly hasSubLabel?: boolean
+}
+
+export const computeKeyFromPlace = (place: Place) => {
+  if (place.key && typeof place.key === 'string') {
+    return place.key
+  }
+
+  if (typeof place.subLabel === 'string') {
+    return `${place.mainLabel}-${place.subLabel}-${place.isoDate}`
+  }
+
+  return `${place.mainLabel}-${place.isoDate}`
+}
+
+const renderMeta = (mainLabel: string, subLabel: ReactNode) => (
+  <Fragment>
+    <meta itemProp="name" content={mainLabel} />
+    <meta
+      itemProp="address"
+      content={subLabel && typeof subLabel === 'string' ? subLabel : mainLabel}
+    />
+  </Fragment>
+)
+
+const renderTime = (isoDate: string, time: string) => (
+  <time dateTime={isoDate}>
+    <Text tag={TextTagType.DIV} display={TextDisplayType.TITLESTRONG}>
+      {time}
+    </Text>
+  </time>
+)
+
+const renderMainLabel = (label: string) => (
+  <Text
+    tag={TextTagType.PARAGRAPH}
+    display={TextDisplayType.TITLESTRONG}
+    textColor={color.primaryText}
+  >
+    {label}
+  </Text>
+)
+
+const renderSubLabel = (label: ReactNode) =>
+  typeof label === 'string' ? (
+    <Text
+      tag={TextTagType.PARAGRAPH}
+      display={TextDisplayType.CAPTION}
+      textColor={color.primaryText}
+    >
+      {label}
+    </Text>
+  ) : (
+    <div>{label}</div>
+  )
+
+const ItineraryLocation = ({
+  place,
+  className = '',
+  isSmall = false,
+  isArrival = false,
+  hasBottomAddon = false,
+  hasTime = false,
+  hasSubLabel = false,
+}: ItineraryLocationProps) => {
+  const baseClassName = 'kirk-itineraryLocation'
+  const classNames = cc([
+    baseClassName,
+    {
+      [`${baseClassName}--small`]: isSmall,
+      [`${baseClassName}--withTime`]: hasTime,
+      [`${baseClassName}--arrival`]: isArrival,
+      [`${baseClassName}--withToAddon`]: hasBottomAddon,
+    },
+    className,
+  ])
+  const hasRoad = !isArrival || (isArrival && hasBottomAddon)
+  const link = place.href
+  let Component
+  let hasChevron = false
+  let hrefProps
+
+  if (!isSmall && !isEmpty(link) && typeof link !== 'string') {
+    Component = link.type
+    hasChevron = true
+    hrefProps = {
+      ...link.props,
+      className: cc([`${baseClassName}-wrapper`, link.props.className]),
+    }
+  } else if (!isSmall && typeof link === 'string') {
+    Component = 'a'
+    hasChevron = true
+    hrefProps = {
+      href: place.href,
+      className: `${baseClassName}-wrapper`,
+    }
+  } else {
+    Component = 'div'
+    hrefProps = {
+      className: `${baseClassName}-wrapper`,
+    }
+  }
+
+  return (
+    <li
+      className={classNames}
+      itemProp="location"
+      itemScope
+      itemType="http://schema.org/Place"
+      aria-label={place.stepAriaLabel}
+    >
+      {renderMeta(place.mainLabel, place.subLabel)}
+      <Component {...hrefProps} aria-label={place.actionAriaLabel}>
+        {hasTime && renderTime(place.isoDate, place.time)}
+        <div className="kirk-itineraryLocation-roadContainer" aria-hidden="true">
+          <Bullet
+            className="kirk-itineraryLocation-bullet"
+            type={isSmall ? BulletTypes.SMALL : BulletTypes.DEFAULT}
+          />
+          {hasRoad && <div className="kirk-itineraryLocation-road" />}
+        </div>
+        <div className="kirk-itineraryLocation-label">
+          {renderMainLabel(place.mainLabel)}
+          {hasSubLabel && renderSubLabel(place.subLabel)}
+        </div>
+        {hasChevron && (
+          <div className="kirk-itineraryLocation-chevron">
+            <ChevronIcon />
+          </div>
+        )}
+      </Component>
+    </li>
+  )
+}
+
+export default ItineraryLocation

--- a/src/_utils/itineraryLocation/ItineraryLocation.unit.tsx
+++ b/src/_utils/itineraryLocation/ItineraryLocation.unit.tsx
@@ -1,0 +1,88 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import Proximity from 'proximity'
+import Bullet, { BulletTypes } from 'bullet'
+
+import ItineraryLocation from './ItineraryLocation'
+
+const place: Place = {
+  time: '09:00',
+  isoDate: '2017-12-11T09:00',
+  stepAriaLabel: 'Pick up/drop off location',
+  mainLabel: 'Paris',
+  subLabel: '21 Jump Street',
+}
+
+const placeWithProximity: Place = {
+  ...place,
+  subLabel: <Proximity value="FAR" title="Pick up point is quite far fom your place" />,
+}
+
+const placeWithLink: Place = {
+  ...place,
+  actionAriaLabel: 'New page with a map',
+  href: '#test',
+}
+
+const placeWithButton: Place = {
+  ...place,
+  actionAriaLabel: 'New page with a map',
+  href: <button type="button" />,
+}
+
+const placeWithKey: Place = {
+  ...place,
+}
+
+describe('ItineraryLocation', () => {
+  it('Should display stopover with a11y label', () => {
+    const wrapper = shallow(<ItineraryLocation place={place} />)
+    expect(wrapper.prop('aria-label')).toEqual('Pick up/drop off location')
+  })
+
+  it('Should display link with a11y label', () => {
+    const wrapper = shallow(<ItineraryLocation place={placeWithLink} />)
+    const locationWrapper = wrapper.find('.kirk-itineraryLocation-wrapper')
+    expect(locationWrapper.type()).toEqual('a')
+    expect(locationWrapper.prop('aria-label')).toEqual('New page with a map')
+    expect(locationWrapper.find('.kirk-itineraryLocation-chevron').exists()).toBe(true)
+  })
+
+  it('Should display button', () => {
+    const wrapper = shallow(<ItineraryLocation place={placeWithButton} />)
+    const locationWrapper = wrapper.find('.kirk-itineraryLocation-wrapper')
+    expect(locationWrapper.type()).toEqual('button')
+    expect(locationWrapper.prop('aria-label')).toEqual('New page with a map')
+    expect(locationWrapper.prop('type')).toEqual('button')
+    expect(locationWrapper.find('.kirk-itineraryLocation-chevron').exists()).toBe(true)
+  })
+
+  it('Should display Proximity if found in subLabel', () => {
+    const wrapper = shallow(<ItineraryLocation place={placeWithProximity} hasSubLabel />)
+    expect(wrapper.find(Proximity).prop('value')).toBe('FAR')
+  })
+
+  it('Should display time if "hasTime"', () => {
+    const wrapper = shallow(<ItineraryLocation place={placeWithKey} hasTime />)
+    expect(wrapper.find('time').exists()).toBe(true)
+  })
+
+  it('Should display a small Bullet if "isSmall"', () => {
+    const wrapper = shallow(<ItineraryLocation place={placeWithKey} isSmall hasTime />)
+    expect(wrapper.find(Bullet).prop('type')).toBe(BulletTypes.SMALL)
+  })
+
+  it('Should not display road if "isArrival"', () => {
+    const wrapper = shallow(<ItineraryLocation place={placeWithKey} isArrival />)
+    expect(wrapper.hasClass('kirk-itineraryLocation--arrival')).toBe(true)
+    expect(wrapper.find('.kirk-itineraryLocation-road').exists()).toBe(false)
+  })
+
+  it('Should still display road if "isArrival" but also "hasBottomAddon"', () => {
+    const wrapper = shallow(<ItineraryLocation place={placeWithKey} isArrival hasBottomAddon />)
+    expect(wrapper.hasClass('kirk-itineraryLocation--arrival')).toBe(true)
+    expect(wrapper.hasClass('kirk-itineraryLocation--withToAddon')).toBe(true)
+    expect(wrapper.find('.kirk-itineraryLocation-road').exists()).toBe(true)
+  })
+})

--- a/src/_utils/itineraryLocation/index.tsx
+++ b/src/_utils/itineraryLocation/index.tsx
@@ -1,0 +1,88 @@
+import styled from 'styled-components'
+import { color, space, componentSizes } from '_utils/branding'
+
+import ItineraryLocation from './ItineraryLocation'
+
+const totalTimeWidth = `${Math.ceil(
+  parseInt(componentSizes.timeWidth, 10) + parseInt(componentSizes.bulletSize, 10),
+)}px`
+
+const StyledItineraryLocation = styled(ItineraryLocation)`
+  & {
+    position: relative;
+    list-style-type: none;
+  }
+
+  /* wrapper */
+  & .kirk-itineraryLocation-wrapper {
+    display: flex;
+    padding: ${space.m} 0;
+    width: 100%;
+  }
+
+  & a.kirk-itineraryLocation-wrapper {
+    background: none;
+    text-decoration: none;
+    user-select: none;
+    -webkit-tap-highlight-color: ${color.tapHighlight};
+    -webkit-touch-callout: none;
+  }
+
+  & button.kirk-itineraryLocation-wrapper {
+    border: 0;
+    cursor: pointer;
+    text-align: left;
+    width: 100%;
+    font-family: inherit;
+    outline: none;
+    background-color: transparent;
+    -webkit-tap-highlight-color: ${color.tapHighlight};
+    -webkit-touch-callout: none;
+  }
+
+  & a.kirk-itineraryLocation-wrapper:hover,
+  & button.kirk-itineraryLocation-wrapper:hover {
+    background-color: ${color.tapHighlight};
+  }
+
+  /* city */
+  & time {
+    min-width: ${totalTimeWidth};
+  }
+
+  & .kirk-itineraryLocation-chevron {
+    display: flex;
+    align-self: center;
+  }
+
+  & .kirk-itineraryLocation-city {
+    display: flex;
+  }
+
+  & .kirk-itineraryLocation-label {
+    flex: 1;
+  }
+
+  &:not(.kirk-itineraryLocation--arrival) .kirk-itineraryLocation-city {
+    padding-bottom: 0;
+  }
+
+  & .kirk-itineraryLocation-roadContainer {
+    position: relative;
+    top: ${space.s};
+    margin-right: ${space.m};
+  }
+
+  & .kirk-itineraryLocation-bullet {
+    z-index: 1; /* Bullets overlap roads */
+    position: relative;
+  }
+
+  &.kirk-itineraryLocation--withToAddon .kirk-itineraryLocation-road {
+    min-height: 48px;
+    background-color: ${color.fadedText} !important;
+  }
+`
+
+export { ItineraryLocationProps, computeKeyFromPlace } from './ItineraryLocation'
+export default StyledItineraryLocation

--- a/src/_utils/keycodes.ts
+++ b/src/_utils/keycodes.ts
@@ -1,5 +1,7 @@
 export const KEYCODES = {
   ESCAPE: 27,
+  ENTER: 13,
+  SPACEBAR: 32,
 }
 
 export default KEYCODES

--- a/src/bullet/index.tsx
+++ b/src/bullet/index.tsx
@@ -1,12 +1,12 @@
 import styled from 'styled-components'
-import { color } from '_utils/branding'
+import { color, componentSizes } from '_utils/branding'
 import Bullet from './Bullet'
 
 const StyledBullet = styled(Bullet)`
   & {
-    box-sizing: content-box;
-    width: 6px;
-    height: 6px;
+    box-sizing: border-box;
+    width: ${componentSizes.bulletSize};
+    height: ${componentSizes.bulletSize};
     background-color: ${color.white};
     border: 2px solid ${color.primaryText};
     border-radius: 50%;
@@ -17,14 +17,14 @@ const StyledBullet = styled(Bullet)`
   }
 
   &.kirk-bullet--small {
-    width: 4px;
-    height: 4px;
+    width: ${componentSizes.bulletSizeSmall};
+    height: ${componentSizes.bulletSizeSmall};
   }
 
   &.kirk-bullet--map-active,
   &.kirk-bullet--map-inactive {
-    width: 11px;
-    height: 11px;
+    width: ${componentSizes.bulletSizeMap};
+    height: ${componentSizes.bulletSizeMap};
     border-width: 3px;
   }
 

--- a/src/itinerary/Itinerary.tsx
+++ b/src/itinerary/Itinerary.tsx
@@ -5,10 +5,11 @@ import isString from 'lodash.isstring'
 
 import { color } from '_utils/branding'
 import Text, { TextDisplayType, TextTagType } from 'text'
-import ChevronIcon from 'icon/chevronIcon'
 import SubHeader from 'subHeader'
 import BlankSeparator from 'blankSeparator'
 import Bullet, { BulletTypes } from 'bullet'
+import ItineraryCollapsible from '_utils/itineraryCollapsible'
+import ItineraryLocation, { computeKeyFromPlace } from '_utils/itineraryLocation'
 
 export interface ItineraryProps {
   readonly ariaLabelledBy?: string
@@ -22,6 +23,9 @@ export interface ItineraryProps {
   readonly small?: boolean
   readonly headline?: string
   readonly highlightRoad?: boolean
+  readonly isCollapsible?: boolean
+  readonly collapsedLabel?: string
+  readonly collapsedAriaLabel?: string
 }
 
 interface RootA11yProps {
@@ -30,16 +34,6 @@ interface RootA11yProps {
 }
 
 const isNonEmptyString = (str: string) => isString(str) && str.trim().length > 0
-
-const computeKeyFromPlace = (place: Place) => {
-  if (place.key && typeof place.key === 'string') {
-    return place.key
-  }
-  if (typeof place.subLabel === 'string') {
-    return `${place.mainLabel}-${place.subLabel}-${place.isoDate}`
-  }
-  return `${place.mainLabel}-${place.isoDate}`
-}
 
 const computeRootA11yProps = (ariaLabel?: string, ariaLabelledBy?: string): RootA11yProps => {
   const rootA11yProps: RootA11yProps = {}
@@ -51,6 +45,61 @@ const computeRootA11yProps = (ariaLabel?: string, ariaLabelledBy?: string): Root
     rootA11yProps['aria-labelledby'] = ariaLabelledByValue
   }
   return rootA11yProps
+}
+
+// Get places between departure and arrival
+const getIntermediatePlaces = (places: Place[]) => places.slice(1, -1)
+
+const renderLocation = (
+  places: Place[],
+  isArrival: boolean,
+  small: boolean,
+  withTime: boolean,
+  hasBottomAddon: boolean,
+) => {
+  // if there's only one place, we display it as Arrival, not Departure
+  if (places.length === 1 && !isArrival) {
+    return null
+  }
+
+  const place = isArrival ? places[places.length - 1] : places[0]
+
+  return (
+    <ItineraryLocation
+      place={place}
+      isArrival={isArrival}
+      hasTime={!small && withTime}
+      hasSubLabel={!small && !isEmpty(place.subLabel)}
+      hasBottomAddon={isArrival ? hasBottomAddon : false}
+    />
+  )
+}
+
+const renderAddon = (type: string, addon: string, ariaLabel: string) => {
+  if (!isNonEmptyString(addon) || (type !== 'from' && type !== 'to')) {
+    return null
+  }
+
+  return (
+    <li
+      className={`kirk-itineraryLocation kirk-itinerary-addon kirk-itinerary-addon--${type}`}
+      aria-label={ariaLabel}
+    >
+      <div className="kirk-itineraryLocation-roadContainer" aria-hidden="true">
+        <Bullet className="kirk-itineraryLocation-bullet" type={BulletTypes.ADDON} />
+        {type === 'from' && <div className="kirk-itineraryLocation-road" aria-hidden="true" />}
+      </div>
+      <div className="kirk-itineraryLocation-label">
+        <Text
+          tag={TextTagType.PARAGRAPH}
+          display={TextDisplayType.CAPTION}
+          textColor={color.fadedText}
+        >
+          {addon}
+        </Text>
+      </div>
+    </li>
+  )
 }
 
 const Itinerary = ({
@@ -65,12 +114,18 @@ const Itinerary = ({
   small = false,
   headline = null,
   highlightRoad = true,
+  isCollapsible = false,
+  collapsedLabel,
+  collapsedAriaLabel,
 }: ItineraryProps) => {
-  // Add the small class if we don't have times to prevent empty content
+  // Add the small class if we don't have "time" to prevent empty content
   const withTime = places.filter(p => !isEmpty(p.time)).length > 0
 
   // Remove aria-labelledby attribute if aria-label already used
   const rootA11yProps = computeRootA11yProps(ariaLabel, ariaLabelledBy)
+
+  const intermediatePlaces = getIntermediatePlaces(places)
+
   return (
     <div className={cc(['kirk-itinerary-root', className])} {...rootA11yProps}>
       {isNonEmptyString(headline) && (
@@ -87,132 +142,27 @@ const Itinerary = ({
           },
         ])}
       >
-        {isNonEmptyString(fromAddon) && (
-          <li
-            className="kirk-itinerary-location kirk-itinerary-addon kirk-itinerary-addon--from"
-            aria-label={fromAddonAriaLabel}
-          >
-            <div className="kirk-itinerary-road" aria-hidden="true" />
-            <Bullet type={BulletTypes.ADDON} />
-            <div className="kirk-itinerary-location-city">
-              <Text
-                tag={TextTagType.PARAGRAPH}
-                display={TextDisplayType.CAPTION}
-                textColor={color.fadedText}
-              >
-                {fromAddon}
-              </Text>
-            </div>
-          </li>
+        {renderAddon('from', fromAddon, fromAddonAriaLabel)}
+        {renderLocation(places, false, small, withTime, false)}
+        {isCollapsible && intermediatePlaces.length > 0 && (
+          <ItineraryCollapsible
+            places={intermediatePlaces}
+            label={collapsedLabel}
+            ariaLabel={collapsedAriaLabel}
+          />
         )}
-        {places.map((place, index) => {
-          let Component
-          let hasChevron = false
-          let hrefProps
-
-          const link = place.href
-          const isLastPlace = places.length - 1 === index
-          const hasTime = !small && withTime
-          const hasSubLabel = !small && place.subLabel
-
-          if (!isEmpty(link) && typeof link !== 'string') {
-            Component = link.type
-            hasChevron = true
-            hrefProps = {
-              ...link.props,
-              className: cc(['kirk-itinerary-location-wrapper', link.props.className]),
-            }
-          } else if (typeof link === 'string') {
-            Component = 'a'
-            hasChevron = true
-            hrefProps = {
-              href: place.href,
-              className: 'kirk-itinerary-location-wrapper',
-            }
-          } else {
-            Component = 'div'
-            hrefProps = {
-              className: 'kirk-itinerary-location-wrapper',
-            }
-          }
-
-          return (
-            <li
-              className={cc([
-                'kirk-itinerary-location',
-                {
-                  'kirk-itinerary--arrival': isLastPlace,
-                  'kirk-itinerary-location--withToAddon': isLastPlace && isNonEmptyString(toAddon),
-                },
-              ])}
+        {!isCollapsible &&
+          intermediatePlaces.length > 0 &&
+          intermediatePlaces.map(place => (
+            <ItineraryLocation
+              place={place}
+              hasTime={!small && withTime}
+              hasSubLabel={!small && Boolean(place.subLabel)}
               key={computeKeyFromPlace(place)}
-              itemProp="location"
-              itemScope
-              itemType="http://schema.org/Place"
-              aria-label={place.stepAriaLabel}
-            >
-              <meta itemProp="name" content={place.mainLabel} />
-              <meta
-                itemProp="address"
-                content={
-                  place.subLabel && typeof place.subLabel === 'string'
-                    ? place.subLabel
-                    : place.mainLabel
-                }
-              />
-              <Component {...hrefProps} aria-label={place.actionAriaLabel}>
-                {hasTime && (
-                  <time dateTime={place.isoDate}>
-                    <Text tag={TextTagType.DIV} display={TextDisplayType.TITLESTRONG}>
-                      {place.time}
-                    </Text>
-                  </time>
-                )}
-                <div className="kirk-itinerary-location-city">
-                  <div className="kirk-itinerary-road" aria-hidden="true" />
-                  <Bullet />
-                  <Text tag={TextTagType.PARAGRAPH} display={TextDisplayType.TITLESTRONG}>
-                    {place.mainLabel}
-                  </Text>
-                  {hasSubLabel &&
-                    (typeof place.subLabel === 'string' ? (
-                      <Text
-                        tag={TextTagType.PARAGRAPH}
-                        display={TextDisplayType.CAPTION}
-                        textColor={color.primaryText}
-                      >
-                        {place.subLabel}
-                      </Text>
-                    ) : (
-                      <div>{place.subLabel}</div>
-                    ))}
-                </div>
-                {hasChevron && (
-                  <div className="kirk-itinerary-location-chevron">
-                    <ChevronIcon />
-                  </div>
-                )}
-              </Component>
-            </li>
-          )
-        })}
-        {isNonEmptyString(toAddon) && (
-          <li
-            className="kirk-itinerary-location kirk-itinerary-addon kirk-itinerary-addon--to"
-            aria-label={toAddonAriaLabel}
-          >
-            <Bullet type={BulletTypes.ADDON} />
-            <div className="kirk-itinerary-location-city">
-              <Text
-                tag={TextTagType.PARAGRAPH}
-                display={TextDisplayType.CAPTION}
-                textColor={color.fadedText}
-              >
-                {toAddon}
-              </Text>
-            </div>
-          </li>
-        )}
+            />
+          ))}
+        {renderLocation(places, true, small, withTime, isNonEmptyString(toAddon))}
+        {renderAddon('to', toAddon, toAddonAriaLabel)}
       </ul>
     </div>
   )

--- a/src/itinerary/Itinerary.unit.tsx
+++ b/src/itinerary/Itinerary.unit.tsx
@@ -62,9 +62,6 @@ describe('Itinerary component', () => {
     const itinerary = shallow(
       <Itinerary toAddon="test" toAddonAriaLabel="testLabel" places={places} />,
     )
-    expect(
-      itinerary.find('.kirk-itinerary--arrival').hasClass('kirk-itinerary-location--withToAddon'),
-    ).toBe(true)
     expect(itinerary.find('.kirk-itinerary-addon--to').exists()).toBe(true)
     expect(itinerary.find('.kirk-itinerary-addon--to').prop('aria-label')).toEqual('testLabel')
   })
@@ -77,192 +74,6 @@ describe('Itinerary component', () => {
   it('Should not render bottom addon with blank string', () => {
     const itinerary = shallow(<Itinerary toAddon=" " places={places} />)
     expect(itinerary.find('.kirk-itinerary-addon--to').exists()).toBe(false)
-  })
-
-  describe('Should handle highlightRoad', () => {
-    it('Should add kirk-itinerary--highlightRoad class by default', () => {
-      const itinerary = shallow(<Itinerary places={places} />)
-      expect(itinerary.find('.kirk-itinerary--highlightRoad').exists()).toBe(true)
-    })
-
-    it('Should add kirk-itinerary--highlightRoad class if highighlightRoad is true', () => {
-      const itinerary = shallow(<Itinerary places={places} highighlightRoad />)
-      expect(itinerary.find('.kirk-itinerary--highlightRoad').exists()).toBe(true)
-    })
-
-    it('Should not add kirk-itinerary--highlightRoad class highighlightRoad is false', () => {
-      const itinerary = shallow(<Itinerary places={places} highlightRoad={false} />)
-      expect(itinerary.find('.kirk-itinerary--highlightRoad').exists()).toBe(false)
-    })
-  })
-
-  it('Should display stopover with a11y label', () => {
-    const itinerary = shallow(<Itinerary places={places} />)
-    expect(itinerary.find('.kirk-itinerary-location')).toHaveLength(places.length)
-    expect(
-      itinerary
-        .find('.kirk-itinerary-location')
-        .first()
-        .prop('aria-label'),
-    ).toEqual('Pick up/drop off location')
-  })
-
-  it('Should display link with a11y label', () => {
-    const itinerary = shallow(
-      <Itinerary
-        places={[
-          {
-            distanceFromPoint: '1,5km',
-            time: '09:00',
-            isoDate: '2017-12-11T09:00',
-            subLabel: <Proximity value="FAR" title="Pick up point is quite far fom your place" />,
-            mainLabel: 'Paris',
-            actionAriaLabel: 'New page with a map',
-            href: '#test',
-          },
-          {
-            distanceFromPoint: '8km',
-            time: '15:00',
-            isoDate: '2017-12-11T15:00',
-            subLabel: <Proximity value="FAR" title="Pick up point is quite far fom your place" />,
-            mainLabel: 'Bordeaux',
-          },
-        ]}
-      />,
-    )
-    expect(
-      itinerary
-        .find('.kirk-itinerary-location-wrapper')
-        .first()
-        .type(),
-    ).toEqual('a')
-    expect(
-      itinerary
-        .find('.kirk-itinerary-location-wrapper')
-        .first()
-        .prop('aria-label'),
-    ).toEqual('New page with a map')
-    expect(itinerary.find('.kirk-itinerary-location-chevron').exists()).toBe(true)
-  })
-
-  it('Should display button', () => {
-    const itinerary = shallow(
-      <Itinerary
-        places={[
-          {
-            distanceFromPoint: '1,5km',
-            time: '09:00',
-            isoDate: '2017-12-11T09:00',
-            subLabel: <Proximity value="FAR" title="Pick up point is quite far fom your place" />,
-            mainLabel: 'Paris',
-            actionAriaLabel: 'New page with a map',
-            href: <button type="button" />,
-          },
-          {
-            distanceFromPoint: '8km',
-            time: '15:00',
-            isoDate: '2017-12-11T15:00',
-            subLabel: <Proximity value="FAR" title="Pick up point is quite far fom your place" />,
-            mainLabel: 'Bordeaux',
-          },
-        ]}
-      />,
-    )
-    expect(
-      itinerary
-        .find('.kirk-itinerary-location-wrapper')
-        .first()
-        .type(),
-    ).toEqual('button')
-    expect(
-      itinerary
-        .find('.kirk-itinerary-location-wrapper')
-        .first()
-        .prop('aria-label'),
-    ).toEqual('New page with a map')
-    expect(
-      itinerary
-        .find('.kirk-itinerary-location-wrapper')
-        .first()
-        .prop('type'),
-    ).toEqual('button')
-    expect(itinerary.find('.kirk-itinerary-location-chevron').exists()).toBe(true)
-  })
-
-  it('Should display proximity pills for all points', () => {
-    const itinerary = shallow(<Itinerary places={places} />)
-    const proxi = itinerary.find(Proximity)
-    expect(proxi).toHaveLength(3)
-    expect(proxi.first().prop('value')).toBe('FAR')
-  })
-
-  it("Should use subLabel in key if it's a string", () => {
-    const placesList = [
-      {
-        distanceFromPoint: '1,5km',
-        time: '09:00',
-        isoDate: '2017-12-11T09:00',
-        subLabel: 'rue Ménars',
-        mainLabel: 'Paris',
-      },
-      {
-        time: '12:00',
-        isoDate: '2017-12-11T12:00',
-        subLabel: <Proximity value="FAR" title="Pick up point is quite far fom your place" />,
-        mainLabel: 'Tours',
-      },
-    ]
-    const itinerary = shallow(<Itinerary fromAddon="test" places={placesList} />)
-    const key1 = itinerary
-      .find('li.kirk-itinerary-location')
-      .at(1)
-      .key()
-    expect(key1).toBe('Paris-rue Ménars-2017-12-11T09:00')
-    const key2 = itinerary
-      .find('li.kirk-itinerary-location')
-      .at(2)
-      .key()
-    expect(key2).toBe('Tours-2017-12-11T12:00')
-  })
-
-  it("Should not use subLabel in key if it's a JSX object", () => {
-    const itinerary = shallow(<Itinerary fromAddon="test" places={places} />)
-    const key = itinerary
-      .find('li.kirk-itinerary-location')
-      .at(1)
-      .key()
-    expect(key).toBe('Paris-2017-12-11T09:00')
-  })
-
-  it('Should use key attribute as key if provided', () => {
-    const placesList = [
-      {
-        distanceFromPoint: '1,5km',
-        time: '09:00',
-        isoDate: '2017-12-11T09:00',
-        subLabel: 'rue Ménars',
-        mainLabel: 'Paris',
-        key: 'route-start-paris',
-      },
-      {
-        time: '12:00',
-        isoDate: '2017-12-11T12:00',
-        subLabel: <Proximity value="FAR" title="Pick up point is quite far fom your place" />,
-        mainLabel: 'Tours',
-        key: 'route-end-tours',
-      },
-    ]
-    const itinerary = shallow(<Itinerary fromAddon="test" places={placesList} />)
-    const key1 = itinerary
-      .find('li.kirk-itinerary-location')
-      .at(1)
-      .key()
-    expect(key1).toBe('route-start-paris')
-    const key2 = itinerary
-      .find('li.kirk-itinerary-location')
-      .at(2)
-      .key()
-    expect(key2).toBe('route-end-tours')
   })
 
   describe('small', () => {
@@ -296,6 +107,23 @@ describe('Itinerary component', () => {
       const itinerary = shallow(<Itinerary places={placesList} />)
       const ul = itinerary.find('ul')
       expect(ul.hasClass('kirk-itinerary--noTime')).toBe(true)
+    })
+  })
+
+  describe('Should handle highlightRoad', () => {
+    it('Should add kirk-itinerary--highlightRoad class by default', () => {
+      const itinerary = shallow(<Itinerary places={places} />)
+      expect(itinerary.find('.kirk-itinerary--highlightRoad').exists()).toBe(true)
+    })
+
+    it('Should add kirk-itinerary--highlightRoad class if highighlightRoad is true', () => {
+      const itinerary = shallow(<Itinerary places={places} />)
+      expect(itinerary.find('.kirk-itinerary--highlightRoad').exists()).toBe(true)
+    })
+
+    it('Should not add kirk-itinerary--highlightRoad class highighlightRoad is false', () => {
+      const itinerary = shallow(<Itinerary places={places} highlightRoad={false} />)
+      expect(itinerary.find('.kirk-itinerary--highlightRoad').exists()).toBe(false)
     })
   })
 })

--- a/src/itinerary/index.tsx
+++ b/src/itinerary/index.tsx
@@ -3,12 +3,13 @@ import { color, space, componentSizes } from '_utils/branding'
 
 import Itinerary from './Itinerary'
 
-const distanceFromHeight = '40px'
-const gutterPaddingStart = space.m
-const gutterTopOffset = '1px'
-const lineHeightAdjustment = '4px'
-const bulletOuterSize = '10px'
-const roadWidth = '4px'
+const distanceFromHeight = '48px'
+const totalTimeWidth = `${Math.ceil(
+  parseInt(componentSizes.timeWidth, 10) + parseInt(componentSizes.bulletSize, 10),
+)}px`
+const smallBulletPositionLeft = `${Math.ceil(
+  (parseInt(componentSizes.bulletSize, 10) - parseInt(componentSizes.bulletSizeSmall, 10)) / 2,
+)}px`
 
 const StyledItinerary = styled(Itinerary)`
   li {
@@ -16,130 +17,73 @@ const StyledItinerary = styled(Itinerary)`
     list-style-type: none;
   }
 
-  & .kirk-itinerary-location-wrapper {
-    display: flex;
-    padding: ${space.m} 0;
-    width: 100%;
+  & .kirk-itinerary--highlightRoad .kirk-itineraryLocation-road {
+    background-color: ${color.primaryText};
   }
 
-  & a.kirk-itinerary-location-wrapper {
-    background: none;
-    text-decoration: none;
-    user-select: none;
-    -webkit-tap-highlight-color: ${color.tapHighlight};
-    -webkit-touch-callout: none;
+  & .kirk-itineraryLocation-road {
+    display: block;
+    width: ${componentSizes.roadWidth};
+    height: calc(
+      100% - ${componentSizes.bulletSize} + 4px
+    ); /* +4px to better hide behind small Bullets */
+    position: relative;
+    top: -1px; /* -1px to better hide behind small Bullets */
+    background-color: ${color.fadedText};
+    margin: 0 auto;
   }
 
-  & button.kirk-itinerary-location-wrapper {
-    border: 0;
-    cursor: pointer;
-    text-align: left;
-    width: 100%;
-    font-family: inherit;
-    outline: none;
-    background-color: transparent;
-    -webkit-tap-highlight-color: ${color.tapHighlight};
-    -webkit-touch-callout: none;
-  }
-
-  & a.kirk-itinerary-location-wrapper:hover,
-  & button.kirk-itinerary-location-wrapper:hover {
-    background-color: ${color.tapHighlight};
-  }
-
-  & .kirk-itinerary-location time {
-    min-width: calc(${gutterPaddingStart} + ${componentSizes.timeWidth});
-  }
-
-  & .kirk-itinerary-location-chevron {
-    display: flex;
-    align-items: center;
-  }
-
-  & .kirk-itinerary-location-city {
-    padding-left: ${space.l}; /* Adding the width of the step points to the regular spacing */
-    flex: 1;
-  }
-
-  &
-    .kirk-itinerary--noTime
-    .kirk-itinerary-location:not(.kirk-itinerary--arrival)
-    .kirk-itinerary-location-city {
-    padding-bottom: 0;
-  }
-
-  /* bullet */
-  & .kirk-bullet {
-    position: absolute;
-    top: calc(${lineHeightAdjustment} + ${space.m} + ${gutterTopOffset});
-    left: calc(${componentSizes.timeWidth} + (${bulletOuterSize} / 2));
-  }
-
-  & .kirk-itinerary-addon--from .kirk-bullet {
-    top: calc(-1 * ${gutterTopOffset});
-  }
-
-  & .kirk-itinerary-addon--to .kirk-bullet {
-    top: auto;
-    bottom: calc(-1 * ${gutterTopOffset});
-  }
-
-  & .kirk-itinerary--noTime .kirk-bullet {
-    left: 0;
+  & .kirk-itinerary--noTime .kirk-itinerary-addon {
+    margin-left: 0;
   }
 
   /* addons */
   & .kirk-itinerary-addon {
+    padding-left: ${space.l}; /* Adding the width of the step points to the regular spacing */
     height: ${distanceFromHeight};
+    display: flex;
+    padding-left: 0;
+    margin-left: ${totalTimeWidth};
   }
 
-  & :not(.kirk-itinerary--noTime) .kirk-itinerary-addon .kirk-itinerary-location-city {
-    margin-left: calc(${gutterPaddingStart} + ${componentSizes.timeWidth});
-  }
-
-  & .kirk-itinerary-addon .kirk-itinerary-location-city .kirk-text {
+  & .kirk-itinerary-addon .kirk-itineraryLocation-roadContainer {
     position: relative;
-    top: calc(-1 * ${lineHeightAdjustment});
+    top: ${space.s};
+    margin-right: ${space.m};
   }
 
-  & .kirk-itinerary-addon--to .kirk-itinerary-location-city .kirk-text {
-    top: calc(${distanceFromHeight} - ${bulletOuterSize} - 2px); /* Magic */
+  & .kirk-itinerary-addon--to .kirk-itineraryLocation-label {
+    padding-bottom: 0;
   }
 
-  /* road */
-  & .kirk-itinerary-road {
-    position: absolute;
-    top: calc(${bulletOuterSize} + ${space.m} + ${lineHeightAdjustment});
-    left: calc(${gutterPaddingStart} + ${componentSizes.timeWidth});
-    width: ${roadWidth};
-    height: calc(100% - (${space.m}));
+  & .kirk-itinerary-addon--to .kirk-itineraryLocation-roadContainer {
+    position: static;
+  }
+
+  & :not(.kirk-itinerary--noTime) .kirk-itinerary-addon .kirk-itineraryLocation-city {
+    margin-left: calc(${space.m} + ${componentSizes.timeWidth});
+  }
+
+  /* road, only for -addon--from */
+  & .kirk-itinerary-addon--from .kirk-itineraryLocation-road {
     background-color: ${color.fadedText};
   }
 
-  & .kirk-itinerary--highlightRoad .kirk-itinerary-road {
-    background-color: ${color.primaryText};
+  /* isCollapsible */
+  & .kirk-itineraryCollapsible {
+    margin-left: calc(${totalTimeWidth} + ${smallBulletPositionLeft});
   }
 
-  & .kirk-itinerary--noTime .kirk-itinerary-road {
-    left: calc((${bulletOuterSize} - ${roadWidth}) / 2);
+  & .kirk-itinerary--noTime .kirk-itineraryCollapsible {
+    margin-left: ${smallBulletPositionLeft};
   }
 
-  & .kirk-itinerary-addon--from .kirk-itinerary-road,
-  & .kirk-itinerary--arrival .kirk-itinerary-road {
-    background-color: ${color.fadedText};
+  & .kirk-itineraryLocation-wrapper {
+    padding: 0;
   }
 
-  & .kirk-itinerary-addon--from .kirk-itinerary-road {
-    top: calc(${bulletOuterSize} - (${lineHeightAdjustment} / 2));
-    height: calc(100% + (${bulletOuterSize} / 2));
-  }
-
-  & .kirk-itinerary--arrival .kirk-itinerary-road {
-    height: calc(100% + (${bulletOuterSize}));
-  }
-
-  & .kirk-itinerary--arrival:not(.kirk-itinerary-location--withToAddon) .kirk-itinerary-road {
-    display: none;
+  & .kirk-itineraryLocation-label {
+    padding-bottom: ${space.l};
   }
 `
 

--- a/src/itinerary/story.tsx
+++ b/src/itinerary/story.tsx
@@ -86,6 +86,9 @@ stories.add('default', () => {
         small={boolean('small', false)}
         headline={headline}
         highlightRoad={highlightRoad}
+        isCollapsible={boolean('isCollapsible', false)}
+        collapsedLabel={text('collapsed label', `${placesWithStopover.length} stops`)}
+        collapsedAriaLabel={text('collapsed aria label', 'Show or hide all stops')}
       />
     </div>
   )
@@ -155,45 +158,6 @@ stories.add('with stopovers', () => {
       toAddon={toAddon}
       toAddonAriaLabel={toAddonLabel}
       places={placesWithStopover}
-      small={boolean('small', false)}
-      headline={headline}
-      highlightRoad={highlightRoad}
-    />
-  )
-})
-
-stories.add('with button tiles', () => {
-  const fromAddon = text('From addon', 'Lille')
-  const toAddon = text('To addon', 'Biarritz')
-  const headline = text('Headline', 'Mon 11 December')
-  const highlightRoad = boolean('Highlight road', true)
-  const placesWithButton = [
-    {
-      time: '09:00',
-      isoDate: '2017-12-11T09:00',
-      subLabel: 'Porte de Vincennes',
-      mainLabel: 'Paris',
-      href: <button type="button" />,
-    },
-    {
-      time: '15:00',
-      isoDate: '2017-12-11T15:00',
-      subLabel: 'Gare Bordeaux Saint-Jean',
-      mainLabel: 'Bordeaux',
-    },
-    {
-      time: '12:00',
-      isoDate: '2017-12-11T12:00',
-      subLabel: 'Gare de Tours',
-      mainLabel: 'Tours',
-      href: <button type="button" />,
-    },
-  ]
-  return (
-    <Itinerary
-      fromAddon={fromAddon}
-      toAddon={toAddon}
-      places={placesWithButton}
       small={boolean('small', false)}
       headline={headline}
       highlightRoad={highlightRoad}


### PR DESCRIPTION
I expect a lot of feedback, don't be shy.

Most of the logic found in the previous Itinerary is now in a new component ItineraryLocation.
ItineraryCollapsible can be used in Itinerary to collapse intermediate stopovers.

![kap_itineraryCollapsible](https://user-images.githubusercontent.com/373381/73103037-6de63580-3ef3-11ea-93fe-7b07749c7fb4.gif)

