### PR TITLE
Loader overhaul + new BLOCK mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
 
 - **[UPDATE]** Add `autocompleteFrom` & `autocompleteTo` props to `SearchForm`
-  [...]
+- **[UPDATE]** Add new layoutMode props to `Loader`  and add support for `block` mode.
+- [...]
 
 # v27.0.0 (09/04/2020)
 

--- a/src/_utils/checkboxIcon/__snapshots__/index.unit.tsx.snap
+++ b/src/_utils/checkboxIcon/__snapshots__/index.unit.tsx.snap
@@ -110,7 +110,11 @@ exports[`CheckboxIcon Should render a loader if isLoading and isChecked are set 
   stroke-width: 0;
 }
 
-.c0 {
+.c0.kirk-loader--inline {
+  display: inline-block;
+}
+
+.c0.kirk-loader--fullScreen {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -123,9 +127,6 @@ exports[`CheckboxIcon Should render a loader if isLoading and isChecked are set 
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c0.kirk-loader--fullScreen {
   position: fixed;
   top: 0;
   left: 0;
@@ -135,39 +136,68 @@ exports[`CheckboxIcon Should render a loader if isLoading and isChecked are set 
   z-index: 4;
 }
 
-.c0.kirk-loader--done {
+.c0.kirk-loader--block {
+  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 16px 0;
+}
+
+.c0 .kirk-loader--done {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   background-color: #5DD167;
   color: #FFF;
   border-radius: 50%;
 }
 
 <div
-  className="kirk-loader c0"
-  style={
-    Object {
-      "height": "24px",
-      "width": "24px",
-    }
-  }
+  className="c0 kirk-loader--inline"
 >
-  <svg
-    aria-hidden={true}
-    className="kirk-icon kirk-icon-circle spinning c1 c2"
-    fill="#5DD167"
-    height={24}
-    viewBox="0 0 66 66"
-    width={24}
-    xmlns="http://www.w3.org/2000/svg"
+  <div
+    className=""
+    style={
+      Object {
+        "height": "24px",
+        "width": "24px",
+      }
+    }
   >
-    
-    <circle
-      cx="33"
-      cy="33"
-      fill="none"
-      r="30"
-      stroke="#5DD167"
-    />
-  </svg>
+    <svg
+      aria-hidden={true}
+      className="kirk-icon kirk-icon-circle spinning c1 c2"
+      fill="#5DD167"
+      height={24}
+      viewBox="0 0 66 66"
+      width={24}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      
+      <circle
+        cx="33"
+        cy="33"
+        fill="none"
+        r="30"
+        stroke="#5DD167"
+      />
+    </svg>
+  </div>
 </div>
 `;
 
@@ -220,7 +250,11 @@ exports[`CheckboxIcon Should render a loader if isLoading is set to true 1`] = `
   stroke-width: 0;
 }
 
-.c0 {
+.c0.kirk-loader--inline {
+  display: inline-block;
+}
+
+.c0.kirk-loader--fullScreen {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -233,9 +267,6 @@ exports[`CheckboxIcon Should render a loader if isLoading is set to true 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c0.kirk-loader--fullScreen {
   position: fixed;
   top: 0;
   left: 0;
@@ -245,39 +276,68 @@ exports[`CheckboxIcon Should render a loader if isLoading is set to true 1`] = `
   z-index: 4;
 }
 
-.c0.kirk-loader--done {
+.c0.kirk-loader--block {
+  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 16px 0;
+}
+
+.c0 .kirk-loader--done {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   background-color: #5DD167;
   color: #FFF;
   border-radius: 50%;
 }
 
 <div
-  className="kirk-loader c0"
-  style={
-    Object {
-      "height": "24px",
-      "width": "24px",
-    }
-  }
+  className="c0 kirk-loader--inline"
 >
-  <svg
-    aria-hidden={true}
-    className="kirk-icon kirk-icon-circle spinning c1 c2"
-    fill="#5DD167"
-    height={24}
-    viewBox="0 0 66 66"
-    width={24}
-    xmlns="http://www.w3.org/2000/svg"
+  <div
+    className=""
+    style={
+      Object {
+        "height": "24px",
+        "width": "24px",
+      }
+    }
   >
-    
-    <circle
-      cx="33"
-      cy="33"
-      fill="none"
-      r="30"
-      stroke="#5DD167"
-    />
-  </svg>
+    <svg
+      aria-hidden={true}
+      className="kirk-icon kirk-icon-circle spinning c1 c2"
+      fill="#5DD167"
+      height={24}
+      viewBox="0 0 66 66"
+      width={24}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      
+      <circle
+        cx="33"
+        cy="33"
+        fill="none"
+        r="30"
+        stroke="#5DD167"
+      />
+    </svg>
+  </div>
 </div>
 `;
 

--- a/src/_utils/radioIcon/__snapshots__/index.unit.tsx.snap
+++ b/src/_utils/radioIcon/__snapshots__/index.unit.tsx.snap
@@ -125,7 +125,11 @@ exports[`RadioIcon Should render a loader if isLoading and isChecked are set to 
   stroke-width: 0;
 }
 
-.c0 {
+.c0.kirk-loader--inline {
+  display: inline-block;
+}
+
+.c0.kirk-loader--fullScreen {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -138,9 +142,6 @@ exports[`RadioIcon Should render a loader if isLoading and isChecked are set to 
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c0.kirk-loader--fullScreen {
   position: fixed;
   top: 0;
   left: 0;
@@ -150,39 +151,68 @@ exports[`RadioIcon Should render a loader if isLoading and isChecked are set to 
   z-index: 4;
 }
 
-.c0.kirk-loader--done {
+.c0.kirk-loader--block {
+  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 16px 0;
+}
+
+.c0 .kirk-loader--done {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   background-color: #5DD167;
   color: #FFF;
   border-radius: 50%;
 }
 
 <div
-  className="kirk-loader c0"
-  style={
-    Object {
-      "height": "24px",
-      "width": "24px",
-    }
-  }
+  className="c0 kirk-loader--inline"
 >
-  <svg
-    aria-hidden={true}
-    className="kirk-icon kirk-icon-circle spinning c1 c2"
-    fill="#5DD167"
-    height={24}
-    viewBox="0 0 66 66"
-    width={24}
-    xmlns="http://www.w3.org/2000/svg"
+  <div
+    className=""
+    style={
+      Object {
+        "height": "24px",
+        "width": "24px",
+      }
+    }
   >
-    
-    <circle
-      cx="33"
-      cy="33"
-      fill="none"
-      r="30"
-      stroke="#5DD167"
-    />
-  </svg>
+    <svg
+      aria-hidden={true}
+      className="kirk-icon kirk-icon-circle spinning c1 c2"
+      fill="#5DD167"
+      height={24}
+      viewBox="0 0 66 66"
+      width={24}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      
+      <circle
+        cx="33"
+        cy="33"
+        fill="none"
+        r="30"
+        stroke="#5DD167"
+      />
+    </svg>
+  </div>
 </div>
 `;
 
@@ -235,7 +265,11 @@ exports[`RadioIcon Should render a loader if isLoading is set to true 1`] = `
   stroke-width: 0;
 }
 
-.c0 {
+.c0.kirk-loader--inline {
+  display: inline-block;
+}
+
+.c0.kirk-loader--fullScreen {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -248,9 +282,6 @@ exports[`RadioIcon Should render a loader if isLoading is set to true 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c0.kirk-loader--fullScreen {
   position: fixed;
   top: 0;
   left: 0;
@@ -260,39 +291,68 @@ exports[`RadioIcon Should render a loader if isLoading is set to true 1`] = `
   z-index: 4;
 }
 
-.c0.kirk-loader--done {
+.c0.kirk-loader--block {
+  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 16px 0;
+}
+
+.c0 .kirk-loader--done {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   background-color: #5DD167;
   color: #FFF;
   border-radius: 50%;
 }
 
 <div
-  className="kirk-loader c0"
-  style={
-    Object {
-      "height": "24px",
-      "width": "24px",
-    }
-  }
+  className="c0 kirk-loader--inline"
 >
-  <svg
-    aria-hidden={true}
-    className="kirk-icon kirk-icon-circle spinning c1 c2"
-    fill="#5DD167"
-    height={24}
-    viewBox="0 0 66 66"
-    width={24}
-    xmlns="http://www.w3.org/2000/svg"
+  <div
+    className=""
+    style={
+      Object {
+        "height": "24px",
+        "width": "24px",
+      }
+    }
   >
-    
-    <circle
-      cx="33"
-      cy="33"
-      fill="none"
-      r="30"
-      stroke="#5DD167"
-    />
-  </svg>
+    <svg
+      aria-hidden={true}
+      className="kirk-icon kirk-icon-circle spinning c1 c2"
+      fill="#5DD167"
+      height={24}
+      viewBox="0 0 66 66"
+      width={24}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      
+      <circle
+        cx="33"
+        cy="33"
+        fill="none"
+        r="30"
+        stroke="#5DD167"
+      />
+    </svg>
+  </div>
 </div>
 `;
 

--- a/src/itemCheckbox/__snapshots__/ItemCheckbox.unit.tsx.snap
+++ b/src/itemCheckbox/__snapshots__/ItemCheckbox.unit.tsx.snap
@@ -523,7 +523,11 @@ button:hover.c0 {
   stroke-width: 0;
 }
 
-.c2 {
+.c2.kirk-loader--inline {
+  display: inline-block;
+}
+
+.c2.kirk-loader--fullScreen {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -536,9 +540,6 @@ button:hover.c0 {
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c2.kirk-loader--fullScreen {
   position: fixed;
   top: 0;
   left: 0;
@@ -548,7 +549,32 @@ button:hover.c0 {
   z-index: 4;
 }
 
-.c2.kirk-loader--done {
+.c2.kirk-loader--block {
+  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 16px 0;
+}
+
+.c2 .kirk-loader--done {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   background-color: #5DD167;
   color: #FFF;
   border-radius: 50%;
@@ -596,32 +622,36 @@ button:hover.c0 {
       type="checkbox"
     />
     <div
-      className="kirk-loader c2"
-      style={
-        Object {
-          "height": "24px",
-          "width": "24px",
-        }
-      }
+      className="c2 kirk-loader--inline"
     >
-      <svg
-        aria-hidden={true}
-        className="kirk-icon kirk-icon-circle spinning c3 c4"
-        fill="#5DD167"
-        height={24}
-        viewBox="0 0 66 66"
-        width={24}
-        xmlns="http://www.w3.org/2000/svg"
+      <div
+        className=""
+        style={
+          Object {
+            "height": "24px",
+            "width": "24px",
+          }
+        }
       >
-        
-        <circle
-          cx="33"
-          cy="33"
-          fill="none"
-          r="30"
-          stroke="#5DD167"
-        />
-      </svg>
+        <svg
+          aria-hidden={true}
+          className="kirk-icon kirk-icon-circle spinning c3 c4"
+          fill="#5DD167"
+          height={24}
+          viewBox="0 0 66 66"
+          width={24}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          
+          <circle
+            cx="33"
+            cy="33"
+            fill="none"
+            r="30"
+            stroke="#5DD167"
+          />
+        </svg>
+      </div>
     </div>
   </span>
 </label>

--- a/src/itemChoice/__snapshots__/index.unit.tsx.snap
+++ b/src/itemChoice/__snapshots__/index.unit.tsx.snap
@@ -234,7 +234,11 @@ button:hover.c0 {
   stroke-width: 0;
 }
 
-.c3 {
+.c3.kirk-loader--inline {
+  display: inline-block;
+}
+
+.c3.kirk-loader--fullScreen {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -247,9 +251,6 @@ button:hover.c0 {
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c3.kirk-loader--fullScreen {
   position: fixed;
   top: 0;
   left: 0;
@@ -259,7 +260,32 @@ button:hover.c0 {
   z-index: 4;
 }
 
-.c3.kirk-loader--done {
+.c3.kirk-loader--block {
+  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 16px 0;
+}
+
+.c3 .kirk-loader--done {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   background-color: #5DD167;
   color: #FFF;
   border-radius: 50%;
@@ -358,32 +384,36 @@ button:hover.c0 {
     className="kirk-item-rightAddon"
   >
     <div
-      className="kirk-loader c3"
-      style={
-        Object {
-          "height": "24px",
-          "width": "24px",
-        }
-      }
+      className="c3 kirk-loader--inline"
     >
-      <svg
-        aria-hidden={true}
-        className="kirk-icon kirk-icon-circle spinning c4 c1"
-        fill="#5DD167"
-        height={24}
-        viewBox="0 0 66 66"
-        width={24}
-        xmlns="http://www.w3.org/2000/svg"
+      <div
+        className=""
+        style={
+          Object {
+            "height": "24px",
+            "width": "24px",
+          }
+        }
       >
-        
-        <circle
-          cx="33"
-          cy="33"
-          fill="none"
-          r="30"
-          stroke="#5DD167"
-        />
-      </svg>
+        <svg
+          aria-hidden={true}
+          className="kirk-icon kirk-icon-circle spinning c4 c1"
+          fill="#5DD167"
+          height={24}
+          viewBox="0 0 66 66"
+          width={24}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          
+          <circle
+            cx="33"
+            cy="33"
+            fill="none"
+            r="30"
+            stroke="#5DD167"
+          />
+        </svg>
+      </div>
     </div>
   </span>
 </a>
@@ -613,7 +643,11 @@ button:hover.c0 {
   animation: dash 0.5s cubic-bezier(0.65,0,0.45,1) forwards;
 }
 
-.c3 {
+.c3.kirk-loader--inline {
+  display: inline-block;
+}
+
+.c3.kirk-loader--fullScreen {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -626,9 +660,6 @@ button:hover.c0 {
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c3.kirk-loader--fullScreen {
   position: fixed;
   top: 0;
   left: 0;
@@ -638,7 +669,32 @@ button:hover.c0 {
   z-index: 4;
 }
 
-.c3.kirk-loader--done {
+.c3.kirk-loader--block {
+  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 16px 0;
+}
+
+.c3 .kirk-loader--done {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   background-color: #5DD167;
   color: #FFF;
   border-radius: 50%;
@@ -737,34 +793,38 @@ button:hover.c0 {
     className="kirk-item-rightAddon"
   >
     <div
-      className="kirk-loader kirk-loader--done c3"
-      style={
-        Object {
-          "height": "24px",
-          "width": "24px",
-        }
-      }
+      className="c3 kirk-loader--inline"
     >
-      <svg
-        aria-hidden={true}
-        className="kirk-icon kirk-icon-check validate c4 c1"
-        fill="#FFF"
-        height={12}
-        viewBox="0 0 24 24"
-        width={12}
-        xmlns="http://www.w3.org/2000/svg"
+      <div
+        className="kirk-loader--done"
+        style={
+          Object {
+            "height": "24px",
+            "width": "24px",
+          }
+        }
       >
-        
-        <path
-          d="M6.5 12.5l4 4 8-8"
-          fill="none"
-          stroke="#FFF"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeMiterlimit="10"
-          strokeWidth="2"
-        />
-      </svg>
+        <svg
+          aria-hidden={true}
+          className="kirk-icon kirk-icon-check validate c4 c1"
+          fill="#FFF"
+          height={12}
+          viewBox="0 0 24 24"
+          width={12}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          
+          <path
+            d="M6.5 12.5l4 4 8-8"
+            fill="none"
+            stroke="#FFF"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeMiterlimit="10"
+            strokeWidth="2"
+          />
+        </svg>
+      </div>
     </div>
   </span>
 </a>

--- a/src/itemRadio/__snapshots__/ItemRadio.unit.tsx.snap
+++ b/src/itemRadio/__snapshots__/ItemRadio.unit.tsx.snap
@@ -542,7 +542,11 @@ button:hover.c0 {
   stroke-width: 0;
 }
 
-.c2 {
+.c2.kirk-loader--inline {
+  display: inline-block;
+}
+
+.c2.kirk-loader--fullScreen {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -555,9 +559,6 @@ button:hover.c0 {
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-}
-
-.c2.kirk-loader--fullScreen {
   position: fixed;
   top: 0;
   left: 0;
@@ -567,7 +568,32 @@ button:hover.c0 {
   z-index: 4;
 }
 
-.c2.kirk-loader--done {
+.c2.kirk-loader--block {
+  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 16px 0;
+}
+
+.c2 .kirk-loader--done {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
   background-color: #5DD167;
   color: #FFF;
   border-radius: 50%;
@@ -619,32 +645,36 @@ button:hover.c0 {
       value={0}
     />
     <div
-      className="kirk-loader c2"
-      style={
-        Object {
-          "height": "24px",
-          "width": "24px",
-        }
-      }
+      className="c2 kirk-loader--inline"
     >
-      <svg
-        aria-hidden={true}
-        className="kirk-icon kirk-icon-circle spinning c3 c4"
-        fill="#5DD167"
-        height={24}
-        viewBox="0 0 66 66"
-        width={24}
-        xmlns="http://www.w3.org/2000/svg"
+      <div
+        className=""
+        style={
+          Object {
+            "height": "24px",
+            "width": "24px",
+          }
+        }
       >
-        
-        <circle
-          cx="33"
-          cy="33"
-          fill="none"
-          r="30"
-          stroke="#5DD167"
-        />
-      </svg>
+        <svg
+          aria-hidden={true}
+          className="kirk-icon kirk-icon-circle spinning c3 c4"
+          fill="#5DD167"
+          height={24}
+          viewBox="0 0 66 66"
+          width={24}
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          
+          <circle
+            cx="33"
+            cy="33"
+            fill="none"
+            r="30"
+            stroke="#5DD167"
+          />
+        </svg>
+      </div>
     </div>
   </span>
 </label>

--- a/src/loader/Loader.tsx
+++ b/src/loader/Loader.tsx
@@ -1,16 +1,31 @@
 import React, { PureComponent } from 'react'
 import cc from 'classcat'
 
-import prefix from '_utils'
 import { color, transition } from '_utils/branding'
 import CircleIcon from 'icon/circleIcon'
 import CheckIcon from 'icon/checkIcon'
 
+const FULLSCREEN_MODE_CSS_CLASSNAME = 'kirk-loader--fullScreen'
+const INLINE_MODE_CSS_CLASSNAME = 'kirk-loader--inline'
+const BLOCK_MODE_CSS_CLASSNAME = 'kirk-loader--block'
+
+export enum LoaderLayoutMode {
+  // In this mode, the loader will be centered in the middle of the viewport and a modal mask
+  // will be applied to the viewport content.
+  FULLSCREEN = 'fullscreen',
+  // The loader will behave as an inline block.
+  INLINE = 'inline',
+  // The loader will behave as a block element with some vertical padding.
+  // It will be horizontally and vertically centered in the block content.
+  BLOCK = 'block',
+}
+
 export interface LoaderProps {
   className?: Classcat.Class
-  inline?: boolean
+  inline?: boolean // Deprecated, use layoutMode instead.
   size?: number
   done?: boolean
+  layoutMode?: LoaderLayoutMode
   onDoneAnimationEnd?: () => void
 }
 
@@ -40,22 +55,42 @@ class Loader extends PureComponent<LoaderProps> {
     }
   }
 
+  computeLayoutClass() {
+    const { inline, layoutMode } = this.props
+    if (inline) {
+      // Support for legacy inline attribute.
+      return INLINE_MODE_CSS_CLASSNAME
+    }
+
+    if (layoutMode) {
+      switch (layoutMode) {
+        case LoaderLayoutMode.INLINE:
+          return INLINE_MODE_CSS_CLASSNAME
+        case LoaderLayoutMode.BLOCK:
+          return BLOCK_MODE_CSS_CLASSNAME
+        case LoaderLayoutMode.FULLSCREEN:
+        default:
+          return FULLSCREEN_MODE_CSS_CLASSNAME
+      }
+    }
+
+    // Legacy fallback to fullscreen.
+    return FULLSCREEN_MODE_CSS_CLASSNAME
+  }
+
   render() {
-    const { className, inline, size, done } = this.props
-    const sizes = {
+    const { className, size, done } = this.props
+    const iconSize = {
       width: `${size}px`,
       height: `${size}px`,
     }
+
     return (
-      <div
-        className={cc([
-          prefix({ loader: true, 'loader--fullScreen': !inline, 'loader--done': done }),
-          className,
-        ])}
-        style={inline ? sizes : null}
-      >
-        {!done && <CircleIcon iconColor={color.success} size={size} spinning />}
-        {done && <CheckIcon iconColor={color.white} size={size / 2} validate />}
+      <div className={cc([className, this.computeLayoutClass()])}>
+        <div className={cc([{ 'kirk-loader--done': done }])} style={iconSize}>
+          {!done && <CircleIcon iconColor={color.success} size={size} spinning />}
+          {done && <CheckIcon iconColor={color.white} size={size / 2} validate />}
+        </div>
       </div>
     )
   }

--- a/src/loader/Loader.unit.tsx
+++ b/src/loader/Loader.unit.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { shallow, mount } from 'enzyme'
+import { mount } from 'enzyme'
 
-import Loader from './Loader'
+import Loader, { LoaderLayoutMode } from './Loader'
 import { StyledCircleIcon } from 'icon/circleIcon'
 import { StyledCheckIcon } from 'icon/checkIcon'
 
@@ -10,7 +10,7 @@ jest.useFakeTimers()
 describe('Loader', () => {
   it('Should have a custom className', () => {
     const customClassName = 'custom-loader'
-    const wrapper = shallow(<Loader className={customClassName} />)
+    const wrapper = mount(<Loader className={customClassName} />)
     expect(wrapper.hasClass(customClassName)).toBe(true)
   })
 
@@ -20,22 +20,47 @@ describe('Loader', () => {
     expect(wrapper.find(StyledCircleIcon).prop('size')).toBe(size)
   })
 
-  it('Should be inlined', () => {
+  it('Should be fullscreen by default', () => {
+    const wrapper = mount(<Loader />)
+    expect(wrapper.find('.kirk-loader--fullScreen').exists()).toBe(true)
+  })
+
+  it('Should be inline when using the prop', () => {
     const wrapper = mount(<Loader inline />)
-    expect(wrapper.prop('inline')).toBe(true)
+    expect(wrapper.find('.kirk-loader--inline').exists()).toBe(true)
+  })
+
+  it('Should override layoutMode when inline prop is set', () => {
+    const wrapper = mount(<Loader inline layoutMode={LoaderLayoutMode.BLOCK} />)
+    expect(wrapper.find('.kirk-loader--inline').exists()).toBe(true)
+  })
+
+  it('Should use correctly inline layout mode', () => {
+    const wrapper = mount(<Loader layoutMode={LoaderLayoutMode.INLINE} />)
+    expect(wrapper.find('.kirk-loader--inline').exists()).toBe(true)
+  })
+
+  it('Should use correctly block layout mode', () => {
+    const wrapper = mount(<Loader layoutMode={LoaderLayoutMode.BLOCK} />)
+    expect(wrapper.find('.kirk-loader--block').exists()).toBe(true)
+  })
+
+  it('Should use correctly fullscreen layout mode', () => {
+    const wrapper = mount(<Loader layoutMode={LoaderLayoutMode.FULLSCREEN} />)
+    expect(wrapper.find('.kirk-loader--fullScreen').exists()).toBe(true)
   })
 
   it('Should show the done icon', () => {
     const wrapper = mount(<Loader done />)
-    expect(wrapper.find(StyledCheckIcon)).toHaveLength(1)
+    expect(wrapper.find(StyledCheckIcon).exists()).toBe(true)
   })
 
   it('Should fire the callback event when done', () => {
-    const event = jest.fn()
-    const wrapper = mount(<Loader onDoneAnimationEnd={event} />)
+    const callback = jest.fn()
+    const wrapper = mount(<Loader onDoneAnimationEnd={callback} />)
     wrapper.setProps({ done: true })
-    expect(event).not.toBeCalled()
+    expect(callback).not.toBeCalled()
     jest.advanceTimersByTime(1500)
-    expect(event).toBeCalled()
+    expect(callback).toBeCalled()
   })
 })

--- a/src/loader/index.tsx
+++ b/src/loader/index.tsx
@@ -4,13 +4,14 @@ import { color } from '_utils/branding'
 import Loader from './Loader'
 
 const StyledLoader = styled(Loader)`
-  & {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  &.kirk-loader--inline {
+    display: inline-block;
   }
 
   &.kirk-loader--fullScreen {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     position: fixed;
     top: 0;
     left: 0;
@@ -20,12 +21,22 @@ const StyledLoader = styled(Loader)`
     z-index: 4;
   }
 
-  &.kirk-loader--done {
+  &.kirk-loader--block {
+    display: block;
+    display: flex;
+    justify-content: center;
+    padding: 16px 0;
+  }
+
+  & .kirk-loader--done {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     background-color: ${color.success};
     color: ${color.white};
     border-radius: 50%;
   }
 `
 
-export { LoaderProps } from './Loader'
+export { LoaderProps, LoaderLayoutMode } from './Loader'
 export default StyledLoader

--- a/src/loader/story.tsx
+++ b/src/loader/story.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 
 import { storiesOf } from '@storybook/react'
-import { withKnobs, boolean, number } from '@storybook/addon-knobs'
+import { withKnobs, boolean, number, select } from '@storybook/addon-knobs'
 import Section from 'layout/section/baseSection'
-import Loader from './index'
+import Loader, { LoaderLayoutMode } from './index'
 
 const stories = storiesOf('Widgets|Loader', module)
 stories.addDecorator(withKnobs)
@@ -11,7 +11,18 @@ stories.addDecorator(withKnobs)
 stories.add('default', () => (
   <Section>
     <Loader
-      inline={boolean('inline', true)}
+      layoutMode={select('layoutMode', LoaderLayoutMode, LoaderLayoutMode.FULLSCREEN)}
+      size={number('size', 48)}
+      done={boolean('done', false)}
+    />
+  </Section>
+))
+
+stories.add('legacy inline prop', () => (
+  <Section>
+    <Loader
+      inline={boolean('inline (deprecated - use layoutMode)', true)}
+      layoutMode={select('layoutMode', LoaderLayoutMode, null)}
       size={number('size', 48)}
       done={boolean('done', false)}
     />


### PR DESCRIPTION
Loader overhaul:
 - introduce a new **layoutMode** enum prop that can be in **inline** (existing), **fullscreen**( existing) or **block** (new) modes. The **block** mode renders the loader as a block (in the sense 'CSS block formatting context' with some top/bottom padding and centering the loader horizontally. This new block mode is used a bunch of time in BBC by using duplicated code like:

`<div className="flex justify-center">
                  <Loader inline />
                </div>`

 - The **inline** prop is commented as deprecated since it's a particular and simpler case of the layoutMode prop. It will be removed in a later PR to avoid a big breaking change. The new loader will be fuly backward compatible with existing cases.
- Fix the size param when using the fullscreen mode; previously it was broken and was stretching the loader to the viewport.
- Add tests to cover the new block mode and improve existing tests (remove shallow poop, test actual modes by checking explicit classes, etc).

TESTED=Locally in storybook (loader and itemaction/choice/radio stories) and unit tests (to test CSS classes states mostly).