### PR TITLE
Introduce new LayoutNormalizer component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[NEW]** Introduce `LayoutNormalizer` with legacy global layout overrides. Not activated by default.
 - [...]
 
 # v21.1.0 (19/02/2020)

--- a/src/layout/layoutNormalizer.tsx
+++ b/src/layout/layoutNormalizer.tsx
@@ -1,0 +1,50 @@
+import { createGlobalStyle } from 'styled-components'
+import React from 'react'
+
+// Legacy layout rules from production BBC.
+const LegacyLayoutNormalizationGlobalStyles = createGlobalStyle`
+    /* Items negative margins from legacy layouts. */
+    .kirk-item.kirk-item--clickable {
+        margin-left: -24px;
+        margin-right: -24px;
+        padding-left: 24px;
+        padding-right: 24px;
+    }
+    button.kirk-item.kirk-item--clickable {
+        width: calc(100% + 48px); /* fixes button width not scaling with negative margins */
+    }
+    .kirk-autoComplete {
+        margin-left: -24px;
+        margin-right: -24px;
+    }
+    
+    .home-column .kirk-item.kirk-item--clickable,
+    .user-menu-item.kirk-item.kirk-item--clickable,
+    .addressField .kirk-item.kirk-item--clickable {
+        margin-left: 0;
+        margin-right: 0;
+    }
+    .home-column button.kirk-item.kirk-item--clickable,
+    button.user-menu-item.kirk-item.kirk-item--clickable,
+    .addressField button.kirk-item.kirk-item--clickable {
+        max-width: 100%;
+    }
+`
+
+const LayoutNormalizationGlobalStyles = createGlobalStyle`
+  // Add normalization styles.
+`
+
+export interface LayoutNormalizerProps {
+  readonly useLegacyNormalization?: boolean
+}
+
+const LayoutNormalizer = ({ useLegacyNormalization = true }: LayoutNormalizerProps) => {
+  if (useLegacyNormalization) {
+    return <LegacyLayoutNormalizationGlobalStyles />
+  }
+
+  return <LayoutNormalizationGlobalStyles />
+}
+
+export default LayoutNormalizer

--- a/src/pages/messaging/brazemarketing.story.tsx
+++ b/src/pages/messaging/brazemarketing.story.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react'
 
 import { storiesOf } from '@storybook/react'
+import { boolean } from '@storybook/addon-knobs'
 import Section from 'layout/section/baseSection'
 import SubHeader from 'subHeader'
 import Text from 'text'
@@ -9,13 +10,16 @@ import Button from 'button'
 import ItemInfo from 'itemInfo'
 import Avatar from 'avatar'
 import MarketingMessage from 'marketingMessage'
+import LayoutNormalizer from 'layout/layoutNormalizer'
 
 const stories = storiesOf('Pages|Messaging/Braze marketing', module)
 
 const avatarUrl = 'https://pbs.twimg.com/profile_images/749446875162505218/6r6-9wDn.jpg'
 const longContent = 'Long content.'.repeat(50)
+
 stories.add('Default', () => (
   <Fragment>
+    <LayoutNormalizer useLegacyNormalization={boolean('Use legacy normalization', false)} />
     <Section>
       <ItemInfo mainInfo="" mainTitle="BlaBlaCar" icon={<Avatar image={avatarUrl} />} />
       <MarketingMessage>

--- a/src/pages/messaging/inbox.story.tsx
+++ b/src/pages/messaging/inbox.story.tsx
@@ -1,12 +1,14 @@
 import React, { Fragment } from 'react'
 
 import { storiesOf } from '@storybook/react'
+import { boolean } from '@storybook/addon-knobs'
 import Section from 'layout/section/baseSection'
 import TabsSection from 'layout/section/tabsSection'
 import TheVoice from 'theVoice'
 import ClockIcon from 'icon/clockIcon'
 import ItemAction from 'itemAction'
 import MessagingSummaryItem from 'messagingSummaryItem'
+import LayoutNormalizer from 'layout/layoutNormalizer'
 
 const stories = storiesOf('Pages|Messaging/Inbox', module)
 
@@ -67,6 +69,7 @@ const defaultTabsConfig = {
 
 stories.add('Default', () => (
   <Fragment>
+    <LayoutNormalizer useLegacyNormalization={boolean('Use legacy normalization', false)} />
     <Section>
       <TheVoice>Inbox</TheVoice>
     </Section>

--- a/src/pages/ridedetails/carpool.story.tsx
+++ b/src/pages/ridedetails/carpool.story.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react'
 
 import { storiesOf } from '@storybook/react'
+import { boolean } from '@storybook/addon-knobs'
 import Section from 'layout/section/baseSection'
 import TheVoice from 'theVoice'
 import Itinerary from 'itinerary'
@@ -12,11 +13,13 @@ import ItemAction from 'itemAction'
 import ItemInfo from 'itemInfo'
 import { PetIcon, SmokeIcon, BubbleIcon } from 'icon'
 import SubHeader from 'subHeader'
+import LayoutNormalizer from 'layout/layoutNormalizer'
 
 const stories = storiesOf('Pages|Ride details/Carpool', module)
 
 stories.add('Default', () => (
   <Fragment>
+    <LayoutNormalizer useLegacyNormalization={boolean('Use legacy normalization', false)} />
     <Section>
       <TheVoice>Ven. 11 octobre</TheVoice>
       <Itinerary


### PR DESCRIPTION
This component role is to install layout normalization CSS **global** rules.
It has a **useLegacyNormalization** mode which is used to import the layout override from production  BBC. When this useLegacyNormalization mode is disabled, the new normalization rules will be used instead (currently empty, it will come in future normalization PRs).

This component will allow us to move layout rules from BBC to kirk and have an easy toggle (controlled by a feature flag) to control the layout normalization mode on production BBC and kirk pages (ridedetails, etc).