### PR TITLE
Release/23.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Unreleased
 
+- [...]
+
+# v23.0.0 (12/03/2020)
+
 - **[FIX]** Remove horizontal padding override in `MessagingSummaryItem`
 - **[BREAKING CHANGE]** Remove `highlighted` prop from `TripCard` component.
-- [...]
 
 # v22.4.0 (11/03/2020)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "22.4.0",
+  "version": "23.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "22.4.0",
+  "version": "23.0.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# v23.0.0 (12/03/2020)

- **[FIX]** Remove horizontal padding override in `MessagingSummaryItem`
- **[BREAKING CHANGE]** Remove `highlighted` prop from `TripCard` component.