### PR TITLE
[BOYSCOUT] Fix typography invalid styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Fix the `font-size` and `line-height` of `TextBody`, `TextSubHeader` and `TextTitle` components.
 - [...]
 
 # v29.0.0 (20/04/2020)

--- a/src/review/__snapshots__/Review.unit.tsx.snap
+++ b/src/review/__snapshots__/Review.unit.tsx.snap
@@ -99,7 +99,8 @@ Array [
 .c1 {
   color: #054752;
   font-size: 18px;
-  font-weight: 400 line-height:20px;
+  font-weight: 400;
+  line-height: 20px;
 }
 
 .c0 {
@@ -252,7 +253,8 @@ Array [
 .c1 {
   color: #054752;
   font-size: 18px;
-  font-weight: 400 line-height:20px;
+  font-weight: 400;
+  line-height: 20px;
 }
 
 .c0 {

--- a/src/typography/body/index.tsx
+++ b/src/typography/body/index.tsx
@@ -6,7 +6,7 @@ import TextStyle from '../index'
 const TextBody = styled(TextStyle)`
   color: ${color.secondaryText};
   font-size: ${font.base.size};
-  font-weight: ${fontWeight.regular} 
+  font-weight: ${fontWeight.regular};
   line-height: ${font.base.lineHeight};
 `
 export default TextBody

--- a/src/typography/subHeader/index.tsx
+++ b/src/typography/subHeader/index.tsx
@@ -6,7 +6,7 @@ import Text from '../index'
 const TextSubHeader = styled(Text)`
   color: ${color.primaryText};
   font-size: ${font.l.size};
-  font-weight: ${fontWeight.regular} 
+  font-weight: ${fontWeight.regular};
   line-height: ${font.l.lineHeight};
 `
 export default TextSubHeader

--- a/src/typography/title/index.tsx
+++ b/src/typography/title/index.tsx
@@ -6,7 +6,7 @@ import Text from '../index'
 const TextTitle = styled(Text)`
   color: ${color.primaryText};
   font-size: ${font.m.size};
-  font-weight: ${fontWeight.regular} 
+  font-weight: ${fontWeight.regular};
   line-height: ${font.m.lineHeight};
 `
 export default TextTitle


### PR DESCRIPTION
## Description

Some missing semi-colons are causing styles to be generated as:

```css
font-weight: 400 line-height:24px;
```

## What has been done

Add a semi-colon at the end of a CSS line.

## Things to consider

For the `TextBody` screenshots bellow, only the `line-height` fix is visible as `font-weight: 400` is the default one.

## How was it tested

With storybook. I also updated some (invalid) snapshots.

| Component        | Before           | After  |
| ------------- |-------------| -----|
| `TextBody` | <img width="110" alt="Screenshot 2020-04-20 at 18 09 32" src="https://user-images.githubusercontent.com/17502801/79775790-0ba3a200-8335-11ea-8216-a86ac9849998.png"> | <img width="113" alt="Screenshot 2020-04-20 at 18 10 02" src="https://user-images.githubusercontent.com/17502801/79775894-30981500-8335-11ea-9c57-378a4532a3fe.png"> |
| `TextSubHeader` | <img width="144" alt="Screenshot 2020-04-20 at 18 09 39" src="https://user-images.githubusercontent.com/17502801/79775973-51f90100-8335-11ea-9aa8-c8ae6eca593c.png"> | <img width="146" alt="Screenshot 2020-04-20 at 18 09 58" src="https://user-images.githubusercontent.com/17502801/79775990-58877880-8335-11ea-95d0-0b19ddadf642.png"> |
| `TextTitle`      | <img width="137" alt="Screenshot 2020-04-20 at 18 09 14" src="https://user-images.githubusercontent.com/17502801/79775509-a3ed5700-8334-11ea-8713-6f5b5aed18a9.png"> | <img width="129" alt="Screenshot 2020-04-20 at 18 09 53" src="https://user-images.githubusercontent.com/17502801/79775485-99cb5880-8334-11ea-9d75-3dbdd5f13a1a.png"> |
