### PR TITLE
Fix typo in github issue template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,15 +2,14 @@
 
 <!-- Give some context of this PR. Illustrate with screenshots or a video (gif, loom, etc.) -->
 
-
 ## What has been done
 
 <!-- How do you solve the problem? -->
 
 ## Things to consider
 
-<!-- Explain your changes. What are you expecting for the reviewers?  -->
+<!-- Explain your changes. What are you expecting for the reviewers? -->
 
-## How was it was tested
+## How it was tested
 
-<!--  Local environment with ui-library only, integrated within the main project, on which browsers, etc.   -->
+<!-- Local environment with ui-library only, integrated within the main project, on which browsers, etc. -->


### PR DESCRIPTION
## Description

Fix the typo in the Github issue template "How was it was tested" => "How it was tested".

## What has been done

Remove the 2nd "was".

## Things to consider

Not much.

## How it was tested

I wasn't 🤷‍♂️.