### PR TITLE
[BBC-5337] Upgrade `Modal` with `TheVoice` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Unreleased
 
-- [...]
+- **[UPDATE]** Update `TheVoice` component to be applied on dark backgrounds. `ConfirmationModal` and `SuccessModal` now use `TheVoice` component.
 
 # v21.0.1 (17/02/2020)
 
 - **[FIX]** Fix `RotateIcon` viewbox
 
 # v21.0.0 (14/02/2020)
+
 - **[NEW]** Implement `Paragraph` widget
 - **[BREAKING CHANGE]** `Tabs` and `TabsSection` layout/spacing overhaul
 
@@ -18,7 +19,6 @@
 
 - **[FIX]** `Itinerary` subLabel rendered in case of stopovers
 - **[FIX]** Add border radius, article tag name, proper image position and title alignment for `MediaContentSection` section.
-
 
 # v20.1.0 (12/02/2020)
 

--- a/src/confirmationModal/ConfirmationModal.tsx
+++ b/src/confirmationModal/ConfirmationModal.tsx
@@ -5,6 +5,7 @@ import { color } from '_utils/branding'
 import Button, { ButtonStatus } from 'button'
 import Modal, { ModalSize } from 'modal'
 import { ModalProps } from 'modal/Modal'
+import TheVoice from 'theVoice'
 import CrossIcon from 'icon/crossIcon'
 import WarningIcon from 'icon/warningIcon'
 import InfoIcon from 'icon/infoIcon'
@@ -26,6 +27,7 @@ export interface ConfirmationModalProps extends ModalProps {
   readonly confirmLabel?: string
   readonly confirmIsLoading?: boolean
   readonly size?: ModalSize
+  readonly children?: string
 }
 
 class ConfirmationModal extends Component<ConfirmationModalProps> {
@@ -98,7 +100,9 @@ class ConfirmationModal extends Component<ConfirmationModalProps> {
       >
         <div className={`${baseClassName}-dialog`}>
           {getIcon()}
-          <div className={`${baseClassName}-body`}>{children}</div>
+          <div className={`${baseClassName}-body`}>
+            <TheVoice isInverted>{children}</TheVoice>
+          </div>
           <footer className={`${baseClassName}-footer`}>
             {isWarning && (
               <Button

--- a/src/confirmationModal/ConfirmationModal.tsx
+++ b/src/confirmationModal/ConfirmationModal.tsx
@@ -27,7 +27,6 @@ export interface ConfirmationModalProps extends ModalProps {
   readonly confirmLabel?: string
   readonly confirmIsLoading?: boolean
   readonly size?: ModalSize
-  readonly children?: string
 }
 
 class ConfirmationModal extends Component<ConfirmationModalProps> {

--- a/src/confirmationModal/index.tsx
+++ b/src/confirmationModal/index.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { color, space, font, modalSize, fontWeight } from '_utils/branding'
+import { color, space, modalSize } from '_utils/branding'
 import ConfirmationModal from './ConfirmationModal'
 
 const footerHeight = '96px' /* = padding + content */
@@ -40,9 +40,6 @@ const StyledConfirmationModal = styled(ConfirmationModal)`
 
   & .kirk-confirmationModal-body {
     padding: ${space.xl};
-    font-size: ${font.xl.size};
-    line-height: ${font.xl.lineHeight};
-    font-weight: ${fontWeight.medium};
   }
 
   & .kirk-confirmationModal-icon {

--- a/src/confirmationModal/specifications/confirmationModal.md
+++ b/src/confirmationModal/specifications/confirmationModal.md
@@ -1,4 +1,4 @@
-# ConfirmationModal
+# `ConfirmationModal`
 
 ```js
 import { confirmationModal, ConfirmationModalStatus } from '@blablacar/ui-library'

--- a/src/confirmationModal/story.tsx
+++ b/src/confirmationModal/story.tsx
@@ -43,10 +43,8 @@ class ConfirmationModalOpener extends Component<ConfirmationModalProps> {
           isOpen={this.state.confirmationModalOpen}
           confirmIsLoading={this.props.confirmIsLoading}
         >
-          <div>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-            incididunt ut labore et dolore magna aliqua.
-          </div>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+          ut labore et dolore magna aliqua.
         </ConfirmationModal>
       </Section>
     )

--- a/src/confirmationModal/story.tsx
+++ b/src/confirmationModal/story.tsx
@@ -8,7 +8,7 @@ import { ConfirmationModalProps, ConfirmationModalSize } from './ConfirmationMod
 import ConfirmationModal, { ConfirmationModalStatus } from 'confirmationModal'
 import confirmationModalDoc from './specifications/confirmationModal.md'
 
-const stories = storiesOf('Widgets|ConfirmationModal', module)
+const stories = storiesOf('Widgets|Modal|ConfirmationModal', module)
 stories.addDecorator(withKnobs)
 
 class ConfirmationModalOpener extends Component<ConfirmationModalProps> {
@@ -54,7 +54,7 @@ class ConfirmationModalOpener extends Component<ConfirmationModalProps> {
 }
 
 stories.add(
-  'Warning',
+  'warning',
   () => (
     <ConfirmationModalOpener
       status={ConfirmationModalStatus.WARNING}
@@ -72,7 +72,7 @@ stories.add(
 )
 
 stories.add(
-  'Reminder',
+  'reminder',
   () => (
     <ConfirmationModalOpener
       status={ConfirmationModalStatus.REMINDER}

--- a/src/successModal/SuccessModal.tsx
+++ b/src/successModal/SuccessModal.tsx
@@ -68,7 +68,7 @@ class SuccessModal extends Component<SuccessModalProps> {
           aria-hidden
         />
         <div id={successContentId} className={`${baseClassName}-bodyItem`}>
-          <TheVoice>{children}</TheVoice>
+          <TheVoice isInverted>{children}</TheVoice>
           <footer className={`${baseClassName}-footer`}>
             <Button
               status={ButtonStatus.SECONDARY}

--- a/src/successModal/SuccessModal.tsx
+++ b/src/successModal/SuccessModal.tsx
@@ -11,7 +11,6 @@ export interface SuccessModalProps extends ModalProps {
   readonly confirmLabel?: string
   readonly imageSrc: string
   readonly imageText?: string
-  readonly children?: string
 }
 
 export enum SuccessModalSize {

--- a/src/successModal/SuccessModal.tsx
+++ b/src/successModal/SuccessModal.tsx
@@ -3,8 +3,7 @@ import React, { Component } from 'react'
 import Modal, { ModalSize } from 'modal'
 import { ModalProps } from 'modal/Modal'
 import Button, { ButtonStatus } from 'button'
-import Text, { TextTagType, TextDisplayType } from 'text'
-import { color } from '_utils/branding'
+import TheVoice from 'theVoice'
 import { assertModalSizes } from '_utils/assert'
 import uuidv4 from 'uuid/v4'
 
@@ -12,6 +11,7 @@ export interface SuccessModalProps extends ModalProps {
   readonly confirmLabel?: string
   readonly imageSrc: string
   readonly imageText?: string
+  readonly children?: string
 }
 
 export enum SuccessModalSize {
@@ -68,13 +68,7 @@ class SuccessModal extends Component<SuccessModalProps> {
           aria-hidden
         />
         <div id={successContentId} className={`${baseClassName}-bodyItem`}>
-          <Text
-            display={TextDisplayType.SUBHEADER}
-            tag={TextTagType.PARAGRAPH}
-            textColor={color.white}
-          >
-            {children}
-          </Text>
+          <TheVoice>{children}</TheVoice>
           <footer className={`${baseClassName}-footer`}>
             <Button
               status={ButtonStatus.SECONDARY}

--- a/src/successModal/SuccessModal.unit.tsx
+++ b/src/successModal/SuccessModal.unit.tsx
@@ -36,7 +36,7 @@ describe('<SuccessModal>', () => {
 
   it('Should have proper linked id to the content text', () => {
     const ariaLabelledByValue = wrapperOpen.find('.kirk-successModal').prop('aria-labelledby')
-    expect(wrapperOpen.find(`#${ariaLabelledByValue} p`).text()).toEqual('Success description')
+    expect(wrapperOpen.find(`#${ariaLabelledByValue} h1`).text()).toEqual('Success description')
   })
 
   it('Should have a confirmation button and call the according function when click on it', () => {

--- a/src/successModal/specifications/successModal.md
+++ b/src/successModal/specifications/successModal.md
@@ -1,4 +1,4 @@
-# Modal
+# Success Modal
 
 ```js
 import { successModal } from '@blablacar/ui-library'

--- a/src/successModal/story.tsx
+++ b/src/successModal/story.tsx
@@ -8,7 +8,8 @@ import SuccessModal from 'successModal'
 import { SuccessModalProps, SuccessModalSize } from './SuccessModal'
 import successModalDoc from './specifications/successModal.md'
 
-const stories = storiesOf('Widgets|SuccessModal', module)
+const stories = storiesOf('Widgets|Modal|SuccessModal', module)
+
 stories.addDecorator(withKnobs)
 
 class SuccessModalOpener extends Component<SuccessModalProps> {
@@ -42,7 +43,7 @@ class SuccessModalOpener extends Component<SuccessModalProps> {
 }
 
 stories.add(
-  'SuccessModal',
+  'success',
   () => (
     <SuccessModalOpener
       isOpen={false}

--- a/src/theVoice/TheVoice.tsx
+++ b/src/theVoice/TheVoice.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 import Title from 'title'
 
 export interface TheVoiceProps {
   readonly id?: string
   readonly className?: Classcat.Class
-  readonly children: string
+  readonly children: ReactNode
   readonly isInverted?: boolean
 }
 

--- a/src/theVoice/TheVoice.tsx
+++ b/src/theVoice/TheVoice.tsx
@@ -5,12 +5,16 @@ export interface TheVoiceProps {
   readonly id?: string
   readonly className?: Classcat.Class
   readonly children: string
+  readonly isInverted?: boolean
 }
 
-const TheVoice = ({ id, className, children }: TheVoiceProps) => (
-  <Title id={id} className={className} headingLevel="1">
-    {children}
-  </Title>
-)
+const TheVoice = ({ id, className, children, isInverted = false }: TheVoiceProps) => {
+  const classes = isInverted ? `kirk-title--inverse ${className}` : className
+  return (
+    <Title id={id} className={classes} headingLevel="1">
+      {children}
+    </Title>
+  )
+}
 
 export default TheVoice

--- a/src/theVoice/index.tsx
+++ b/src/theVoice/index.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { space, font, responsiveBreakpoints } from '_utils/branding'
+import { space, color, font, responsiveBreakpoints } from '_utils/branding'
 
 import TheVoice from './TheVoice'
 
@@ -8,6 +8,10 @@ const StyledTheVoice = styled(TheVoice)`
     text-align: center;
     font-size: ${font.xl.size};
     margin: ${space.xxl} 0;
+  }
+
+  &.kirk-title--inverse {
+    color: ${color.textWithBackground};
   }
 
   @media (${responsiveBreakpoints.isMediaSmall}) {

--- a/src/theVoice/specifications/theVoice.md
+++ b/src/theVoice/specifications/theVoice.md
@@ -30,7 +30,7 @@ When screen width is less than 800px:
 
 **COLORS**
 
-It can switch colors when applyed to darker backgrounds.
+It can switch colors when applied to darker backgrounds.
 
 > Long texts
 

--- a/src/theVoice/specifications/theVoice.md
+++ b/src/theVoice/specifications/theVoice.md
@@ -1,4 +1,3 @@
-
 ## The Voice
 
 ```js
@@ -7,7 +6,7 @@ import { TheVoice } from '@blablacar/ui-library'
 
 ```html
 <TheVoice>
-    This is the Voice!
+  This is the Voice!
 </TheVoice>
 ```
 
@@ -16,17 +15,23 @@ import { TheVoice } from '@blablacar/ui-library'
 > Behaviour
 
 Use it to guide the member on what to do in the screen.
-This component is the core of our conversational approach.
+This component is the core of our **conversational approach**.
 
 The voice is not clickable.
 It’s not sticky but when scrolling it slides under the topbar.
 
+**SIZING AND POSITIONING**
+
 Tall viewport, above 800px: Text is centered, font size is 32px.
 When screen width is less than 800px:
- - the font size moves down to 22px.
- - the text becomes left-aligned instead of centered
+
+- the font size moves down to 22px.
+- the text becomes left-aligned instead of centered
+
+**COLORS**
+
+It can switch colors when applyed to darker backgrounds.
 
 > Long texts
 
 There’s no limitation on the number of lines.
-

--- a/src/theVoice/story.tsx
+++ b/src/theVoice/story.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 
 import { storiesOf } from '@storybook/react'
-import { withKnobs } from '@storybook/addon-knobs'
+import { withKnobs, boolean, text } from '@storybook/addon-knobs'
 import Section from 'layout/section/baseSection'
 import TheVoice from '.'
 import readme from 'theVoice/specifications/theVoice.md'
@@ -13,8 +13,17 @@ stories.add('Specifications', () => null, {
   readme: { content: readme },
 })
 
-stories.add('Default (responsive based on width)', () => (
-  <Section>
-    <TheVoice>This is the Voice !</TheVoice>
-  </Section>
+stories.add('default', () => (
+  <Fragment>
+    <Section>
+      <TheVoice id={text('id', 'MyId')} className={text('className', 'other-classes')}>
+        This is the Voice !
+      </TheVoice>
+    </Section>
+    <Section>
+      <div style={{ backgroundColor: 'lightgreen' }}>
+        <TheVoice isInverted={boolean('isInverted', true)}>This is inverted The Voice !</TheVoice>
+      </div>
+    </Section>
+  </Fragment>
 ))

--- a/src/title/Title.tsx
+++ b/src/title/Title.tsx
@@ -1,10 +1,10 @@
-import React, { Fragment } from 'react'
+import React, { Fragment, ReactNode } from 'react'
 import cc from 'classcat'
 
 export interface TitleProps {
   readonly id?: string
   readonly className?: Classcat.Class
-  readonly children: string
+  readonly children: ReactNode
   readonly headingLevel?: number | string
 }
 


### PR DESCRIPTION
## Description
Update **Modal** component to receive `TheVoice`

## What has been done

- `TheVoice` component now receive a prop `isInverted` to define its color `title` or `textWithBackground`. It receives a modifier class `.kirk-title--inverted`.
- `ConfirmationModal` and `SuccessModal` now use `TheVoice` component
- Move around **Modals stories** (SuccessModal, ConfirmationModal) to improve discoverability/heuristics. _We could also consider to move folders_

## Warnings  / Things to pay attention to
- I've declare `children` as `string` since we had only text as child... **I don't feel its a good practice.. What do you think?!**

## Last considerations
It's my first PR, so please be kind! 🗡 
