### PR TITLE
[BOYSCOUT] Config Default Viewports to improve device testing

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -20,7 +20,7 @@ addParameters({
   },
   viewport: {
     viewports: INITIAL_VIEWPORTS,
-    defaultViewport: 'iPhone6',
+    defaultViewport: 'iPhone 6',
   },
   readme: {
     sidebar: props,

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -19,7 +19,7 @@ addParameters({
     // You can still set it to false, but it's strongly unrecommendend in cases when you host your storybook on some route of your main site or web app.
   },
   viewport: {
-    viewports: INITIAL_VIEWPORTS, // newViewports would be an ViewportMap. (see below for examples)
+    viewports: INITIAL_VIEWPORTS,
     defaultViewport: 'iPhone6',
   },
   readme: {

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,7 +1,7 @@
 import { configure, addDecorator, addParameters } from '@storybook/react'
-
 import { withA11y } from '@storybook/addon-a11y'
 import { withKnobs } from '@storybook/addon-knobs'
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
 import { addReadme } from 'storybook-readme'
 
 import props from './props.md'
@@ -17,6 +17,10 @@ addParameters({
   knobs: {
     escapeHTML: false, // Escapes strings to be safe for inserting as innerHTML. This option is true by default. It's safe to set it to `false` with frameworks like React which do escaping on their side.
     // You can still set it to false, but it's strongly unrecommendend in cases when you host your storybook on some route of your main site or web app.
+  },
+  viewport: {
+    viewports: INITIAL_VIEWPORTS, // newViewports would be an ViewportMap. (see below for examples)
+    defaultViewport: 'iPhone6',
   },
   readme: {
     sidebar: props,


### PR DESCRIPTION
## Description
Configure [storybook viewport addons ](https://github.com/storybookjs/storybook/tree/master/addons/viewport) to be able to test on common devices on the market.

Improve testability