### PR TITLE
Add autoComplete attribute on SelectField and PhoneField components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- **[UPDATE]** Add autoComplete attribute on `SelectField` and `PhoneField` components.
+- **[UPDATE]** Change autoComplete type on `TextField` to allow other values than `on` and `off`.
 - [..]
 
 # v22.1.1 (28/02/2020)

--- a/src/phoneField/PhoneField.tsx
+++ b/src/phoneField/PhoneField.tsx
@@ -244,6 +244,7 @@ export default class PhoneField extends PureComponent<PhoneFieldProps, PhoneFiel
             onBlur={this.onBlur}
             focusBorder={!isInline}
             autoFocus={selectAutoFocus}
+            autoComplete="tel-country-code"
             ref={this.ref}
           />
           <TextField
@@ -256,6 +257,7 @@ export default class PhoneField extends PureComponent<PhoneFieldProps, PhoneFiel
             onFocus={this.onFocus}
             onBlur={this.onBlur}
             focusBorder={!isInline}
+            autoComplete="tel-national"
           />
         </div>
         {!!error && DisplayError(error)}

--- a/src/phoneField/__snapshots__/PhoneField.unit.tsx.snap
+++ b/src/phoneField/__snapshots__/PhoneField.unit.tsx.snap
@@ -494,6 +494,7 @@ exports[`PhoneField should have the expected markup in the DOM with custom setti
     >
       <select
         aria-label="Phone Country code"
+        autoComplete="tel-country-code"
         autoFocus={true}
         defaultValue="ES"
         name="phoneRegion"
@@ -541,6 +542,7 @@ exports[`PhoneField should have the expected markup in the DOM with custom setti
         className="kirk-textField-wrapper"
       >
         <input
+          autoComplete="tel-national"
           name="phoneNumber"
           onBlur={[Function]}
           onChange={[Function]}
@@ -901,6 +903,7 @@ exports[`PhoneField should have the expected markup in the DOM with default sett
       className="kirk-selectField c1"
     >
       <select
+        autoComplete="tel-country-code"
         defaultValue=""
         name="phoneRegion"
         onBlur={[Function]}
@@ -947,6 +950,7 @@ exports[`PhoneField should have the expected markup in the DOM with default sett
         className="kirk-textField-wrapper"
       >
         <input
+          autoComplete="tel-national"
           name="phoneNumber"
           onBlur={[Function]}
           onChange={[Function]}

--- a/src/selectField/SelectField.tsx
+++ b/src/selectField/SelectField.tsx
@@ -15,6 +15,7 @@ export interface SelectFieldProps extends Partial<CommonFieldsProps> {
   readonly onBlur?: (event: React.FocusEvent<HTMLSelectElement>) => void
   readonly focus?: boolean
   readonly focusBorder?: boolean
+  readonly autoComplete?: string
 }
 
 const SelectField = React.forwardRef(
@@ -33,6 +34,7 @@ const SelectField = React.forwardRef(
       required,
       focus,
       autoFocus,
+      autoComplete,
       focusBorder = true,
     }: SelectFieldProps,
     ref: RefObject<HTMLSelectElement>,
@@ -71,6 +73,7 @@ const SelectField = React.forwardRef(
           disabled={disabled}
           required={required}
           autoFocus={autoFocus}
+          autoComplete={autoComplete}
           ref={ref}
         >
           {options.map(({ value, label, ariaLabel: optionAriaLabel }: SelectFieldItem) => (

--- a/src/textField/TextField.tsx
+++ b/src/textField/TextField.tsx
@@ -37,7 +37,7 @@ export interface CommonFormFields {
   placeholder?: string
   maxLength?: number
   autoCorrect?: 'on' | 'off'
-  autoComplete?: 'on' | 'off'
+  autoComplete?: string
   disabled?: boolean
   readOnly?: boolean
   autoFocus?: boolean


### PR DESCRIPTION
## Changes
- **[UPDATE]** Add autoComplete attribute on `SelectField` and `PhoneField` components.
- **[UPDATE]** Change autoComplete type on `TextField` to allow other values than `on` and `off`.

[MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete)

> "tel-country-code"
The country code, such as "1" for the United States, Canada, and other areas in North America and parts of the Caribbean.
> "tel-national"
The entire phone number without the country code component, including a country-internal prefix. For the phone number "1-855-555-6502", this field's value would be "855-555-6502".

## Preview
![image](https://user-images.githubusercontent.com/2495124/75693033-b3421380-5ca6-11ea-9424-1709fe20f247.png)
