### PR TITLE
[BBC-6919] Fix Datepicker on small screen.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - **[UPDATE]** Add autoComplete attribute on `SelectField` and `PhoneField` components.
 - **[UPDATE]** Change autoComplete type on `TextField` to allow other values than `on` and `off`.
 - **[FIX]** Fix `TripsSection` left scroll padding issue
+- **[FIX]** Fix `Datepicker` previous month selection on vertical mode if selected date is far in the future
 - [..]
 
 # v22.1.1 (28/02/2020)

--- a/src/datePicker/DatePicker.unit.tsx
+++ b/src/datePicker/DatePicker.unit.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import renderer from 'react-test-renderer'
 import DayPicker, { NavbarElementProps, CaptionElementProps } from 'react-day-picker'
 import DatePicker, { DatePickerOrientation } from './DatePicker'
@@ -64,19 +64,69 @@ describe('DatePicker', () => {
   describe('react-day-picker', () => {
     it('Should forward props to the DayPicker component', () => {
       const now = new Date()
-      const wrapper = shallow(
-        <DatePicker name="datepicker" initialDate={now} numberOfMonths={12} />,
-      )
+      const wrapper = mount(<DatePicker name="datepicker" initialDate={now} />)
       const instance = wrapper.instance()
 
-      expect(wrapper.find(DayPicker).prop('numberOfMonths')).toEqual(12)
+      expect(wrapper.find(DayPicker).prop('numberOfMonths')).toEqual(2)
       expect(wrapper.find(DayPicker).prop('selectedDays')).toEqual(now)
-      expect(wrapper.find(DayPicker).prop('initialMonth')).toEqual(now)
       expect(wrapper.find(DayPicker).prop('onDayClick')).toEqual(instance.onDayClick)
       expect(wrapper.find(DayPicker).prop('navbarElement')).toEqual(instance.renderNavbar)
       expect(wrapper.find(DayPicker).prop('captionElement')).toEqual(instance.renderCaption)
       expect(wrapper.find(DayPicker).prop('renderDay')).toEqual(instance.renderDay)
       expect(wrapper.find(DayPicker).prop('firstDayOfWeek')).toEqual(0)
+    })
+
+    it('Should forward same value for selectedDays and initialMonth props to the DayPicker component', () => {
+      const initialDate = new Date()
+      initialDate.setMonth(initialDate.getMonth() + 6)
+      const wrapper = mount(
+        <DatePicker
+          name="datepicker"
+          initialDate={initialDate}
+          initialMonth={initialDate}
+          numberOfMonths={12}
+        />,
+      )
+
+      expect(wrapper.find(DayPicker).prop('numberOfMonths')).toEqual(12)
+      expect(wrapper.find(DayPicker).prop('selectedDays')).toEqual(initialDate)
+      expect(wrapper.find(DayPicker).prop('initialMonth')).toEqual(initialDate)
+    })
+
+    it('Should forward only selectedDays and keep default initialMonth props to the DayPicker component', () => {
+      const offsetTop = 1000
+      const stickyPositionTop = 50
+      window.scrollTo = jest.fn()
+      Object.defineProperty(HTMLElement.prototype, 'offsetTop', {
+        configurable: true,
+        value: offsetTop,
+      })
+
+      const initialDate = new Date()
+      initialDate.setMonth(initialDate.getMonth() + 6)
+      const wrapper = mount(
+        <DatePicker
+          name="datepicker"
+          initialDate={initialDate}
+          numberOfMonths={12}
+          stickyPositionTop={stickyPositionTop}
+        />,
+      )
+
+      expect(wrapper.find(DayPicker).prop('numberOfMonths')).toEqual(12)
+      expect(wrapper.find(DayPicker).prop('selectedDays')).toEqual(initialDate)
+      expect(wrapper.find(DayPicker).prop('initialMonth')).not.toEqual(initialDate)
+      expect(window.scrollTo).toHaveBeenCalledWith(0, offsetTop + stickyPositionTop)
+    })
+
+    afterEach(() => {
+      // Reset offsetTop
+      Object.defineProperty(HTMLElement.prototype, 'offsetTop', {
+        configurable: true,
+        value: 0,
+      })
+
+      jest.clearAllMocks()
     })
   })
 })

--- a/src/datePicker/story.tsx
+++ b/src/datePicker/story.tsx
@@ -90,3 +90,20 @@ stories.add('example vertical (6 months)', () => (
     />
   </Section>
 ))
+
+stories.add('example vertical (12 months - selected date in 6 months)', () => {
+  const initialeDate = new Date()
+  initialeDate.setMonth(initialeDate.getMonth() + 6)
+
+  return (
+    <Section>
+      <DatePicker
+        initialDate={initialeDate}
+        name="datepicker"
+        onChange={action('onChange')}
+        orientation={DatePickerOrientation.VERTICAL}
+        numberOfMonths={12}
+      />
+    </Section>
+  )
+})


### PR DESCRIPTION
Previously if we selected date in few months and opened the datepicker again. The first available month was the one that have been selected and it was impossible to scroll up to the current month.

![2](https://user-images.githubusercontent.com/3979553/75563715-17689b80-5a4b-11ea-9835-a2cd69a1c7e0.gif)
