### PR TITLE
[BBC-7444] Calendar is limited to 1 year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
--[...]
+- **[UPDATE]** Add `toMonth` parameter to `DatePicker` and set it to 1 year by default
+- [...]
 
 # v26.0.1 (08/04/2020)
 

--- a/src/datePicker/DatePicker.tsx
+++ b/src/datePicker/DatePicker.tsx
@@ -36,6 +36,7 @@ export interface DatePickerProps {
   readonly orientation?: DatePickerOrientation
   readonly isOutsideRange?: (day: Date) => boolean
   readonly fromMonth?: Date
+  readonly toMonth?: Date
   readonly firstDayOfWeek?: number
   readonly stickyPositionTop?: number
 }
@@ -56,6 +57,7 @@ export class DatePicker extends PureComponent<DatePickerProps, DatePickerState> 
     isOutsideRange: day => DayPicker.DateUtils.isDayBefore(day, new Date()),
     orientation: DatePickerOrientation.HORIZONTAL,
     fromMonth: new Date(),
+    toMonth: new Date(new Date().getFullYear() + 1, new Date().getMonth(), new Date().getDate()),
     firstDayOfWeek: 0,
     stickyPositionTop: 0,
   }
@@ -185,6 +187,7 @@ export class DatePicker extends PureComponent<DatePickerProps, DatePickerState> 
       isOutsideRange,
       orientation,
       fromMonth,
+      toMonth,
       weekdaysShort,
       weekdaysLong,
       months,
@@ -220,6 +223,7 @@ export class DatePicker extends PureComponent<DatePickerProps, DatePickerState> 
           firstDayOfWeek={firstDayOfWeek}
           localeUtils={{ ...DayPicker.LocaleUtils, formatMonthTitle: this.formatMonthTitle }}
           initialMonth={initialMonth}
+          toMonth={toMonth}
         />
       </div>
     )


### PR DESCRIPTION
On large screen we can navigate through calendar with arrow buttons and we can display dates in far future.
The calendar will now display dates until 1 year by default

![a](https://user-images.githubusercontent.com/3979553/78684943-637fe900-78f1-11ea-978e-41df9a5a7fb3.gif)
