### PR TITLE
[Fix] Resolve `ModalProps` path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Convert `SuccessModalProps` and `ModalProps` to type instead of interface; Resolve `ModalProps` path;
 - **[FIX]** Fix breakpoints values to make them exclusive betweens small & large
 - **[UPDATE]** Use focus & blur for improving keyboard navigation in `searchForm`
 - [...]

--- a/src/modal/Modal.tsx
+++ b/src/modal/Modal.tsx
@@ -19,22 +19,22 @@ export enum ModalSize {
   FULLSCREEN = 'fullscreen',
 }
 
-export interface ModalProps {
-  readonly onClose: () => void
-  readonly isOpen?: boolean
-  readonly children?: React.ReactNode
-  readonly className?: Classcat.Class
-  readonly modalContentClassName?: Classcat.Class
-  readonly closeOnEsc?: boolean
-  readonly closeOnOutsideClick?: boolean
-  readonly displayCloseButton?: boolean
-  readonly size?: ModalSize
-  readonly displayDimmer?: boolean
-  readonly closeButtonTitle?: string
-  readonly forwardedRef?: Ref<HTMLDivElement>
-  readonly ariaLabelledBy?: string
-  readonly ariaDescribedBy?: string
-}
+export type ModalProps = Readonly<{
+  onClose: () => void
+  isOpen?: boolean
+  children?: React.ReactNode
+  className?: Classcat.Class
+  modalContentClassName?: Classcat.Class
+  closeOnEsc?: boolean
+  closeOnOutsideClick?: boolean
+  displayCloseButton?: boolean
+  size?: ModalSize
+  displayDimmer?: boolean
+  closeButtonTitle?: string
+  forwardedRef?: Ref<HTMLDivElement>
+  ariaLabelledBy?: string
+  ariaDescribedBy?: string
+}>
 
 export default class Modal extends Component<ModalProps> {
   private portalNode: HTMLElement

--- a/src/successModal/SuccessModal.tsx
+++ b/src/successModal/SuccessModal.tsx
@@ -1,18 +1,20 @@
 import React from 'react'
 import uuidv4 from 'uuid/v4'
 
-import { ModalProps } from 'modal'
 import { ButtonStatus } from 'button'
+
+import { ModalProps } from '../modal'
 
 import TextDisplay1 from 'typography/display1'
 
 import SuccessModalElements from './elements'
 
-export interface SuccessModalProps extends ModalProps {
-  readonly confirmLabel?: string
-  readonly imageSrc: string
-  readonly imageText?: string
-}
+export type SuccessModalProps = ModalProps &
+  Readonly<{
+    confirmLabel?: string
+    imageSrc: string
+    imageText?: string
+  }>
 
 const SuccessModal = (props: SuccessModalProps): JSX.Element => {
   const {

--- a/src/successModal/SuccessModal.tsx
+++ b/src/successModal/SuccessModal.tsx
@@ -4,7 +4,7 @@ import uuidv4 from 'uuid/v4'
 import { ButtonStatus } from 'button'
 
 // TODO: fix alias resolving path on build
-// Must use natural path since alias is broken
+// Must use relative path since alias is broken
 import { ModalProps } from '../modal'
 
 import TextDisplay1 from 'typography/display1'

--- a/src/successModal/SuccessModal.tsx
+++ b/src/successModal/SuccessModal.tsx
@@ -3,6 +3,8 @@ import uuidv4 from 'uuid/v4'
 
 import { ButtonStatus } from 'button'
 
+// TODO: fix alias resolving path on build
+// Must use natural path since alias is broken
 import { ModalProps } from '../modal'
 
 import TextDisplay1 from 'typography/display1'


### PR DESCRIPTION
## Description

<!-- Give some context of this PR. Illustrate with screenshots or a video (gif, loom, etc.) -->

`ModalProps` hasn't been found when extended on other components.

_SPA_ is not able to resolve the 'modal' path (which is normal because it has no way of knowing where to find it), the issue will appear for every type that reference at least one from another file.

## What has been done

<!-- How do you solve the problem? -->

- update path

## Things to consider

<!-- Explain your changes. What are you expecting for the reviewers?  -->

- Convert **interface** into **type**

## How was it was tested

<!--  Local environment with ui-library only, integrated within the main project, on which browsers, etc.   -->

-  **Manually** fixing it on node_modules
