### PR TITLE
Update hero section to accept search form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[UPDATE]** Add `searchForm` prop to `HeroSection`.
 - [...]
 
 # v29.2.0 (23/04/2020)

--- a/src/layout/section/heroSection/heroSection.tsx
+++ b/src/layout/section/heroSection/heroSection.tsx
@@ -1,17 +1,17 @@
 import React from 'react'
-import Button from 'button'
+import Button, { ButtonProps } from 'button'
 import Title from 'title'
 import Text, { TextTagType } from 'text'
 import cc from 'classcat'
 
 export interface HeroSectionProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly heroImageUrl: string
   readonly heroImageUrlLarge: string
   readonly heroText?: string
   readonly heroDescription?: string
   readonly buttonText?: string
-  readonly buttonHref?: string | JSX.Element
+  readonly buttonHref?: ButtonProps['href']
 }
 
 function HeroSection({

--- a/src/layout/section/heroSection/heroSection.tsx
+++ b/src/layout/section/heroSection/heroSection.tsx
@@ -1,17 +1,17 @@
-import React from 'react'
 import Button, { ButtonProps } from 'button'
-import Title from 'title'
-import Text, { TextTagType } from 'text'
-import cc from 'classcat'
+import React from 'react'
+import TextDisplay1 from 'typography/display1'
+import TextTitle from 'typography/title'
 
-export interface HeroSectionProps {
-  readonly className?: string
-  readonly heroImageUrl: string
-  readonly heroImageUrlLarge: string
-  readonly heroText?: string
-  readonly heroDescription?: string
-  readonly buttonText?: string
-  readonly buttonHref?: ButtonProps['href']
+export type HeroSectionProps = {
+  className?: string
+  heroImageUrl: string
+  heroImageUrlLarge: string
+  heroText?: string
+  heroDescription?: string
+  buttonText?: string
+  buttonHref?: ButtonProps['href']
+  bottomElement?: React.ReactElement
 }
 
 function HeroSection({
@@ -20,22 +20,28 @@ function HeroSection({
   heroDescription,
   buttonText,
   buttonHref,
+  bottomElement,
 }: HeroSectionProps) {
   return (
-    <div className={cc(className)}>
+    <div className={className}>
       <div className="hero-image" aria-hidden="true" />
-      <div className="hero-info wrapper wrapper--large">
+
+      <div className="hero-info">
         <div className="hero-info-title-wrapper">
-          <Title className="hero-info-title">{heroText}</Title>
+          <h1 className="hero-info-title">
+            <TextDisplay1 className="hero-info-title--display1">{heroText}</TextDisplay1>
+          </h1>
+
           {heroDescription && (
-            <Text tag={TextTagType.PARAGRAPH} className="hero-info-text">
-              {heroDescription}
-            </Text>
+            <p className="hero-info-text">
+              <TextTitle className="hero-info-text-title">{heroDescription}</TextTitle>
+            </p>
           )}
         </div>
-        <Button className="hero-button" href={buttonHref}>
-          {buttonText}
-        </Button>
+
+        <div className="hero-content">
+          {bottomElement ?? <Button href={buttonHref}>{buttonText}</Button>}
+        </div>
       </div>
     </div>
   )

--- a/src/layout/section/heroSection/heroSection.tsx
+++ b/src/layout/section/heroSection/heroSection.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react'
+import React from 'react'
 import Button from 'button'
 import Title from 'title'
 import Text, { TextTagType } from 'text'
@@ -14,28 +14,31 @@ export interface HeroSectionProps {
   readonly buttonHref?: string | JSX.Element
 }
 
-class HeroSection extends PureComponent<HeroSectionProps> {
-  render() {
-    const { className, heroText, heroDescription, buttonText, buttonHref } = this.props
-    return (
-      <div className={cc(className)}>
-        <div className="hero-image" aria-hidden="true" />
-        <div className="hero-info wrapper wrapper--large">
-          <div className="hero-info-title-wrapper">
-            <Title className="hero-info-title">{heroText}</Title>
-            {heroDescription && (
-              <Text tag={TextTagType.PARAGRAPH} className="hero-info-text">
-                {heroDescription}
-              </Text>
-            )}
-          </div>
-          <Button className="hero-button" href={buttonHref}>
-            {buttonText}
-          </Button>
+function HeroSection({
+  className,
+  heroText,
+  heroDescription,
+  buttonText,
+  buttonHref,
+}: HeroSectionProps) {
+  return (
+    <div className={cc(className)}>
+      <div className="hero-image" aria-hidden="true" />
+      <div className="hero-info wrapper wrapper--large">
+        <div className="hero-info-title-wrapper">
+          <Title className="hero-info-title">{heroText}</Title>
+          {heroDescription && (
+            <Text tag={TextTagType.PARAGRAPH} className="hero-info-text">
+              {heroDescription}
+            </Text>
+          )}
         </div>
+        <Button className="hero-button" href={buttonHref}>
+          {buttonText}
+        </Button>
       </div>
-    )
-  }
+    </div>
+  )
 }
 
 export default HeroSection

--- a/src/layout/section/heroSection/index.tsx
+++ b/src/layout/section/heroSection/index.tsx
@@ -1,123 +1,195 @@
-import styled from 'styled-components'
-import { responsiveBreakpoints, componentSizes, color, space } from '_utils/branding'
+import styled, { css } from 'styled-components'
+import { responsiveBreakpoints, componentSizes, color, space, font } from '_utils/branding'
+import HeroSection, { HeroSectionProps } from './heroSection'
 
-import HeroSection from './heroSection'
+// Remove these deprecated styles once all the button content parts have been removed.
+const DEPRECATED_STYLES = css`
+  & {
+    margin-bottom: 0;
+    height: initial;
+  }
+
+  & .hero-image {
+    position: static;
+    height: 136px;
+    background-image: ${(props: HeroSectionProps) => `url(${props.heroImageUrl})`};
+  }
+
+  & .hero-image::after {
+    content: none;
+  }
+
+  & .hero-info {
+    padding-top: ${space.xl};
+  }
+
+  & .hero-info-title--display1 {
+    color: ${color.primaryText};
+  }
+
+  & .hero-info-text-title {
+    color: ${color.secondaryText};
+    font-size: ${font.base.size};
+    line-height: ${font.base.lineHeight};
+  }
+
+  & .hero-content {
+    align-items: center;
+  }
+`
+
+const DEPRECATED_LARGE_MEDIA_STYLES = css`
+  & {
+    margin-bottom: ${space.xl};
+    justify-content: flex-end;
+  }
+
+  & .hero-image {
+    position: absolute;
+    background-image: ${(props: HeroSectionProps) => `url(${props.heroImageUrlLarge})`};
+  }
+
+  & .hero-image::after {
+    content: '';
+  }
+
+  & .hero-info {
+    padding-top: 0;
+    padding-bottom: ${space.xl};
+    margin-bottom: ${space.xl};
+  }
+
+  & .hero-info-title--display1 {
+    color: ${color.textWithBackground};
+  }
+
+  & .hero-info-text-title {
+    color: ${color.textWithBackground};
+  }
+`
 
 const StyledHeroSection = styled(HeroSection)`
   & {
     background-color: ${color.defaultBackground};
     position: relative;
     z-index: 1;
-    padding: 0;
+    height: 80vh;
+    margin-bottom: ${space.xl};
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-end;
   }
 
   & .hero-image {
-    position: relative;
-    min-height: 136px;
+    position: absolute;
+    z-index: -1;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 80%;
     background-size: cover;
     background-position: center;
-    background-image: ${props => `url(${props.heroImageUrl})`};
+    background-image: ${props => `url(${props.heroImageUrlLarge})`};
+
+    /* Hide the shadow. */
+    overflow: hidden;
+  }
+
+  & .hero-image::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 80%;
+    display: block;
+    background: linear-gradient(
+      0deg,
+      rgba(0, 0, 0, 0.4) 72%,
+      rgba(0, 0, 0, 0.2) 85%,
+      rgba(0, 0, 0, 0) 100%
+    );
   }
 
   & .hero-info {
-    text-align: center;
-    margin-left: auto;
-    margin-right: auto;
+    width: 100%;
     max-width: ${componentSizes.largeSectionWidth};
-    padding: ${space.xl};
-    padding-top: 0;
+    padding: 0 ${space.xl};
+    display: flex;
+    flex-direction: column;
+    align-items: center;
   }
 
   & .hero-info-title-wrapper {
-    display: flex;
-    flex-direction: column;
+    text-align: center;
   }
 
-  & .hero-info-title.kirk-title {
-    min-height: auto;
-    align-items: flex-end;
-    align-self: center;
-    display: flex;
-    padding-top: ${space.xl};
-    padding-bottom: ${space.ms};
+  & .hero-info-title {
+    margin: 0;
+    padding-top: ${space.m};
+    padding-bottom: ${space.m};
+  }
+  
+  & .hero-info-title--display1 {
+    color: ${color.textWithBackground};
+  }
+
+  & .hero-info-text {
     margin: 0;
   }
-
-  & .hero-button {
-    margin-top: ${space.xl};
+  
+  & .hero-info-text-title {
+    color: ${color.textWithBackground};
   }
+
+  & .hero-content {
+    width: 100%;
+    margin-top: ${space.xl};
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  ${props => (props.bottomElement == null ? DEPRECATED_STYLES : null)}
 
   @media (${responsiveBreakpoints.isMediaLarge}) {
     & {
       height: 75vh;
-      margin-bottom: ${space.xl};
-      /* Clip overflowing bottom shadow */
-      overflow: hidden;
+      justify-content: center;
     }
 
     & .hero-image {
       height: 100%;
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      z-index: 1;
-      background-image: ${props => `url(${props.heroImageUrlLarge});`};
+    }
+
+    & .hero-image::after {
+      height: 75%;
     }
 
     & .hero-info {
-      position: absolute;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      z-index: 3;
-      width: 100%;
-      margin-bottom: ${space.xl};
+      /* This value seams to work in most cases. */
+      padding-top: 120px;
     }
 
-    & .hero-info * {
-      position: relative;
-      z-index: 3;
-    }
-
-    & .hero-info::after {
-      content: '';
-      display: block;
-      width: 200%;
-      height: 150%;
-      position: absolute;
-      bottom: -${space.xl};
-      left: -50%;
-      right: -50%;
-      z-index: 2;
-      background: linear-gradient(
-        0deg,
-        rgba(0, 0, 0, 0.4) 72%,
-        rgba(0, 0, 0, 0.2) 85%,
-        rgba(0, 0, 0, 0) 100%
-      );
-    }
-
-    /* override ui-library */
-    & .hero-info .hero-info-title {
+    & .hero-info-title--display1 {
+      /* This is a custom font size which is only used for the hero section. */
       font-size: 60px;
-      color: ${color.textWithBackground};
-      padding-top: 8px;
-      padding-bottom: 8px;
+      line-height: 60px;
     }
 
-    /* override ui-library */
-    & .hero-info .hero-info-text {
-      font-size: 26px;
-      color: ${color.textWithBackground};
+    & .hero-info-text-title {
+      font-size: ${font.l.size};
+      line-height: ${font.l.lineHeight};
     }
 
-    & .hero-button {
-      margin-bottom: ${space.xl};
+    & .hero-content {
+      align-items: center;
     }
+
+    ${props => (props.bottomElement == null ? DEPRECATED_LARGE_MEDIA_STYLES : null)}
   }
 `
 
-export { HeroSectionProps } from './heroSection'
+export { HeroSectionProps }
 export default StyledHeroSection

--- a/src/layout/section/heroSection/index.unit.tsx
+++ b/src/layout/section/heroSection/index.unit.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import { mount } from 'enzyme'
 
-import HeroSection from './heroSection'
+import HeroSection, { HeroSectionProps } from './heroSection'
 
-const defaultProps = {
+const defaultProps: HeroSectionProps = {
   heroImageUrl: 'http://heroImageUrl',
   heroImageUrlLarge: 'http://heroImageUrl',
   heroText: 'hero text',
@@ -19,5 +19,18 @@ describe('HeroSection', () => {
     expect(wrapper.find('p').text()).toContain('hero description')
     const button = wrapper.find('a')
     expect(button.text()).toContain('button text')
+  })
+
+  it('should render a serch form', () => {
+    const props: HeroSectionProps = {
+      ...defaultProps,
+      bottomElement: <div>Bottom element</div>,
+    }
+
+    const wrapper = mount(<HeroSection {...props} />)
+    expect(wrapper.find('h1').text()).toContain('hero text')
+    expect(wrapper.find('p').text()).toContain('hero description')
+    expect(wrapper.find('a')).toHaveLength(0)
+    expect(wrapper.find('form')).toBeDefined()
   })
 })

--- a/src/layout/section/heroSection/story.tsx
+++ b/src/layout/section/heroSection/story.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
-
 import { storiesOf } from '@storybook/react'
 import { withKnobs, text } from '@storybook/addon-knobs'
-
 import HeroSection from './index'
+import SearchForm from 'searchForm'
+import MediaSizeProvider from '_utils/mediaSizeProvider'
+import { AutoCompleteExample } from 'autoComplete/story'
 
 const stories = storiesOf('Sections|HeroSection', module)
 stories.addDecorator(withKnobs)
@@ -21,9 +22,54 @@ stories.add('default', () => (
     )}
     heroImageUrlLarge={text(
       'heroImageUrlLarge',
-      'https://cdn.blablacar.com/kairos/assets/build/images/home_summer_campaign-1ea3207605913c1e26410e605a467eb7.jpg',
+      'https://cdn.blablacar.com/kairos/assets/build/images/home_summer_campaign_large-240e0d9fe2123506cca634c2acedce24.jpg',
     )}
     buttonText={text('buttonText', 'Rechercher un trajet')}
     buttonHref={text('buttonHref', 'http://google.fr')}
   />
+))
+
+stories.add('search form', () => (
+  <MediaSizeProvider>
+    <HeroSection
+      heroDescription={text(
+        'heroDescription',
+        'Bus ou covoiturage : choisissez le trajet qui vous convient le mieux',
+      )}
+      heroText={text('heroText', 'Et vous, qui allez-vous retrouver ?')}
+      heroImageUrl={text(
+        'heroImageUrl',
+        'https://cdn.blablacar.com/kairos/assets/build/images/home_summer_campaign-1ea3207605913c1e26410e605a467eb7.jpg',
+      )}
+      heroImageUrlLarge={text(
+        'heroImageUrlLarge',
+        'https://cdn.blablacar.com/kairos/assets/build/images/home_summer_campaign_large-240e0d9fe2123506cca634c2acedce24.jpg',
+      )}
+      bottomElement={
+        // This should not be needed...
+        // eslint-disable-next-line react/jsx-wrap-multilines
+        <SearchForm
+          onSubmit={() => {}}
+          autocompleteFromPlaceholder="Leaving From"
+          autocompleteToPlaceholder="Going to"
+          renderAutocompleteFrom={props => <AutoCompleteExample {...props} />}
+          renderAutocompleteTo={props => <AutoCompleteExample {...props} />}
+          datepickerProps={{
+            defaultValue: new Date().toISOString(),
+            format: value => new Date(value).toLocaleDateString(),
+          }}
+          stepperProps={{
+            defaultValue: 1,
+            min: 1,
+            max: 8,
+            title: 'Choose your number of seats',
+            increaseLabel: 'Increase the number of seats by 1',
+            decreaseLabel: 'Decrease the number of seats by 1',
+            format: value => `${value} seat(s)`,
+            confirmLabel: 'Submit',
+          }}
+        />
+      }
+    />
+  </MediaSizeProvider>
 ))


### PR DESCRIPTION
The `HeroSection` component now support 2 contents:
- A link to the search page (deprecated)
- The `SearchForm` component

**DEMO**

Desktop: 
<img width="1312" alt="Screenshot 2020-04-20 at 15 48 12" src="https://user-images.githubusercontent.com/17502801/79759032-74335480-831e-11ea-98b9-7378a2291ec9.png">

Mobile: 
<img width="391" alt="Screenshot 2020-04-20 at 15 48 35" src="https://user-images.githubusercontent.com/17502801/79759060-7c8b8f80-831e-11ea-8682-b8650b2733d6.png">


**TESTED**: Unit test and manually on Chrome, Firefox and Safari