### PR TITLE
Fix the Hint close icon when the content is too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** `Hint` close icon was cropped when the hint content was too long.
 - [...]
 
 # v29.3.0 (24/04/2020)

--- a/src/hint/HintBubble.tsx
+++ b/src/hint/HintBubble.tsx
@@ -65,6 +65,7 @@ export default styled(HintBubble)`
   & p {
     margin: 0;
     padding: 0;
+    flex: 1;
   }
 
   & .kirk-button {

--- a/src/hint/__snapshots__/index.unit.tsx.snap
+++ b/src/hint/__snapshots__/index.unit.tsx.snap
@@ -225,6 +225,9 @@ exports[`Hint Default rendering (above) 1`] = `
 .c2 p {
   margin: 0;
   padding: 0;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 .c2 .kirk-button {
@@ -571,6 +574,9 @@ exports[`Hint Default rendering (below) 1`] = `
 .c2 p {
   margin: 0;
   padding: 0;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 }
 
 .c2 .kirk-button {


### PR DESCRIPTION
## Description

When the content of the hint is too long the cross is cropped. This PR fixes it.
![image](https://user-images.githubusercontent.com/2495124/80197148-88c56480-861e-11ea-8561-7bfe44baec2b.png)


## What has been done

Just add a `flex: 1`.

## How was it was tested

Tested locally in storybook

![image](https://user-images.githubusercontent.com/2495124/80197606-2456d500-861f-11ea-8122-da8d2d4a3a3d.png)

