### PR TITLE
BBC 7140 handle autocomplete loading

### DIFF
--- a/src/autoComplete/AutoComplete.tsx
+++ b/src/autoComplete/AutoComplete.tsx
@@ -10,6 +10,7 @@ import ItemInfo from 'itemInfo'
 import TextField, { inputTypes } from 'textField'
 import AutoCompleteList from './AutoCompleteListStyle'
 import Divider from 'divider'
+import Loader from 'loader'
 
 type query = string | number | boolean
 export interface AutoCompleteProps {
@@ -51,7 +52,7 @@ export interface AutoCompleteProps {
   readonly required?: boolean
   readonly error?: string | JSX.Element
   readonly selectedItemStatus?: ItemStatus
-  readonly shouldDisplayDivider?: boolean
+  readonly embeddedInSearchForm?: boolean
 }
 
 interface AutoCompleteState {
@@ -105,7 +106,7 @@ export default class AutoComplete extends Component<AutoCompleteProps, AutoCompl
     readOnly: false,
     required: false,
     error: null,
-    shouldDisplayDivider: false,
+    embeddedInSearchForm: false,
   }
 
   constructor(props: AutoCompleteProps) {
@@ -270,7 +271,9 @@ export default class AutoComplete extends Component<AutoCompleteProps, AutoCompl
       ? this.state.items
       : this.props.renderEmptySearch
     const shouldDisplayDivider =
-      this.props.shouldDisplayDivider && (listItems.length > 0 || shouldDisplayNoResults)
+      this.props.embeddedInSearchForm && (listItems.length > 0 || shouldDisplayNoResults)
+    const loader =
+      this.props.embeddedInSearchForm && this.state.isSearching ? <Loader size={24} inline /> : null
 
     return (
       <div role="combobox" className={cc([prefix({ autoComplete: true }), this.props.className])}>
@@ -296,6 +299,7 @@ export default class AutoComplete extends Component<AutoCompleteProps, AutoCompl
           required={this.props.required}
           error={this.props.error}
           focusBorder={false}
+          loader={loader}
         />
         {shouldDisplayDivider && <Divider />}
         {shouldDisplayBusyState && (

--- a/src/searchForm/autoComplete/overlay/AutoCompleteOverlay.tsx
+++ b/src/searchForm/autoComplete/overlay/AutoCompleteOverlay.tsx
@@ -9,7 +9,7 @@ export const AutoCompleteOverlay = (props: AutoCompleteProps) => {
     </div>
   )
 
-  return <AutoComplete {...props} inputAddon={icon} shouldDisplayDivider />
+  return <AutoComplete {...props} inputAddon={icon} embeddedInSearchForm />
 }
 
 export default AutoCompleteOverlay

--- a/src/searchForm/autoComplete/overlay/AutoCompleteOverlay.unit.tsx
+++ b/src/searchForm/autoComplete/overlay/AutoCompleteOverlay.unit.tsx
@@ -4,6 +4,7 @@ import AutoComplete from 'autoComplete'
 import AutoCompleteOverlay from './AutoCompleteOverlay'
 import Bullet from 'bullet'
 import Divider from 'divider'
+import Loader from 'loader'
 
 const initialFakeItems = [
   { id: '1', label: 'title1', labelInfo: 'description1' },
@@ -28,5 +29,15 @@ describe('AutoCompleteOverlay', () => {
 
     expect(wrapper.find('AutoCompleteList').prop('visible')).toBe(true)
     expect(wrapper.find(Divider)).toHaveLength(1)
+  })
+
+  it('should display Loader and then hide it when list is loaded', () => {
+    const wrapper = mount(<AutoCompleteOverlay defaultValue="Paris" />)
+    wrapper.setProps({ isSearching: true })
+
+    expect(wrapper.find(Loader)).toHaveLength(1)
+    wrapper.setProps({ items: fakeSearchForItems(), isSearching: false })
+    expect(wrapper.find(Loader)).toHaveLength(0)
+    expect(wrapper.find('AutoCompleteList').prop('visible')).toBe(true)
   })
 })

--- a/src/searchForm/autoComplete/overlay/index.tsx
+++ b/src/searchForm/autoComplete/overlay/index.tsx
@@ -39,6 +39,12 @@ const StyledAutoComplete = styled(autoComplete)`
     border-radius: 0;
   }
 
+  & .kirk-textField-wrapper .kirk-loader {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+  }
+
   & .kirk-items-list {
     padding: 0;
   }

--- a/src/searchForm/autoComplete/section/AutoCompleteSection.tsx
+++ b/src/searchForm/autoComplete/section/AutoCompleteSection.tsx
@@ -13,7 +13,7 @@ export const AutoCompleteSection = (props: AutoCompleteProps) => {
 
   return (
     <Section className={props.className}>
-      <AutoComplete {...props} inputAddon={backButton} shouldDisplayDivider />
+      <AutoComplete {...props} inputAddon={backButton} embeddedInSearchForm />
     </Section>
   )
 }

--- a/src/searchForm/autoComplete/section/AutoCompleteSection.unit.tsx
+++ b/src/searchForm/autoComplete/section/AutoCompleteSection.unit.tsx
@@ -4,6 +4,7 @@ import AutoComplete from 'autoComplete'
 import AutoCompleteSection from './AutoCompleteSection'
 import ChevronIcon from 'icon/chevronIcon'
 import Divider from 'divider'
+import Loader from 'loader'
 
 const initialFakeItems = [
   { id: '1', label: 'title1', labelInfo: 'description1' },
@@ -28,5 +29,15 @@ describe('AutoCompleteSection', () => {
 
     expect(wrapper.find('AutoCompleteList').prop('visible')).toBe(true)
     expect(wrapper.find(Divider)).toHaveLength(1)
+  })
+
+  it('should display Loader and then hide it when list is loaded', () => {
+    const wrapper = mount(<AutoCompleteSection defaultValue="Paris" />)
+    wrapper.setProps({ isSearching: true })
+
+    expect(wrapper.find(Loader)).toHaveLength(1)
+    wrapper.setProps({ items: fakeSearchForItems(), isSearching: false })
+    expect(wrapper.find(Loader)).toHaveLength(0)
+    expect(wrapper.find('AutoCompleteList').prop('visible')).toBe(true)
   })
 })

--- a/src/searchForm/autoComplete/section/index.tsx
+++ b/src/searchForm/autoComplete/section/index.tsx
@@ -21,6 +21,12 @@ const StyledAutoComplete = styled(autoComplete)`
     border-radius: 0;
   }
 
+  & .kirk-textField-wrapper .kirk-loader {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+  }
+
   & .kirk-items-list {
     padding: 0;
   }

--- a/src/searchForm/story.tsx
+++ b/src/searchForm/story.tsx
@@ -38,7 +38,7 @@ class AutoCompleteExample extends Component<AutoCompleteExampleProps, AutoComple
 
   static defaultProps: AutoCompleteExampleProps = {
     component: AutoCompleteOverlay,
-    searchForItemsDelay: 0,
+    searchForItemsDelay: number('searchForItemsDelay', 2000),
   }
 
   searchForItems = (query: string) => {

--- a/src/textField/TextField.tsx
+++ b/src/textField/TextField.tsx
@@ -66,6 +66,7 @@ export interface TextFieldProps extends CommonFormFields {
   inputRef?: (input: textfield) => void
   format?: (value: string, previousValue: string) => string
   focusBorder?: boolean
+  loader?: JSX.Element
 }
 
 interface FormAttributes extends CommonFormFields {
@@ -239,6 +240,7 @@ export default class TextField extends PureComponent<TextFieldProps, TextFieldSt
       inputMode,
       pattern,
       focusBorder,
+      loader,
     } = this.props
     const value = this.state.value ? format(this.state.value, this.state.previousValue) : ''
 
@@ -303,7 +305,8 @@ export default class TextField extends PureComponent<TextFieldProps, TextFieldSt
             onBlur={this.onBlur}
             type={type === inputTypes.PASSWORD && this.state.showPassword ? inputTypes.TEXT : type}
           />
-          {shouldDisplayButton && (
+          {loader}
+          {!loader && shouldDisplayButton && (
             <Button
               className="kirk-textField-button"
               status={ButtonStatus.UNSTYLED}


### PR DESCRIPTION
Display `Loader` component when `AutoComplete` loads its autocomplete list
Backward compatibility is preserved and the loader is only visible within search form

<img width="411" alt="a" src="https://user-images.githubusercontent.com/3979553/76635191-5ddbf100-6547-11ea-9a23-c63aafdb4d1a.png">
