### PR TITLE
Fix content/background class for sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **[BREAKING CHANGE]** Replace `TopTripCardList` component with `TripsSection` section.
 - **[UPDATE]** Add new Pages leftnav category and a few messaging & ridedetails pages
+- **[BREAKING CHANGE]** Fix background/content classname props on `BaseSection` and `HighlightSection`
 - [...]
 
 # v19.1.1 (07/02/2020)

--- a/src/layout/section/baseSection/baseSection.tsx
+++ b/src/layout/section/baseSection/baseSection.tsx
@@ -8,7 +8,7 @@ export enum SectionContentSize {
 
 export interface BaseSectionProps {
   readonly className?: Classcat.Class
-  readonly backgroundClassName?: Classcat.Class
+  readonly contentClassName?: Classcat.Class
   readonly backgroundStyle?: object
   readonly tagName?: string
   readonly role?: string
@@ -23,7 +23,7 @@ export interface BaseSectionProps {
 const BaseSection = (props: BaseSectionProps) => {
   const {
     className,
-    backgroundClassName,
+    contentClassName,
     backgroundStyle,
     tagName: ContentElement = 'div',
     children,
@@ -33,6 +33,7 @@ const BaseSection = (props: BaseSectionProps) => {
 
   const contentClassNames = cc([
     'section-content',
+    contentClassName,
     {
       'section-content--large': contentSize === SectionContentSize.LARGE,
     },
@@ -46,11 +47,7 @@ const BaseSection = (props: BaseSectionProps) => {
   }
 
   return (
-    <div
-      role="presentation"
-      className={cc([className, backgroundClassName])}
-      style={backgroundStyle}
-    >
+    <div role="presentation" className={cc([className])} style={backgroundStyle}>
       <ContentElement {...contentProps}>{children}</ContentElement>
     </div>
   )

--- a/src/layout/section/highlightSection/__snapshots__/index.unit.tsx.snap
+++ b/src/layout/section/highlightSection/__snapshots__/index.unit.tsx.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`HighlightSection should add a classname to the content 1`] = `
+.c1 .section-content {
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+.c0 {
+  background-color: #5DD167;
+}
+
+@media (min-width:800px) {
+  .c1 .section-content {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 662px;
+  }
+
+  .c1 .section-content.section-content--large {
+    max-width: 1016px;
+  }
+}
+
+<div
+  className="c0 c1"
+  role="presentation"
+>
+  <div
+    className="section-content some-content-class-name section-content--large"
+  >
+    default highlight section
+  </div>
+</div>
+`;
+
 exports[`HighlightSection should render default highlight section 1`] = `
 .c1 .section-content {
   padding-left: 24px;

--- a/src/layout/section/highlightSection/highlightSection.tsx
+++ b/src/layout/section/highlightSection/highlightSection.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import cc from 'classcat'
 import BaseSection, { SectionContentSize } from 'layout/section/baseSection'
 
 export interface HighlightSectionProps {
   readonly className?: Classcat.Class
+  readonly contentClassName?: Classcat.Class
   readonly children: JSX.Element | string
 }
 
@@ -11,9 +11,13 @@ export interface HighlightSectionProps {
  * A specialized section with an highlighting background color.
  */
 const HighlightSection = (props: HighlightSectionProps) => {
-  const { className, children } = props
+  const { className, children, contentClassName } = props
   return (
-    <BaseSection className={cc(className)} contentSize={SectionContentSize.LARGE}>
+    <BaseSection
+      className={className}
+      contentClassName={contentClassName}
+      contentSize={SectionContentSize.LARGE}
+    >
       {children}
     </BaseSection>
   )

--- a/src/layout/section/highlightSection/index.unit.tsx
+++ b/src/layout/section/highlightSection/index.unit.tsx
@@ -9,4 +9,14 @@ describe('HighlightSection', () => {
     const renderedSection = renderer.create(section).toJSON()
     expect(renderedSection).toMatchSnapshot()
   })
+
+  it('should add a classname to the content', () => {
+    const section = (
+      <HighlightSection contentClassName="some-content-class-name">
+        default highlight section
+      </HighlightSection>
+    )
+    const renderedSection = renderer.create(section).toJSON()
+    expect(renderedSection).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
backgroundClassName becomes className.
className becomes contentClassName and is only attached to the inner content.