### PR TITLE
[BBC-6997] Responsive`ModalSuccess`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,6 +12,12 @@
     "@babel/preset-react"
   ],
   "plugins": [
+    [
+      "babel-plugin-styled-components",
+      {
+        "pure": true
+      }
+    ],
     "@babel/plugin-transform-react-jsx",
     "@babel/plugin-proposal-class-properties",
     [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[BREAKING CHANGE]** Resposive `SuccessModal` (no more size)
 - **[UPDATE]** Update `jsx-a11y` linter autofocus rule
 - [...]
 
@@ -21,14 +22,25 @@
 
 # v26.0.0 (06/04/2020)
 
+<<<<<<< HEAD
+
 - **[FIX]** Remove DOM Warning on `MainContent` component
 - **[FIX]** Fix markup `Item` tag label by replacing `div` children with `span`
+- # **[BREAKING CHANGE]** Import `icons` as default instead of named export for a better code splitting
 - **[BREAKING CHANGE]** Import `icons` as default instead of named export for a better code splitting
+- **[FIX]** Remove DOM Warning on `MainContent` component
+- **[FIX]** Fix markup `Item` tag label by replacing `div` children with `span`
+  > > > > > > > [BBC-6997] Responsive ModalSuccess
 - **[UPDATE]** Make `Review` more semantic with proper HTML and Review/Rating microdata
 - **[FIX]** Fix clicking oustide of `SearchForm` closes overlays
 - **[UPDATE]** Use `Divider` in `ItemList` instead of custom CSS
 - **[UPDATE]** Remove legacy style from Autocomplete
 
+<<<<<<< HEAD
+
+=======
+
+> > > > > > > [BBC-6997] Responsive ModalSuccess
 
 # v25.0.0 (02/04/2020)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -287,12 +287,31 @@
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
-      "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz",
+      "integrity": "sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.8.3"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+          "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.9.0",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -1343,6 +1362,12 @@
       "requires": {
         "@babel/types": "^7.4.4"
       }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
+      "integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==",
+      "dev": true
     },
     "@babel/helper-wrap-function": {
       "version": "7.7.4",
@@ -7002,9 +7027,9 @@
       }
     },
     "babel-plugin-styled-components": {
-      "version": "1.10.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.6.tgz",
-      "integrity": "sha512-gyQj/Zf1kQti66100PhrCRjI5ldjaze9O0M3emXRPAN80Zsf8+e1thpTpaXJXVHXtaM4/+dJEgZHyS9Its+8SA==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.7.tgz",
+      "integrity": "sha512-MBMHGcIA22996n9hZRf/UJLVVgkEOITuR2SvjHLb5dSTUyR4ZRGn+ngITapes36FI3WLxZHfRhkA1ffHxihOrg==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "babel-jest": "24.9.0",
     "babel-loader": "8.0.6",
     "babel-plugin-module-resolver": "3.2.0",
+    "babel-plugin-styled-components": "1.10.7",
     "babel-preset-react-app": "9.1.1",
     "caniuse-db": "1.0.30001016",
     "classcat": "4.0.2",

--- a/src/_utils/assert.ts
+++ b/src/_utils/assert.ts
@@ -1,9 +1,8 @@
 import { ModalSize } from 'modal/Modal'
-import { SuccessModalSize } from 'successModal/SuccessModal'
 import { ConfirmationModalSize } from 'confirmationModal/ConfirmationModal'
 
 export const assertModalSizes = (
-  modalSize: typeof ModalSize | typeof SuccessModalSize | typeof ConfirmationModalSize,
+  modalSize: typeof ModalSize | typeof ConfirmationModalSize,
   size: string,
 ): void => {
   const correctModalSize = Object.values(modalSize).includes(size)

--- a/src/datePicker/__snapshots__/DatePicker.unit.tsx.snap
+++ b/src/datePicker/__snapshots__/DatePicker.unit.tsx.snap
@@ -62,8 +62,8 @@ exports[`DatePicker renderNavbar Should render the previous/next buttons in hori
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  -webkit-transition: max-width 500ms ease-in, background-color 200ms ease-in;
-  transition: max-width 500ms ease-in, background-color 200ms ease-in;
+  -webkit-transition: max-width 500ms ease-in,background-color 200ms ease-in;
+  transition: max-width 500ms ease-in,background-color 200ms ease-in;
   white-space: nowrap;
 }
 

--- a/src/hint/__snapshots__/index.unit.tsx.snap
+++ b/src/hint/__snapshots__/index.unit.tsx.snap
@@ -46,8 +46,8 @@ exports[`Hint Default rendering (above) 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  -webkit-transition: max-width 500ms ease-in, background-color 200ms ease-in;
-  transition: max-width 500ms ease-in, background-color 200ms ease-in;
+  -webkit-transition: max-width 500ms ease-in,background-color 200ms ease-in;
+  transition: max-width 500ms ease-in,background-color 200ms ease-in;
   white-space: nowrap;
 }
 
@@ -391,8 +391,8 @@ exports[`Hint Default rendering (below) 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  -webkit-transition: max-width 500ms ease-in, background-color 200ms ease-in;
-  transition: max-width 500ms ease-in, background-color 200ms ease-in;
+  -webkit-transition: max-width 500ms ease-in,background-color 200ms ease-in;
+  transition: max-width 500ms ease-in,background-color 200ms ease-in;
   white-space: nowrap;
 }
 

--- a/src/layout/section/mediaContentSection/__snapshots__/index.unit.tsx.snap
+++ b/src/layout/section/mediaContentSection/__snapshots__/index.unit.tsx.snap
@@ -137,8 +137,8 @@ exports[`MediaContentSection should render default MediaContentSection section 1
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  -webkit-transition: max-width 500ms ease-in, background-color 200ms ease-in;
-  transition: max-width 500ms ease-in, background-color 200ms ease-in;
+  -webkit-transition: max-width 500ms ease-in,background-color 200ms ease-in;
+  transition: max-width 500ms ease-in,background-color 200ms ease-in;
   white-space: nowrap;
 }
 

--- a/src/modal/__snapshots__/Modal.unit.tsx.snap
+++ b/src/modal/__snapshots__/Modal.unit.tsx.snap
@@ -91,8 +91,8 @@ exports[`Modal should not have changed 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  -webkit-transition: max-width 500ms ease-in, background-color 200ms ease-in;
-  transition: max-width 500ms ease-in, background-color 200ms ease-in;
+  -webkit-transition: max-width 500ms ease-in,background-color 200ms ease-in;
+  transition: max-width 500ms ease-in,background-color 200ms ease-in;
   white-space: nowrap;
 }
 

--- a/src/phoneField/__snapshots__/PhoneField.unit.tsx.snap
+++ b/src/phoneField/__snapshots__/PhoneField.unit.tsx.snap
@@ -107,8 +107,8 @@ exports[`PhoneField should have the expected markup in the DOM with custom setti
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  -webkit-transition: max-width 500ms ease-in, background-color 200ms ease-in;
-  transition: max-width 500ms ease-in, background-color 200ms ease-in;
+  -webkit-transition: max-width 500ms ease-in,background-color 200ms ease-in;
+  transition: max-width 500ms ease-in,background-color 200ms ease-in;
   white-space: nowrap;
 }
 

--- a/src/review/__snapshots__/Review.unit.tsx.snap
+++ b/src/review/__snapshots__/Review.unit.tsx.snap
@@ -99,8 +99,7 @@ Array [
 .c1 {
   color: #054752;
   font-size: 18px;
-  font-weight: 400;
-  line-height: 20px;
+  font-weight: 400 line-height:20px;
 }
 
 .c1.kirk-text--inverse {
@@ -257,8 +256,7 @@ Array [
 .c1 {
   color: #054752;
   font-size: 18px;
-  font-weight: 400;
-  line-height: 20px;
+  font-weight: 400 line-height:20px;
 }
 
 .c1.kirk-text--inverse {

--- a/src/snackbar/__snapshots__/Snackbar.unit.tsx.snap
+++ b/src/snackbar/__snapshots__/Snackbar.unit.tsx.snap
@@ -46,8 +46,8 @@ exports[`Snackbar should not have changed 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  -webkit-transition: max-width 500ms ease-in, background-color 200ms ease-in;
-  transition: max-width 500ms ease-in, background-color 200ms ease-in;
+  -webkit-transition: max-width 500ms ease-in,background-color 200ms ease-in;
+  transition: max-width 500ms ease-in,background-color 200ms ease-in;
   white-space: nowrap;
 }
 

--- a/src/successModal/SuccessModal.tsx
+++ b/src/successModal/SuccessModal.tsx
@@ -1,11 +1,12 @@
-import React, { Component } from 'react'
-
-import Modal, { ModalSize } from 'modal'
-import { ModalProps } from 'modal/Modal'
-import Button, { ButtonStatus } from 'button'
-import TheVoice from 'theVoice'
-import { assertModalSizes } from '_utils/assert'
+import React from 'react'
 import uuidv4 from 'uuid/v4'
+
+import { ModalProps } from 'modal'
+import { ButtonStatus } from 'button'
+
+import TextDisplay1 from 'typography/display1'
+
+import { SuccessModalStyle } from './index'
 
 export interface SuccessModalProps extends ModalProps {
   readonly confirmLabel?: string
@@ -13,74 +14,65 @@ export interface SuccessModalProps extends ModalProps {
   readonly imageText?: string
 }
 
-export enum SuccessModalSize {
-  SMALL = 'small',
-  LARGE = 'large',
-}
+const SuccessModal = (props: SuccessModalProps): JSX.Element => {
+  const {
+    isOpen = false,
+    onClose = () => {},
+    forwardedRef = null,
+    confirmLabel,
+    imageSrc,
+    imageText = '',
+    children,
+    className,
+  } = props
 
-class SuccessModal extends Component<SuccessModalProps> {
-  static defaultProps: Partial<SuccessModalProps> = {
-    isOpen: false,
-    closeOnEsc: false,
-    size: ModalSize.SMALL,
-    forwardedRef: null,
-    imageText: '',
-  }
+  const baseClassName = 'kirk-successModal'
+  const successContentId = `${baseClassName}-content-${uuidv4()}`
 
-  render() {
-    const {
-      isOpen,
-      children,
-      size,
-      onClose,
-      confirmLabel,
-      forwardedRef,
-      imageSrc,
-      imageText,
-      className,
-    } = this.props
+  const {
+    StyledSuccessModal,
+    Media,
+    Figure,
+    Content,
+    SuccessTitle,
+    SuccessAction,
+    SuccessButton,
+  } = SuccessModalStyle
 
-    // Will throw if we use a non allowed modal size
-    assertModalSizes(SuccessModalSize, this.props.size)
-
-    const baseClassName = 'kirk-successModal'
-    const successContentId = `${baseClassName}-bodyItem-${uuidv4()}`
-
-    return (
-      <Modal
-        onClose={onClose}
-        isOpen={isOpen}
-        size={size}
-        closeOnEsc={false}
-        displayCloseButton={false}
-        displayDimmer={false}
-        forwardedRef={forwardedRef}
-        className={className}
-        modalContentClassName={baseClassName}
-        ariaLabelledBy={successContentId}
-      >
-        <img
-          className={`${baseClassName}-bodyItem ${baseClassName}-image`}
-          src={imageSrc}
-          alt={imageText}
-          // This image is always decorative
-          aria-hidden
-        />
-        <div id={successContentId} className={`${baseClassName}-bodyItem`}>
-          <TheVoice isInverted>{children}</TheVoice>
-          <footer className={`${baseClassName}-footer`}>
-            <Button
+  return (
+    <StyledSuccessModal
+      onClose={onClose}
+      isOpen={isOpen}
+      closeOnEsc={false}
+      displayCloseButton={false}
+      displayDimmer={false}
+      forwardedRef={forwardedRef}
+      className={className}
+      modalContentClassName={baseClassName}
+      ariaLabelledBy={successContentId}
+      data-test="success-modal"
+    >
+      <Media>
+        <Figure>
+          <img src={imageSrc} alt={imageText} />
+        </Figure>
+        <Content>
+          <SuccessTitle data-test="success-title">
+            <TextDisplay1 isInverted>{children}</TextDisplay1>
+          </SuccessTitle>
+          <SuccessAction>
+            <SuccessButton
               status={ButtonStatus.SECONDARY}
-              className={`${baseClassName}-confirmButton`}
+              data-test="success-button"
               onClick={onClose}
             >
               {confirmLabel}
-            </Button>
-          </footer>
-        </div>
-      </Modal>
-    )
-  }
+            </SuccessButton>
+          </SuccessAction>
+        </Content>
+      </Media>
+    </StyledSuccessModal>
+  )
 }
 
 export default SuccessModal

--- a/src/successModal/SuccessModal.unit.tsx
+++ b/src/successModal/SuccessModal.unit.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { shallow, mount } from 'enzyme'
+import { mount, shallow } from 'enzyme'
 
-import SuccessModal from 'successModal'
+import SuccessModal from './index'
 
 const defaultProps = {
   isOpen: false,
@@ -9,53 +9,49 @@ const defaultProps = {
   imageSrc: 'https://svgshare.com/i/AGz.svg',
   imageText: 'Illustration description',
   closeOnEsc: true,
+  onClose: () => {},
+  forwardedRef: null,
 }
 
 describe('<SuccessModal>', () => {
   let mockClose
-  let wrapper
   let wrapperOpen
 
-  beforeEach(() => {
+  it('Should be visible if isOpen is set to true', () => {
     mockClose = jest.fn()
-    wrapper = shallow(<SuccessModal {...defaultProps} />)
     wrapperOpen = mount(
       <SuccessModal {...defaultProps} isOpen onClose={mockClose}>
         Success description
       </SuccessModal>,
     )
-  })
-
-  it('Should be not visible if isOpen is set to false', () => {
-    expect(wrapper.find('.kirk-modal-dialog').exists()).toBe(false)
-  })
-
-  it('Should be visible if isOpen is set to true', () => {
     expect(wrapperOpen.find('.kirk-modal-dialog').exists()).toBe(true)
   })
 
+  it('Should be hidden if isOpen is set to false', () => {
+    const wrapper = shallow(<SuccessModal {...defaultProps} />)
+    expect(wrapper.find('.kirk-modal-dialog').exists()).toBe(false)
+  })
+
   it('Should have proper linked id to the content text', () => {
-    const ariaLabelledByValue = wrapperOpen.find('.kirk-successModal').prop('aria-labelledby')
-    expect(wrapperOpen.find(`#${ariaLabelledByValue} h1`).text()).toEqual('Success description')
+    expect(
+      wrapperOpen
+        .find('[data-test="success-title"]')
+        .at(0)
+        .text(),
+    ).toEqual('Success description')
   })
 
   it('Should have a confirmation button and call the according function when click on it', () => {
-    expect(wrapperOpen.find('.kirk-button-secondary').text()).toBe('Confirm')
-  })
-
-  it('Should have the proper image', () => {
-    const image = wrapperOpen.find('.kirk-successModal-image')
-    expect(image.prop('src')).toBe('https://svgshare.com/i/AGz.svg')
-    expect(image.prop('alt')).toBe('Illustration description')
-  })
-
-  it("Shouldn't access the image with screen readers", () => {
-    const image = wrapperOpen.find('.kirk-successModal-image')
-    expect(image.prop('aria-hidden')).toBe(true)
+    expect(
+      wrapperOpen
+        .find('[data-test="success-button"]')
+        .at(0)
+        .text(),
+    ).toBe('Confirm')
   })
 
   it('Should have a confirmation button and call the according function when click on it', () => {
-    const confirmButton = wrapperOpen.find('.kirk-button-secondary')
+    const confirmButton = wrapperOpen.find('[data-test="success-button"]').at(0)
     expect(confirmButton.text()).toBe('Confirm')
     confirmButton.simulate('click')
     expect(mockClose).toHaveBeenCalledTimes(1)

--- a/src/successModal/index.tsx
+++ b/src/successModal/index.tsx
@@ -1,100 +1,119 @@
 import styled from 'styled-components'
-import { color, font, space, modalSize } from '_utils/branding'
 import SuccessModal from './SuccessModal'
 
-const footerHeight = '96px' /* = padding + content */
+import { color, space, responsiveBreakpoints, componentSizes } from '_utils/branding'
 
-const StyledSuccessModal = styled(SuccessModal)`
-  & .kirk-successModal {
-    background-color: ${color.successBackground};
-    color: ${color.white};
-  }
+import Modal from 'modal'
+import Button from 'button'
 
-  & .kirk-modal--large {
-    text-align: center;
-  }
+const StyledSuccessModal = styled(Modal)`
+  padding: 0;
+  text-align: center;
+  background-color: ${color.successBackground};
 
-  & .kirk-modal.kirk-successModal .kirk-modal-dialog {
-    margin: 0 auto;
-    max-width: ${modalSize.m};
-    height: 100%;
-    padding: ${space.xl} 0 ${footerHeight} 0;
-    background-color: ${color.successBackground};
-  }
-
-  /* Stronger selector to override Modal component styling */
-  &.kirk-modal-dimmer .kirk-modal.kirk-successModal .kirk-modal-dialog.kirk-modal-dialog {
-    width: auto;
-  }
-
-  & .kirk-modal--large.kirk-successModal .kirk-modal-dialog {
-    padding: ${space.xl} 0;
-  }
-
-  & .kirk-modal.kirk-successModal .kirk-modal-body {
-    padding: ${space.xl};
-    font-size: ${font.l.size};
-    line-height: ${font.l.lineHeight};
-    text-align: center;
-    align-items: center;
-  }
-
-  & .kirk-modal--large.kirk-successModal .kirk-modal-body {
-    position: relative;
+  .kirk-modal-dialog {
     display: flex;
-  }
-
-  & .kirk-modal--large .kirk-successModal-bodyItem {
-    width: 50%;
-  }
-
-  & .kirk-modal--large .kirk-successModal-bodyItem:nth-child(odd) {
-    padding-right: ${space.xl};
-  }
-
-  & .kirk-modal--large .kirk-successModal-bodyItem:nth-child(even) {
-    padding-left: ${space.xl};
-  }
-
-  & .kirk-successModal-image {
-    width: 80%;
-    margin-bottom: ${space.xl};
-  }
-
-  & .kirk-modal--small .kirk-successModal-image {
-    max-height: 33vh;
-    object-fit: contain;
-  }
-
-  & .kirk-modal--large .kirk-successModal-image {
-    margin-bottom: 0;
-  }
-
-  & .kirk-successModal-footer {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    height: ${footerHeight};
-    padding: ${space.xl};
-    text-align: center;
-  }
-
-  & .kirk-modal--large .kirk-successModal-footer {
-    position: relative;
-    display: block;
+    justify-content: center;
+    padding: 0;
     margin: 0 auto;
+    width: 100%;
+    border-radius: 0;
+    background-color: ${color.successBackground};
   }
 
-  & .kirk-modal--large .kirk-successModal-footer .kirk-button {
-    margin: ${space.l} ${space.xl} 0;
-  }
+  .kirk-modal-body {
+    display: flex;
+    min-height: 100vh;
+    /* to avoid scroll on webkit browsers when they have a top bar */
+    min-height: -moz-available;
+    min-height: -webkit-fill-available;
+    flex-direction: column;
 
-  & .kirk-successModal-confirmButton {
-    vertical-align: bottom; /* vertical alignment to be fixed in Button */
-    border: 0; /* content alignment to be fixed in Button */
+    @media (${responsiveBreakpoints.isMediaLarge}) {
+      flex-direction: row;
+      align-items: center;
+      flex-wrap: wrap;
+    }
   }
 `
 
+/* LAYOUT: Media */
+const Media = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+
+  @media (${responsiveBreakpoints.isMediaLarge}) {
+    max-width: ${componentSizes.largeSectionWidth};
+    margin-left: auto;
+    margin-right: auto;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+  }
+`
+
+const Figure = styled.figure`
+  display: flex;
+  margin: 0;
+  justify-content: center;
+  align-items: center;
+  padding-top: calc(2 * ${space.xxl});
+  height: 33.33vh;
+
+  @media (${responsiveBreakpoints.isMediaLarge}) {
+    padding: 0;
+    width: 33.33vh;
+  }
+`
+
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: ${space.xl};
+
+  @media (${responsiveBreakpoints.isMediaLarge}) {
+    flex: 1;
+    width: 66.66vh;
+    height: auto;
+  }
+`
+
+/* SuccessModal Spacements */
+const SuccessTitle = styled.h1`
+  display: flex;
+  flex: 1;
+  padding: ${space.xl};
+
+  @media (${responsiveBreakpoints.isMediaLarge}) {
+    span {
+      /* Font-Size not available on typography scale */
+      font-size: 2.5rem;
+    }
+  }
+`
+
+const SuccessAction = styled.div`
+  padding: ${space.xl};
+`
+
+const SuccessButton = styled(Button)`
+  justify-content: center;
+  /* cascade weight :( */
+  min-width: 8rem !important;
+`
+
+const SuccessModalStyle = {
+  StyledSuccessModal,
+  Media,
+  Figure,
+  Content,
+  SuccessTitle,
+  SuccessAction,
+  SuccessButton,
+}
+
 export { SuccessModalProps } from './SuccessModal'
-export default StyledSuccessModal
+export { SuccessModalStyle }
+export default SuccessModal

--- a/src/successModal/story.tsx
+++ b/src/successModal/story.tsx
@@ -1,12 +1,13 @@
 import React, { Component } from 'react'
-
-import { storiesOf } from '@storybook/react'
-import { withKnobs, boolean, text, select } from '@storybook/addon-knobs'
 import { action } from '@storybook/addon-actions'
+import { storiesOf } from '@storybook/react'
+import { withKnobs, boolean, text } from '@storybook/addon-knobs'
+
 import Section from 'layout/section/baseSection'
-import SuccessModal from 'successModal'
-import { SuccessModalProps, SuccessModalSize } from './SuccessModal'
-import successModalDoc from './specifications/successModal.md'
+
+import SuccessModal, { SuccessModalProps } from 'successModal'
+
+import spec from './specifications/successModal.md'
 
 const stories = storiesOf('Widgets|Modal|SuccessModal', module)
 
@@ -48,14 +49,16 @@ stories.add(
     <SuccessModalOpener
       isOpen={false}
       onClose={action('onClose')}
-      imageSrc={text('imageSrc', 'https://svgshare.com/i/AGz.svg')}
-      imageText={text('imageText', 'Illustation description')}
-      confirmLabel={text('confirmLabel', 'Got it!')}
-      size={select('size', SuccessModalSize, SuccessModalSize.SMALL)}
-      closeOnEsc={boolean('closeOnEsc', false)}
+      imageSrc={text(
+        'SuccessImageSrc',
+        'https://cdn.blablacar.com/insurance/assets/2b950c73301c3b8526772644de550035.svg',
+      )}
+      imageText={text('SuccessImagText', 'Illustation description')}
+      confirmLabel={text('SuccessConfirmationLabel', 'Got it!')}
+      closeOnEsc={boolean('SuccessCloseOnEsc', false)}
     />
   ),
   {
-    readme: { content: successModalDoc },
+    readme: { content: spec },
   },
 )

--- a/src/typography/Text.tsx
+++ b/src/typography/Text.tsx
@@ -5,16 +5,15 @@ import { replaceNewLineWithBR } from '_utils'
 export interface TextProps {
   readonly className?: string
   readonly children: string | ReactNode
-  readonly isInverted?: boolean
+  readonly isInverted?: boolean // Switch colors based on backgournd
   readonly itemProp?: string // Allows microdata annotation on Text
 }
 
-const Text = ({ children, className, isInverted = false, ...props }: TextProps) => {
-  const classes = isInverted ? `kirk-text--inverse ${className}` : className
+const Text = ({ children, className, isInverted, ...props }: TextProps) => {
   const content = typeof children === 'string' ? replaceNewLineWithBR(children) : children
 
   return (
-    <span className={classes} {...props}>
+    <span className={className} {...props}>
       {content}
     </span>
   )


### PR DESCRIPTION
## Description
**Same same but different**

https://www.loom.com/share/4dd212b8d87b45eeae1fe77f19da08d1

Follow new specs to layout `ModalSuccess`. 

## What has been done

- Override `Modal`
- Use `styled-components` to override/style components
- Since using `styled-components`, no more classes, so converting `classes` to `data-test`
- **chore**: Install a plugin babel to help on debugging

## Things to consider
- Converting classes to data-tests


