### PR TITLE
Remove horizontal padding override for MessagingSummaryItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Remove horizontal padding override in `MessagingSummaryItem`
 - [...]
 
 # v22.4.0 (11/03/2020)

--- a/src/messagingSummaryItem/index.tsx
+++ b/src/messagingSummaryItem/index.tsx
@@ -1,15 +1,8 @@
 import styled from 'styled-components'
-import { space } from '_utils/branding'
 
 import MessagingSummaryItem from './MessagingSummaryItem'
 
 const StyledMessagingSummaryItem = styled(MessagingSummaryItem)`
-  /* Overrides horizontal paddings from item styles. */
-  &.kirk-messaging-summary-item {
-    padding-left: ${space.xl};
-    padding-right: ${space.xl};
-  }
-
   & .kirk-messaging-summary-item-sub-label {
     display: flex;
     word-break: break-word;


### PR DESCRIPTION
The padding is already being fixed by the <LayoutNormalizer> component.