### PR TITLE
Fix breakpoints values to make them exclusive betweens small & large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- [...]
+- **[FIX]** Fix breakpoints values to make them exclusive betweens small & large
 
 # v29.1.0 (21/04/2020)
 

--- a/src/_utils/branding.ts
+++ b/src/_utils/branding.ts
@@ -130,10 +130,11 @@ export const inputBorderSize = {
   focus: '3px',
 }
 
-const smallBreakPointThreshold = '800px'
+const largeBreakPointThreshold = '800px'
+const smallBreakPointThreshold = '799px'
 export const responsiveBreakpoints = {
   small: smallBreakPointThreshold,
-  isMediaLarge: `min-width: ${smallBreakPointThreshold}`,
+  isMediaLarge: `min-width: ${largeBreakPointThreshold}`,
   isMediaSmall: `max-width: ${smallBreakPointThreshold}`,
 }
 

--- a/src/_utils/mediaSizeProvider/index.tsx
+++ b/src/_utils/mediaSizeProvider/index.tsx
@@ -19,7 +19,7 @@ export const MediaSizeProvider = ({ children }: MediaSizeProviderProps) => {
   const [mediaSize, setMediaSize] = useState(MediaSize.SMALL)
 
   const handleResize = () => {
-    const isSmall = window.innerWidth < parseInt(responsiveBreakpoints.small, 10)
+    const isSmall = window.innerWidth <= parseInt(responsiveBreakpoints.small, 10)
     setMediaSize(isSmall ? MediaSize.SMALL : MediaSize.LARGE)
   }
 

--- a/src/layout/columns/__snapshots__/index.unit.tsx.snap
+++ b/src/layout/columns/__snapshots__/index.unit.tsx.snap
@@ -23,7 +23,7 @@ exports[`Columns should render default columns 1`] = `
   margin: 0;
 }
 
-@media (max-width:800px) {
+@media (max-width:799px) {
   .c0 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;

--- a/src/layout/section/highlightSection/__snapshots__/index.unit.tsx.snap
+++ b/src/layout/section/highlightSection/__snapshots__/index.unit.tsx.snap
@@ -49,7 +49,7 @@ exports[`HighlightSection should add a classname to the content 1`] = `
   }
 }
 
-@media (max-width:800px) {
+@media (max-width:799px) {
   .c0 .kirk-subheader {
     text-align: center;
   }
@@ -121,7 +121,7 @@ exports[`HighlightSection should render default highlight section 1`] = `
   }
 }
 
-@media (max-width:800px) {
+@media (max-width:799px) {
   .c0 .kirk-subheader {
     text-align: center;
   }

--- a/src/layout/section/mediaContentSection/__snapshots__/index.unit.tsx.snap
+++ b/src/layout/section/mediaContentSection/__snapshots__/index.unit.tsx.snap
@@ -337,7 +337,7 @@ exports[`MediaContentSection should render default MediaContentSection section 1
   }
 }
 
-@media (max-width:800px) {
+@media (max-width:799px) {
   .c2 {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
@@ -357,7 +357,7 @@ exports[`MediaContentSection should render default MediaContentSection section 1
   }
 }
 
-@media (max-width:800px) {
+@media (max-width:799px) {
   .c0 .kirk-media-content-img {
     height: 136px;
     min-height: 0;

--- a/src/layout/section/tabsSection/__snapshots__/index.unit.tsx.snap
+++ b/src/layout/section/tabsSection/__snapshots__/index.unit.tsx.snap
@@ -138,7 +138,7 @@ exports[`TabsSection should render default TabsSection 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-@media (max-width:800px) {
+@media (max-width:799px) {
   .c0 .kirk-panels-section {
     padding-left: 24px;
     padding-right: 24px;

--- a/src/modal/__snapshots__/Modal.unit.tsx.snap
+++ b/src/modal/__snapshots__/Modal.unit.tsx.snap
@@ -326,7 +326,7 @@ exports[`Modal should not have changed 1`] = `
   }
 }
 
-@media (max-width:800px) {
+@media (max-width:799px) {
   .c0 .media-section {
     margin-left: -24px;
     margin-right: -24px;


### PR DESCRIPTION
## Description

The issue was that depending on how we write media queries based on small or large breakpoints, the rendering would differ when the screen is 800px. 
It also broke the mediaSizeProvider which we could in certain case like in the search form returning large instead of small.
See example below: rendering on 800px screen, we should have Divider between the fields which are based on MediaSizeProvider returning large
![image (8)](https://user-images.githubusercontent.com/1606624/79883897-be870500-83f4-11ea-8361-8dcfcb6efa61.png)

## What has been done

Have exclusive values for large and small fixes the issue

## Things to consider

This also makes it consistent with the logic we have in the SPA on breakpoints.

## How was it was tested

Tested locally on storybook
