### PR TITLE
[BOYSCOUT] FIX `TextDisplay1` typographic scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **[UPDATE]** Add explicit support for generic aria attributes on `Item`-like components and `Button`
 - **[FIX]** Fix `MainContent` height when inside a `Modal` with close button
 - **[FIX]** Fix `MediaSection` display inside a `Modal`
+- **[FIX]** Fix `TextDisplay1` scale
 - [...]
 
 # v24.0.0 (23/03/2020)

--- a/src/typography/display1/index.tsx
+++ b/src/typography/display1/index.tsx
@@ -5,8 +5,8 @@ import Text from '../index'
 
 const TextDisplay1 = styled(Text)`
   color: ${color.primaryText};
-  font-size: ${font.l.size};
-  line-height: ${font.l.lineHeight};
+  font-size: ${font.xl.size};
+  line-height: ${font.xl.lineHeight};
   font-weight: ${fontWeight.medium};
 `
 export default TextDisplay1


### PR DESCRIPTION
## Description
`TextDisplay1` doesn't follow the sizing scale

## What has been done
-  Follow **font** scale at `_utils/branding`