### PR TITLE
Tabs and TabsSection layout overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - **[NEW]** Implement `Paragraph` widget
+- **[BREAKING CHANGE]** `Tabs` and `TabsSection` layout/spacing overhaul
 - [...]
 
 # v20.1.2 (12/02/2020)

--- a/src/layout/section/tabsSection/__snapshots__/index.unit.tsx.snap
+++ b/src/layout/section/tabsSection/__snapshots__/index.unit.tsx.snap
@@ -1,12 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TabsSection should render default TabsSection 1`] = `
-.c1 .section-content {
-  padding-left: 24px;
-  padding-right: 24px;
-}
-
-.c3 {
+.c2 {
   box-sizing: border-box;
   display: inline-block;
   min-width: 18px;
@@ -22,15 +17,16 @@ exports[`TabsSection should render default TabsSection 1`] = `
   color: #FFF;
 }
 
-.c2 {
+.c1 {
   position: relative;
 }
 
-.c2 .kirk-tablist-wrapper {
+.c1 .kirk-tabs {
+  margin-bottom: 16px;
   border-bottom: 1px solid #DDD;
 }
 
-.c2 .kirk-tablist {
+.c1 .kirk-tablist {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -44,16 +40,11 @@ exports[`TabsSection should render default TabsSection 1`] = `
   scrollbar-width: none;
 }
 
-.c2 .kirk-tablist::-webkit-scrollbar {
+.c1 .kirk-tablist::-webkit-scrollbar {
   display: none;
 }
 
-.c2 .kirk-tablist-wrapped {
-  width: 662px;
-  padding: 0 24px;
-}
-
-.c2 .kirk-tab {
+.c1 .kirk-tab {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -70,7 +61,7 @@ exports[`TabsSection should render default TabsSection 1`] = `
   width: 100%;
   height: 100%;
   outline: none;
-  padding: 16px;
+  padding: 16px 24px;
   background: none;
   border: none;
   background-color: #FFF;
@@ -79,24 +70,23 @@ exports[`TabsSection should render default TabsSection 1`] = `
   white-space: nowrap;
 }
 
-.c2 .kirk-tab > .kirk-icon {
+.c1 .kirk-tab > .kirk-icon {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c2 .kirk-tab-text {
+.c1 .kirk-tab-text {
   text-overflow: ellipsis;
   overflow: hidden;
 }
 
-.c2 .kirk-tab-text--with-icon {
+.c1 .kirk-tab-text--with-icon {
   margin-left: 16px;
   text-align: left;
 }
 
-.c2 .kirk-tab-container {
-  margin-left: 16px;
+.c1 .kirk-tab-container {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -111,11 +101,11 @@ exports[`TabsSection should render default TabsSection 1`] = `
   align-items: last baseline;
 }
 
-.c2.kirk-tabs-fixed .kirk-tablist {
+.c1.kirk-tabs-fixed .kirk-tablist {
   overflow: initial;
 }
 
-.c2.kirk-tabs-fixed .kirk-tab-container {
+.c1.kirk-tabs-fixed .kirk-tab-container {
   margin-left: 0;
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -124,19 +114,19 @@ exports[`TabsSection should render default TabsSection 1`] = `
   text-align: center;
 }
 
-.c2.kirk-tabs-fixed .kirk-tab {
+.c1.kirk-tabs-fixed .kirk-tab {
   white-space: normal;
 }
 
-.c2 .kirk-tab-selected .kirk-tab {
+.c1 .kirk-tab-selected .kirk-tab {
   color: #054752;
 }
 
-.c2 .kirk-tab:not(.kirk-tab-selected):hover {
+.c1 .kirk-tab:not(.kirk-tab-selected):hover {
   cursor: pointer;
 }
 
-.c2 .kirk-tab-container .kirk-badge {
+.c1 .kirk-tab-container .kirk-badge {
   position: relative;
   left: 0;
   top: calc(-1 * 4px);
@@ -145,7 +135,7 @@ exports[`TabsSection should render default TabsSection 1`] = `
   align-self: flex-start;
 }
 
-.c2 .kirk-tab-highlight {
+.c1 .kirk-tab-highlight {
   position: absolute;
   z-index: 2;
   left: 0;
@@ -161,24 +151,18 @@ exports[`TabsSection should render default TabsSection 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-.c0 .kirk-tabs:after {
-  content: ' ';
-  position: absolute;
-  left: -100vw;
-  right: -100vw;
-  bottom: 0;
-  border-bottom: 1px solid #DDD;
+@media (max-width:800px) {
+  .c0 .kirk-panels-section {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
 }
 
 @media (min-width:800px) {
-  .c1 .section-content {
-    margin-left: auto;
-    margin-right: auto;
-    max-width: 662px;
-  }
-
-  .c1 .section-content.section-content--large {
-    max-width: 1016px;
+  .c0 .kirk-panels-section,
+  .c0 .kirk-tablist-wrapper {
+    width: calc(662px - 2 * 24px);
+    margin: 0 auto;
   }
 }
 
@@ -187,89 +171,90 @@ exports[`TabsSection should render default TabsSection 1`] = `
   role="presentation"
 >
   <div
-    className="section-content"
+    className="kirk-tabs"
   >
     <div
-      className="kirk-tabs c2"
+      className="kirk-tablist-wrapper"
     >
       <div
-        className="kirk-tablist-wrapper"
+        className="kirk-tab-highlight"
+      />
+      <div
+        aria-multiselectable="false"
+        aria-orientation="horizontal"
+        className="kirk-tablist"
+        role="tablist"
       >
         <div
-          className="kirk-tab-highlight"
-        />
-        <div
-          aria-multiselectable="false"
-          aria-orientation="horizontal"
-          className="kirk-tablist"
-          role="tablist"
+          className="kirk-tab-container kirk-tab-selected"
+          style={null}
         >
-          <div
-            className="kirk-tab-container kirk-tab-selected"
-            style={null}
+          <button
+            aria-controls="tab1_panel"
+            aria-selected="true"
+            className="kirk-tab"
+            id="tab1"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+            tabIndex={0}
+            title="Tab label 1"
           >
-            <button
-              aria-controls="tab1_panel"
-              aria-selected="true"
-              className="kirk-tab"
-              id="tab1"
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              role="tab"
-              tabIndex={0}
-              title="Tab label 1"
+            <span
+              className="kirk-tab-text"
+            >
+              Tab label 1
+            </span>
+            <span
+              className="kirk-badge kirk-tab-badge c2"
             >
               <span
-                className="kirk-tab-text"
+                aria-hidden={false}
               >
-                Tab label 1
+                Badge content 1
               </span>
-              <span
-                className="kirk-badge kirk-tab-badge c3"
-              >
-                <span
-                  aria-hidden={false}
-                >
-                  Badge content 1
-                </span>
-              </span>
-            </button>
-          </div>
-          <div
-            className="kirk-tab-container"
-            style={null}
+            </span>
+          </button>
+        </div>
+        <div
+          className="kirk-tab-container"
+          style={null}
+        >
+          <button
+            aria-controls="tab2_panel"
+            aria-selected="false"
+            className="kirk-tab"
+            id="tab2"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="tab"
+            tabIndex={-1}
+            title="Tab label 2 Unread Message"
           >
-            <button
-              aria-controls="tab2_panel"
-              aria-selected="false"
-              className="kirk-tab"
-              id="tab2"
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              role="tab"
-              tabIndex={-1}
-              title="Tab label 2 Unread Message"
+            <span
+              className="kirk-tab-text"
+            >
+              Tab label 2
+            </span>
+            <span
+              aria-label="Unread Message"
+              className="kirk-badge kirk-tab-badge c2"
             >
               <span
-                className="kirk-tab-text"
+                aria-hidden={true}
               >
-                Tab label 2
+                2
               </span>
-              <span
-                aria-label="Unread Message"
-                className="kirk-badge kirk-tab-badge c3"
-              >
-                <span
-                  aria-hidden={true}
-                >
-                  2
-                </span>
-              </span>
-            </button>
-          </div>
+            </span>
+          </button>
         </div>
       </div>
     </div>
+  </div>
+  <div
+    className="kirk-panels-section"
+    role="presentation"
+  >
     <div
       aria-labelledby="tab1"
       className="kirk-tab-panel"

--- a/src/layout/section/tabsSection/index.tsx
+++ b/src/layout/section/tabsSection/index.tsx
@@ -1,20 +1,22 @@
 import styled from 'styled-components'
-import { color } from '_utils/branding'
+import { space, responsiveBreakpoints, componentSizes } from '_utils/branding'
 
 import TabsSection from './tabsSection'
 
 const StyledTabsSection = styled(TabsSection)`
-  & .kirk-tabs:after {
-    /**
-     * Render a line separating the tabs from the tab panel content.
-     * This line should be as wide as the viewport to create a visual section.
-     */
-    content: ' ';
-    position: absolute;
-    left: -100vw;
-    right: -100vw;
-    bottom: 0;
-    border-bottom: 1px solid ${color.border};
+  @media (${responsiveBreakpoints.isMediaSmall}) {
+    & .kirk-panels-section {
+      padding-left: ${space.xl};
+      padding-right: ${space.xl};
+    }
+  }
+
+  @media (${responsiveBreakpoints.isMediaLarge}) {
+    & .kirk-panels-section,
+    & .kirk-tablist-wrapper {
+      width: calc(${componentSizes.smallSectionWidth} - 2 * ${space.xl});
+      margin: 0 auto;
+    }
   }
 `
 

--- a/src/layout/section/tabsSection/story.tsx
+++ b/src/layout/section/tabsSection/story.tsx
@@ -12,8 +12,8 @@ const stories = storiesOf('Sections|TabsSection', module)
 stories.addDecorator(withKnobs)
 
 const panels = [
-  <div style={{ padding: 30 }}>Content for first tab</div>,
-  <div style={{ padding: 30 }}>
+  <div>Content for first tab</div>,
+  <div>
     <Button
       onClick={() => {
         action('onClickButton')
@@ -22,12 +22,12 @@ const panels = [
       Button inside panel 2.
     </Button>
   </div>,
-  <div style={{ padding: 30 }}>Content for tab3</div>,
+  <div>Content for tab3</div>,
 ]
 
 const tabs = {
   activeTabId: 'tab1',
-  status: select('status', TabStatus, TabStatus.SCROLLABLE),
+  status: select('status', TabStatus, TabStatus.FIXED),
   isWrapped: boolean('isWrapped', false),
   tabs: [
     {

--- a/src/layout/section/tabsSection/tabsSection.tsx
+++ b/src/layout/section/tabsSection/tabsSection.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import cc from 'classcat'
-import BaseSection from 'layout/section/baseSection'
 import Tabs, { TabsProps } from 'tabs'
 
 export interface TabsSectionProps {
@@ -18,11 +17,7 @@ export interface TabsSectionProps {
  */
 const TabsSection = (props: TabsSectionProps) => {
   const { className, tabsProps } = props
-  return (
-    <BaseSection className={cc(className)}>
-      <Tabs {...tabsProps} />
-    </BaseSection>
-  )
+  return <Tabs className={cc(className)} {...tabsProps} />
 }
 
 export default TabsSection

--- a/src/tabs/Tabs.tsx
+++ b/src/tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { createRef, PureComponent, RefObject, Fragment } from 'react'
+import React, { createRef, PureComponent, RefObject } from 'react'
 import cc from 'classcat'
 import Badge from 'badge'
 
@@ -23,8 +23,7 @@ export interface TabsProps {
   readonly onChange?: Function
   readonly status?: TabStatus
   readonly className?: Classcat.Class
-  readonly tablistWrapperClassName?: Classcat.Class
-  readonly isWrapped?: boolean
+  readonly tabsClassName?: Classcat.Class
 }
 
 interface TabsState {
@@ -78,8 +77,7 @@ export class Tabs extends PureComponent<TabsProps, TabsState> {
     onChange() {},
     status: TabStatus.SCROLLABLE,
     className: '',
-    tablistWrapperClassName: '',
-    isWrapped: false,
+    tabsClassName: '',
   }
 
   state: TabsState = {
@@ -88,6 +86,7 @@ export class Tabs extends PureComponent<TabsProps, TabsState> {
   }
 
   highlightRef: RefObject<HTMLDivElement> = React.createRef()
+  tabsGroupRef: RefObject<HTMLDivElement> = React.createRef()
 
   static STATUS = TabStatus
 
@@ -127,17 +126,16 @@ export class Tabs extends PureComponent<TabsProps, TabsState> {
 
     // .kirk-tablist-wrapper needed to get the height of the whole component
     // because tabs can have different heights.
-    // Casted as HTMLElement to use offsetHeight (parentNode returns an Element).
-    const parentTabWrapper = this.highlightRef.current.parentNode as HTMLElement
+    const tabsGroup = this.tabsGroupRef.current
 
     // adapt to current tab width
     this.highlightRef.current.style.width = `${tabBounds.width}px`
     // top position, tablist-wrapper height - tablist-wrapper border height
-    this.highlightRef.current.style.top = `${parentTabWrapper.clientHeight -
-      (parentTabWrapper.offsetHeight - parentTabWrapper.clientHeight)}px`
+    this.highlightRef.current.style.top = `${tabsGroup.clientHeight -
+      (tabsGroup.offsetHeight - tabsGroup.clientHeight)}px`
     // left position, tab left position - parent wrapper left position
     this.highlightRef.current.style.left = `${tabBounds.left -
-      parentTabWrapper.getBoundingClientRect().left}px`
+      tabsGroup.getBoundingClientRect().left}px`
   }
 
   activateTabById = (activeTabId: string) => {
@@ -160,7 +158,7 @@ export class Tabs extends PureComponent<TabsProps, TabsState> {
   }
 
   render() {
-    const { tabs, className, tablistWrapperClassName, isWrapped } = this.props
+    const { tabs, className, tabsClassName } = this.props
 
     if (tabs.length === 0) {
       return null
@@ -174,15 +172,18 @@ export class Tabs extends PureComponent<TabsProps, TabsState> {
     }
 
     return (
-      <Fragment>
-        <div className={cc(['kirk-tabs', className, { 'kirk-tabs-fixed': isFixedTabs }])}>
-          <div className={cc(['kirk-tablist-wrapper', tablistWrapperClassName])}>
+      <div role="presentation" className={cc(className)}>
+        <div
+          ref={this.tabsGroupRef}
+          className={cc(['kirk-tabs', tabsClassName, { 'kirk-tabs-fixed': isFixedTabs }])}
+        >
+          <div className={cc(['kirk-tablist-wrapper'])}>
             <div className="kirk-tab-highlight" ref={this.highlightRef} />
             <div
               role="tablist"
               aria-orientation="horizontal"
               aria-multiselectable="false"
-              className={cc(['kirk-tablist', { 'kirk-tablist-wrapped': isWrapped }])}
+              className={cc('kirk-tablist')}
             >
               {tabs.map(tab => {
                 const isSelected = selectedTab.id === tab.id
@@ -194,7 +195,7 @@ export class Tabs extends PureComponent<TabsProps, TabsState> {
                   >
                     <button
                       role="tab"
-                      aria-controls={`${generateTabPanelId(tab)}`}
+                      aria-controls={generateTabPanelId(tab)}
                       aria-selected={isSelected ? 'true' : 'false'}
                       title={`${tab.label}${tab.badgeAriaLabel ? ` ${tab.badgeAriaLabel}` : ''}`}
                       tabIndex={isSelected ? 0 : -1}
@@ -227,22 +228,24 @@ export class Tabs extends PureComponent<TabsProps, TabsState> {
             </div>
           </div>
         </div>
-        {tabs.map(tab => {
-          const isSelected = selectedTab.id === tab.id
-          return (
-            <div
-              role="tabpanel"
-              className="kirk-tab-panel"
-              id={`${generateTabPanelId(tab)}`}
-              key={tab.id}
-              aria-labelledby={tab.id}
-              hidden={!isSelected}
-            >
-              {isSelected ? tab.panelContent : null}
-            </div>
-          )
-        })}
-      </Fragment>
+        <div className="kirk-panels-section" role="presentation">
+          {tabs.map(tab => {
+            const isSelected = selectedTab.id === tab.id
+            return (
+              <div
+                role="tabpanel"
+                className="kirk-tab-panel"
+                id={generateTabPanelId(tab)}
+                key={tab.id}
+                aria-labelledby={tab.id}
+                hidden={!isSelected}
+              >
+                {isSelected ? tab.panelContent : null}
+              </div>
+            )
+          })}
+        </div>
+      </div>
     )
   }
 }

--- a/src/tabs/__snapshots__/Tabs.unit.tsx.snap
+++ b/src/tabs/__snapshots__/Tabs.unit.tsx.snap
@@ -1,7 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Rendering testing should render properly 1`] = `
-Array [
+<div
+  className=""
+  role="presentation"
+>
   <div
     className="kirk-tabs"
   >
@@ -85,44 +88,48 @@ Array [
         </div>
       </div>
     </div>
-  </div>,
+  </div>
   <div
-    aria-labelledby="tab1"
-    className="kirk-tab-panel"
-    hidden={false}
-    id="tab1_panel"
-    role="tabpanel"
+    className="kirk-panels-section"
+    role="presentation"
   >
     <div
-      style={
-        Object {
-          "padding": 30,
-        }
-      }
+      aria-labelledby="tab1"
+      className="kirk-tab-panel"
+      hidden={false}
+      id="tab1_panel"
+      role="tabpanel"
     >
-      Content for first tab
+      <div
+        style={
+          Object {
+            "padding": 30,
+          }
+        }
+      >
+        Content for first tab
+      </div>
     </div>
-  </div>,
-  <div
-    aria-labelledby="tab2"
-    className="kirk-tab-panel"
-    hidden={true}
-    id="tab2_panel"
-    role="tabpanel"
-  />,
-  <div
-    aria-labelledby="tab3"
-    className="kirk-tab-panel"
-    hidden={true}
-    id="tab3_panel"
-    role="tabpanel"
-  />,
-]
+    <div
+      aria-labelledby="tab2"
+      className="kirk-tab-panel"
+      hidden={true}
+      id="tab2_panel"
+      role="tabpanel"
+    />
+    <div
+      aria-labelledby="tab3"
+      className="kirk-tab-panel"
+      hidden={true}
+      id="tab3_panel"
+      role="tabpanel"
+    />
+  </div>
+</div>
 `;
 
 exports[`Rendering testing should render properly with icons 1`] = `
-Array [
-  .c0.kirk-icon-wrapper {
+.c0.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
@@ -139,6 +146,10 @@ Array [
 }
 
 <div
+  className=""
+  role="presentation"
+>
+  <div
     className="kirk-tabs"
   >
     <div
@@ -260,37 +271,42 @@ Array [
         </div>
       </div>
     </div>
-  </div>,
+  </div>
   <div
-    aria-labelledby="iconTab1"
-    className="kirk-tab-panel"
-    hidden={false}
-    id="iconTab1_panel"
-    role="tabpanel"
+    className="kirk-panels-section"
+    role="presentation"
   >
     <div
-      style={
-        Object {
-          "padding": 30,
-        }
-      }
+      aria-labelledby="iconTab1"
+      className="kirk-tab-panel"
+      hidden={false}
+      id="iconTab1_panel"
+      role="tabpanel"
     >
-      Content for first tab
+      <div
+        style={
+          Object {
+            "padding": 30,
+          }
+        }
+      >
+        Content for first tab
+      </div>
     </div>
-  </div>,
-  <div
-    aria-labelledby="iconTab2"
-    className="kirk-tab-panel"
-    hidden={true}
-    id="iconTab2_panel"
-    role="tabpanel"
-  />,
-  <div
-    aria-labelledby="iconTab3"
-    className="kirk-tab-panel"
-    hidden={true}
-    id="iconTab3_panel"
-    role="tabpanel"
-  />,
-]
+    <div
+      aria-labelledby="iconTab2"
+      className="kirk-tab-panel"
+      hidden={true}
+      id="iconTab2_panel"
+      role="tabpanel"
+    />
+    <div
+      aria-labelledby="iconTab3"
+      className="kirk-tab-panel"
+      hidden={true}
+      id="iconTab3_panel"
+      role="tabpanel"
+    />
+  </div>
+</div>
 `;

--- a/src/tabs/index.tsx
+++ b/src/tabs/index.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { color, componentSizes, font, space, transition } from '_utils/branding'
+import { color, font, space, transition } from '_utils/branding'
 
 import Tabs from './Tabs'
 
@@ -10,7 +10,8 @@ const StyledTabs = styled(Tabs)`
     position: relative;
   }
 
-  & .kirk-tablist-wrapper {
+  & .kirk-tabs {
+    margin-bottom: ${space.l};
     border-bottom: 1px solid ${color.border};
   }
 
@@ -26,11 +27,6 @@ const StyledTabs = styled(Tabs)`
     display: none;
   }
 
-  & .kirk-tablist-wrapped {
-    width: ${componentSizes.smallSectionWidth};
-    padding: 0 ${space.xl};
-  }
-
   & .kirk-tab {
     display: flex;
     align-items: center;
@@ -39,7 +35,7 @@ const StyledTabs = styled(Tabs)`
     width: 100%;
     height: 100%;
     outline: none;
-    padding: ${space.l};
+    padding: ${space.l} ${space.xl};
     background: none;
     border: none;
     background-color: ${color.white};
@@ -63,7 +59,6 @@ const StyledTabs = styled(Tabs)`
   }
 
   & .kirk-tab-container {
-    margin-left: ${space.l};
     display: flex;
     justify-content: center;
     align-items: last baseline;

--- a/src/tabs/story.tsx
+++ b/src/tabs/story.tsx
@@ -13,8 +13,8 @@ const stories = storiesOf('Widgets|Tabs', module)
 stories.addDecorator(withKnobs)
 
 const panels = [
-  <div style={{ padding: 30 }}>Content for first tab</div>,
-  <div style={{ padding: 30 }}>
+  <div>Content for first tab</div>,
+  <div>
     <Button
       onClick={() => {
         action('onClickButton')
@@ -23,14 +23,13 @@ const panels = [
       Button inside panel 2.
     </Button>
   </div>,
-  <div style={{ padding: 30 }}>Content for tab3</div>,
+  <div>Content for tab3</div>,
 ]
 
 stories.add('default', () => {
   const defaultTabsConfig = {
     activeTabId: 'tab1',
     status: select('status', TabStatus, TabStatus.SCROLLABLE),
-    isWrapped: boolean('isWrapped', false),
     tabs: [
       {
         id: 'tab1',
@@ -60,7 +59,6 @@ stories.add('default', () => {
         tabs={defaultTabsConfig.tabs}
         activeTabId={defaultTabsConfig.activeTabId}
         status={defaultTabsConfig.status}
-        isWrapped={defaultTabsConfig.isWrapped}
       />
     </Section>
   )
@@ -70,7 +68,6 @@ stories.add('with icons', () => {
   const iconTabsConfig = {
     activeTabId: 'tab1',
     status: select('status', TabStatus, TabStatus.FIXED),
-    isWrapped: boolean('isWrapped', false),
     tabs: [
       {
         id: 'tab1',
@@ -112,7 +109,6 @@ stories.add('with icons', () => {
         tabs={iconTabsConfig.tabs}
         activeTabId={iconTabsConfig.activeTabId}
         status={iconTabsConfig.status}
-        isWrapped={iconTabsConfig.isWrapped}
       />
     </Section>
   )


### PR DESCRIPTION
The core issue was: Some responsive layout was both in Tabs, TabsSection and in Kairos. With this PR, the Tabs is just a full width component, no padding, no wrapped. All layout code (reponsive, paddings) is inside TabsSection. The TabsSection is now divided into 2 full witdh subsections (one for the tabs, one for the panels) which are full width (and does not use a BaseSection anymore) and it sets layout contrains on nested elements inside these sub sections. Having this full width subsection for the tab list gives a perfect container to set the full width separator border too: We don't need a double border in Tabs and TabsSection like before.

Complete changelog:
- create two new virtual sections inside the Tabs => one for the tab lists, one for the panels. Each section is full width but can have constrained elements inside depending on viewport
- remove isWrapped props and replace it with media queries on kirk side
- add margin bottom below tabs (to remove margin bottom from kairos)
- remove unused tablistWrapperClassName
- add wrapper around tabs and panels
- create new tabsClassName (previously className)
- Remove paddings on panels in stories for Tabs and TabsSection to ensure proper vertical alignment between tabs/content
- no more double border (one from TabsSection overlapping one from Tabs). Only one defined on Tabs.
- proper fullwidth layout to remove the negative margins from Kairos

TESTED=Locally in storybook for tabs and tabssection. Locally in kairos (both in small/large/sticky modes on SRP) with this integration branch: BOYSCOUT-integrate-tabs-overhaul