### PR TITLE
improve tripCard layout and how text truncates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[UPDATE]** Improve `TripCard` layout to allow text to truncate.
 - [...]
 
 # v22.3.1 (10/03/2020)

--- a/src/_utils/itineraryLocation/ItineraryLocation.tsx
+++ b/src/_utils/itineraryLocation/ItineraryLocation.tsx
@@ -50,6 +50,7 @@ const renderTime = (isoDate: string, time: string) => (
 
 const renderMainLabel = (label: string) => (
   <Text
+    className="kirk-itineraryLocation-label-text"
     tag={TextTagType.PARAGRAPH}
     display={TextDisplayType.TITLESTRONG}
     textColor={color.primaryText}
@@ -61,6 +62,7 @@ const renderMainLabel = (label: string) => (
 const renderSubLabel = (label: ReactNode) =>
   typeof label === 'string' ? (
     <Text
+      className="kirk-itineraryLocation-label-text"
       tag={TextTagType.PARAGRAPH}
       display={TextDisplayType.CAPTION}
       textColor={color.primaryText}

--- a/src/_utils/itineraryLocation/index.tsx
+++ b/src/_utils/itineraryLocation/index.tsx
@@ -17,7 +17,6 @@ const StyledItineraryLocation = styled(ItineraryLocation)`
   & .kirk-itineraryLocation-wrapper {
     display: flex;
     padding: ${space.m} 0;
-    width: 100%;
   }
 
   & a.kirk-itineraryLocation-wrapper {
@@ -61,6 +60,12 @@ const StyledItineraryLocation = styled(ItineraryLocation)`
 
   & .kirk-itineraryLocation-label {
     flex: 1;
+    min-width: 0; /* reset flex default to allow shrinking below content width */
+  }
+
+  & .kirk-itineraryLocation-label-text {
+    text-overflow: ellipsis;
+    overflow: hidden;
   }
 
   &:not(.kirk-itineraryLocation--arrival) .kirk-itineraryLocation-city {

--- a/src/layout/section/tripsSection/index.tsx
+++ b/src/layout/section/tripsSection/index.tsx
@@ -24,6 +24,7 @@ const StyledTripsSection = styled(TripsSection)`
 
   & .kirk-tripsSection .kirk-tripCard {
     scroll-snap-align: start;
+    overflow: hidden;
   }
 
   /* Remove scrollbar webkit */

--- a/src/tripCard/TripCard.tsx
+++ b/src/tripCard/TripCard.tsx
@@ -9,7 +9,7 @@ import LadyIcon from 'icon/ladyIcon'
 import Star from 'icon/starIcon'
 import Itinerary from 'itinerary'
 import Item from '_utils/item'
-import Text, { TextDisplayType } from 'text'
+import Text, { TextDisplayType, TextTagType } from 'text'
 import { color } from '_utils/branding'
 
 /**
@@ -89,8 +89,10 @@ const TripCard = ({
 }: TripCardProps) => {
   const departure = itinerary[0]
   const arrival = itinerary[itinerary.length - 1]
-  const displayFlags = isEmpty(highlighted) && !isEmpty(flags)
   const itemPropName = `${departure.mainLabel} → ${arrival.mainLabel}`
+  const shouldDisplayBottomLeft = driver || !isEmpty(passengers)
+  const shouldDisplayBottomRight = !isEmpty(highlighted) || !isEmpty(flags)
+  const shouldDisplayBottom = shouldDisplayBottomLeft || shouldDisplayBottomRight
 
   let componentTag
   let componentProps = {}
@@ -119,6 +121,7 @@ const TripCard = ({
         {
           'kirk-tripCard--highlighted': !!highlighted,
           'kirk-tripCard--with-badge': badge && badge.length,
+          'kirk-tripCard--with-price': price && price.length,
         },
         className,
       ])}
@@ -161,52 +164,74 @@ const TripCard = ({
               {title}
             </Text>
           )}
-
-          <div className="kirk-tripCard-main">
-            <Itinerary className="kirk-tripCard-itinerary" places={itinerary} />
-            <Text className="kirk-tripCard-price" display={TextDisplayType.TITLESTRONG}>
-              {price}
-            </Text>
-          </div>
-          <div className="kirk-tripCard-bottom">
-            {driver && (
-              <div className="kirk-tripCard-driver">
-                <div className="kirk-tripCard-avatar">
-                  <Avatar image={driver.avatarUrl} />
-                </div>
-                <div>
-                  <Text display={TextDisplayType.TITLE}>{driver.firstName}</Text>
-                  {driver.rating && (
-                    <div className="kirk-tripCard-ratingContainer">
-                      <Star fill={1} size={16} />
-                      <Text className="kirk-tripCard-rating">{driver.rating}</Text>
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
-            {passengers && (
-              <ul className="kirk-tripCard-passengers">
-                {passengers.length > PASSENGERS_TO_DISPLAY &&
-                  renderMorePassengers(passengers.length - PASSENGERS_TO_DISPLAY + 1)}
-                {passengers.length === PASSENGERS_TO_DISPLAY &&
-                  renderPassenger(passengers[PASSENGERS_TO_DISPLAY - 1])}
-                {passengers
-                  .slice(0, PASSENGERS_TO_DISPLAY - 1)
-                  .reverse()
-                  .map(renderPassenger)}
-              </ul>
-            )}
-            {highlighted && (
-              <Text className="kirk-tripCard-topText" display={TextDisplayType.TITLESTRONG}>
-                {highlighted}
+          <div className="kirk-tripCard-mainContainer">
+            <div className="kirk-tripCard-main">
+              <Itinerary className="kirk-tripCard-itinerary" places={itinerary} />
+              <Text className="kirk-tripCard-price" display={TextDisplayType.TITLESTRONG}>
+                {price}
               </Text>
-            )}
-            {displayFlags && (
-              <div className="kirk-tripCard-flags">
-                {flags.ladiesOnly && <LadyIcon title={titles.ladiesOnly || ''} />}
-                {flags.maxTwo && <ComfortIcon title={titles.maxTwo || ''} />}
-                {flags.autoApproval && <LightningIcon title={titles.autoApproval || ''} />}
+            </div>
+
+            {shouldDisplayBottom && (
+              <div
+                className={cc([
+                  'kirk-tripCard-bottom',
+                  { 'kirk-tripCard-bottom--only-right': !shouldDisplayBottomLeft },
+                ])}
+              >
+                {shouldDisplayBottomLeft && (
+                  <div className="kirk-tripCard-bottom-left">
+                    {driver && (
+                      <div className="kirk-tripCard-driver">
+                        <Avatar className="kirk-tripCard-avatar" image={driver.avatarUrl} />
+                        <div className="kirk-tripCard-driver-info">
+                          <Text
+                            className="kirk-tripCard-driver-name"
+                            tag={TextTagType.PARAGRAPH}
+                            display={TextDisplayType.TITLE}
+                          >
+                            {driver.firstName}
+                          </Text>
+                          {driver.rating && (
+                            <div className="kirk-tripCard-ratingContainer">
+                              <Star fill={1} size={16} />
+                              <Text className="kirk-tripCard-rating">{driver.rating}</Text>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                    {!isEmpty(passengers) && (
+                      <ul className="kirk-tripCard-passengers">
+                        {passengers.length > PASSENGERS_TO_DISPLAY &&
+                          renderMorePassengers(passengers.length - PASSENGERS_TO_DISPLAY + 1)}
+                        {passengers.length === PASSENGERS_TO_DISPLAY &&
+                          renderPassenger(passengers[PASSENGERS_TO_DISPLAY - 1])}
+                        {passengers
+                          .slice(0, PASSENGERS_TO_DISPLAY - 1)
+                          .reverse()
+                          .map(renderPassenger)}
+                      </ul>
+                    )}
+                  </div>
+                )}
+
+                {shouldDisplayBottomRight && (
+                  <div className="kirk-tripCard-bottom-right">
+                    {!isEmpty(highlighted) && (
+                      <Text className="kirk-tripCard-topText" display={TextDisplayType.TITLESTRONG}>
+                        {highlighted}
+                      </Text>
+                    )}
+                    {isEmpty(highlighted) && !isEmpty(flags) && (
+                      <div className="kirk-tripCard-flags">
+                        {flags.ladiesOnly && <LadyIcon title={titles.ladiesOnly || ''} />}
+                        {flags.maxTwo && <ComfortIcon title={titles.maxTwo || ''} />}
+                        {flags.autoApproval && <LightningIcon title={titles.autoApproval || ''} />}
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
             )}
           </div>

--- a/src/tripCard/index.tsx
+++ b/src/tripCard/index.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { color, radius, space, componentSizes, transition } from '_utils/branding'
+import { color, font, radius, space, transition } from '_utils/branding'
 
 import TripCard from './TripCard'
 
@@ -17,6 +17,7 @@ const StyledTripCard = styled(TripCard)`
 
   & a {
     display: block;
+    height: 100%;
     padding: ${space.l};
     text-decoration: none;
   }
@@ -26,7 +27,7 @@ const StyledTripCard = styled(TripCard)`
     padding-top: ${space.xl};
   }
 
-  .kirk-tripCard-badge {
+  & .kirk-tripCard-badge {
     position: absolute;
     top: 0;
     background: ${color.primary};
@@ -34,73 +35,121 @@ const StyledTripCard = styled(TripCard)`
     border-radius: 0 0 ${radius.m} ${radius.m};
   }
 
-  .kirk-item.kirk-tripCard-top-item {
+  & .kirk-item.kirk-tripCard-top-item {
     padding-top: 0;
   }
-  .kirk-item--highlighted .kirk-text-body {
+
+  &.kirk-item--highlighted .kirk-text-body {
     color: ${color.primary};
   }
 
-  .kirk-tripCard-title + .kirk-tripCard-main {
+  & .kirk-tripCard-title + .kirk-tripCard-mainContainer {
     margin-top: ${space.m};
   }
 
-  .kirk-tripCard-main {
+  & .kirk-tripCard-mainContainer {
     display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    height: 100%;
+  }
+
+  & .kirk-tripCard-main {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
     margin-bottom: ${space.l};
   }
 
-  .kirk-tripCard-itinerary {
-    flex: 1;
+  & .kirk-tripCard-itinerary {
+    min-width: 0; /* reset flex default to allow shrinking below content width */
+  }
+
+  &.kirk-tripCard--with-price .kirk-tripCard-itinerary {
+    padding-right: ${space.m};
+  }
+
+  & .kirk-tripCard-price {
+    display: block;
+    flex-shrink: 0;
   }
 
   &.kirk-tripCard--highlighted .kirk-tripCard-price {
     color: ${color.success};
   }
 
-  .kirk-tripCard-bottom {
+  & .kirk-tripCard-bottom {
     display: flex;
     align-items: center;
+    justify-content: space-between;
   }
 
-  .kirk-tripCard-driver,
-  .kirk-tripCard-passengers {
+  & .kirk-tripCard-bottom--only-right {
+    justify-content: flex-end;
+  }
+
+  & .kirk-tripCard-bottom-left {
+    min-width: 0; /* reset flex default to allow shrinking below content width */
+  }
+
+  & .kirk-tripCard-bottom-right {
+    flex-shrink: 0;
+  }
+
+  & .kirk-tripCard-bottom-left + .kirk-tripCard-bottom-right {
+    margin-left: ${space.l};
+  }
+
+  & .kirk-tripCard-driver,
+  & .kirk-tripCard-passengers {
     display: flex;
     align-items: center;
     flex: 1;
-    margin-right: ${space.l};
+    min-width: 0; /* reset flex default to allow shrinking below content width */
   }
 
-  .kirk-tripCard-ratingContainer {
+  & .kirk-tripCard-driver-info {
+    min-width: 0; /* reset flex default to allow shrinking below content width */
+  }
+
+  & .kirk-tripCard-driver-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-height: calc(2 * ${font.m.lineHeight}); /* max 2 lines of text */
+  }
+
+  & .kirk-tripCard-ratingContainer {
     display: flex;
     margin-top: ${space.m};
   }
 
-  .kirk-tripCard-rating {
+  & .kirk-tripCard-rating {
     margin-left: ${space.m};
   }
 
   /* We reverse the passengers array to display the 1st one on top without touching z-indexes */
-  .kirk-tripCard-passengers {
+  & .kirk-tripCard-passengers {
     flex-direction: row-reverse;
     justify-content: flex-end;
     list-style-type: none;
   }
 
   /* To match the width of the time area of the Itinerary */
-  .kirk-tripCard-driver .kirk-tripCard-avatar {
-    min-width: calc(${componentSizes.timeWidth} + ${space.m});
+  & .kirk-tripCard-driver .kirk-tripCard-avatar {
+    flex-shrink: 0;
     margin-right: ${space.l};
   }
 
-  .kirk-tripCard-passengers .kirk-tripCard-avatar {
+  & .kirk-tripCard-passengers .kirk-tripCard-avatar {
     margin-right: -${space.m};
   }
-  .kirk-tripCard-passengers .kirk-avatar {
+
+  & .kirk-tripCard-passengers .kirk-avatar {
     border: 2px solid ${color.white};
     background: ${color.white};
   }
-  .kirk-tripCard-passengers .kirk-tripCard-passengers-more {
+
+  & .kirk-tripCard-passengers .kirk-tripCard-passengers-more {
     background: ${color.iconHighlight};
     border-radius: 50%;
     width: 40px;
@@ -115,7 +164,7 @@ const StyledTripCard = styled(TripCard)`
     margin-left: ${space.m};
   }
 
-  .kirk-tripCard-topText {
+  & .kirk-tripCard-topText {
     color: ${color.success};
   }
 `


### PR DESCRIPTION
Allow long text in Itinerary to be truncated, and make price always visible.
Snaps the driver/passenger/flags info at the bottom of the card to align with adjacent cards.

The bottom part has also been refactored to remove cases of empty tags and also truncate the driver name if needed. I also made the name use all the space to the right in case there's no flag to display. If for some reason we have no driver/passenger to display, flags, if any, will stick to the bottom right position.

TESTED = locally on storybook and kairos

<img width="671" alt="Screen Shot 2020-03-05 at 16 14 34" src="https://user-images.githubusercontent.com/373381/75997170-41183b80-5eff-11ea-906f-ce9c73ad89ad.png">

<img width="648" alt="Screen Shot 2020-03-05 at 16 16 21" src="https://user-images.githubusercontent.com/373381/75997185-45445900-5eff-11ea-956f-8e5aede80005.png">

<img width="643" alt="Screen Shot 2020-03-06 at 15 30 03" src="https://user-images.githubusercontent.com/373381/76093975-24910780-5fc2-11ea-9f38-493ff18faace.png">

