### PR TITLE
[BREAKING CHANGE] Make all className type string instead of Classcat.Class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[BREAKING CHANGE]** All `className` prop types have been changed to `string` instead of `Classcat.Class`
 - **[FIX]** Define `CardsSection`'s justify-content to be centered only in large screens
 - **[UPDATE]** Add focus trap & handling overflow on `searchForm` section components
 - [...]

--- a/src/_utils/card/Card.tsx
+++ b/src/_utils/card/Card.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import cc from 'classcat'
 
 export interface CardProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly children?: React.ReactNode
 }
 

--- a/src/_utils/index.tsx
+++ b/src/_utils/index.tsx
@@ -4,9 +4,9 @@ import { canUseDOM } from 'exenv'
 export const prefix = (
   modifiers: Classcat.ClassObject = {},
   baseClass: string = 'kirk',
-): string[] => {
+): string => {
   const mods = Object.keys(modifiers).filter(elem => modifiers[elem])
-  return [].concat(mods.map(modifier => `${baseClass}-${modifier}`))
+  return mods.map(modifier => `${baseClass}-${modifier}`).join(' ')
 }
 
 export const isTouchEventsAvailable = () =>

--- a/src/_utils/index.unit.tsx
+++ b/src/_utils/index.unit.tsx
@@ -11,10 +11,10 @@ const multipleLineTextWithBR = replaceNewLineWithBR(multipleLineText)
 
 describe('prefix', () => {
   it('Should render prefix syntax with the base class', () => {
-    expect(prefix({}, 'base')).toEqual([])
-    expect(prefix({ modifiers: true }, 'base')).toEqual(['base-modifiers'])
-    expect(prefix({ modifiers: false }, 'base')).toEqual([])
-    expect(prefix({ 'modifier-1': true, 'modifier-2': false }, 'base')).toEqual(['base-modifier-1'])
+    expect(prefix({}, 'base')).toEqual('')
+    expect(prefix({ modifiers: true }, 'base')).toEqual('base-modifiers')
+    expect(prefix({ modifiers: false }, 'base')).toEqual('')
+    expect(prefix({ 'modifier-1': true, 'modifier-2': false }, 'base')).toEqual('base-modifier-1')
   })
 })
 

--- a/src/_utils/interfaces.ts
+++ b/src/_utils/interfaces.ts
@@ -1,7 +1,7 @@
 export interface CommonFieldsProps {
   readonly id?: string
   readonly name: string
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly value: string
   readonly disabled?: boolean
   readonly autoFocus?: boolean

--- a/src/_utils/item/Item.tsx
+++ b/src/_utils/item/Item.tsx
@@ -15,7 +15,7 @@ export enum ItemStatus {
 
 export interface ItemProps extends A11yProps {
   readonly chevron?: boolean
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly href?: string | JSX.Element
   readonly highlighted?: boolean
   readonly isClickable?: boolean

--- a/src/_utils/itineraryCollapsible/ItineraryCollapsible.tsx
+++ b/src/_utils/itineraryCollapsible/ItineraryCollapsible.tsx
@@ -10,7 +10,7 @@ import ItineraryLocation, { computeKeyFromPlace } from '_utils/itineraryLocation
 
 export interface ItineraryCollapsibleProps {
   readonly places: Place[]
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly label?: string
   readonly ariaLabel?: string
 }

--- a/src/_utils/itineraryLocation/ItineraryLocation.tsx
+++ b/src/_utils/itineraryLocation/ItineraryLocation.tsx
@@ -9,7 +9,7 @@ import Text, { TextDisplayType, TextTagType } from 'text'
 
 export interface ItineraryLocationProps {
   readonly place: Place
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly isSmall?: boolean
   readonly isArrival?: boolean
   readonly hasBottomAddon?: boolean

--- a/src/autoComplete/AutoCompleteList.tsx
+++ b/src/autoComplete/AutoCompleteList.tsx
@@ -12,10 +12,10 @@ import ItemsList from 'itemsList'
 export interface AutoCompleteListProps {
   name: string
   onSelect?: (item: AutocompleteItem) => void
-  className?: Classcat.Class
+  className?: string
   items?: AutocompleteItem[]
   maxItems?: number
-  itemClassName?: Classcat.Class
+  itemClassName?: string
   onDoneAnimationEnd?: () => void
   itemKey?: (item: AutocompleteItem) => string
   visible?: boolean

--- a/src/avatar/Avatar.tsx
+++ b/src/avatar/Avatar.tsx
@@ -7,7 +7,7 @@ import Badge from 'badge'
 import CheckIcon from 'icon/checkIcon'
 
 export interface AvatarProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly image?: string
   readonly alt?: string
   readonly isSmall?: boolean

--- a/src/badge/Badge.tsx
+++ b/src/badge/Badge.tsx
@@ -3,7 +3,7 @@ import cc from 'classcat'
 import isEmpty from 'lodash.isempty'
 
 export interface BadgeProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly children: string | JSX.Element | number
   readonly ariaLabel?: string
 }

--- a/src/blankSeparator/BlankSeparator.tsx
+++ b/src/blankSeparator/BlankSeparator.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import cc from 'classcat'
 
 export interface BlankSeparatorProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly size?: BlankSeparatorSize
 }
 

--- a/src/bullet/Bullet.tsx
+++ b/src/bullet/Bullet.tsx
@@ -11,7 +11,7 @@ export enum BulletTypes {
 }
 
 export interface BulletProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly type?: BulletTypes
 }
 

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -20,7 +20,7 @@ export interface ButtonProps extends A11yProps {
   readonly children: string | number | React.ReactNode
   readonly type?: string
   readonly href?: string | JSX.Element
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly title?: string
   readonly status?: ButtonStatus
   readonly focus?: boolean

--- a/src/buttonGroup/ButtonGroup.tsx
+++ b/src/buttonGroup/ButtonGroup.tsx
@@ -7,13 +7,13 @@ import { ButtonProps } from 'button/Button'
 
 export interface ButtonGroupProps {
   readonly children: React.ReactElement<ButtonProps>[]
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly isInline?: boolean
   readonly isReverse?: boolean
   readonly loadingIndex?: string
 }
 
-const [BASE_CLASSNAME] = prefix({ 'button-group': true })
+const BASE_CLASSNAME = prefix({ 'button-group': true })
 
 const ButtonGroup = ({
   children,

--- a/src/caption/Caption.tsx
+++ b/src/caption/Caption.tsx
@@ -13,7 +13,7 @@ export const renderSecondary = (href?: string, secondaryText?: string) =>
   )
 
 export interface CaptionProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly children: any
   readonly isoDate: string
   readonly href?: string

--- a/src/datePicker/DatePicker.tsx
+++ b/src/datePicker/DatePicker.tsx
@@ -7,7 +7,7 @@ import { color } from '_utils/branding'
 import ArrowIcon from 'icon/arrowIcon'
 import Button, { ButtonStatus } from 'button'
 
-const [BASE_CLASSNAME] = prefix({ datepicker: true })
+const BASE_CLASSNAME = prefix({ datepicker: true })
 
 const defaultWeekdaysLong = [0, 1, 2, 3, 4, 5, 6].map(weekday =>
   DayPicker.LocaleUtils.formatWeekdayLong(weekday),

--- a/src/divider/Divider.tsx
+++ b/src/divider/Divider.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import cc from 'classcat'
 
 export interface DividerProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
 }
 
 const Divider = ({ className }: DividerProps) => (

--- a/src/drawer/Drawer.tsx
+++ b/src/drawer/Drawer.tsx
@@ -12,8 +12,8 @@ const DrawerGlobalStyles = createGlobalStyle`
 
 export interface DrawerProps {
   readonly children: string | JSX.Element
-  readonly className?: Classcat.Class
-  readonly innerClassName?: Classcat.Class
+  readonly className?: string
+  readonly innerClassName?: string
   readonly onOpen?: () => void
   readonly onClose?: () => void
   readonly onTransitionEnd?: (open: boolean) => void

--- a/src/emptyState/EmptyState.tsx
+++ b/src/emptyState/EmptyState.tsx
@@ -3,7 +3,7 @@ import cc from 'classcat'
 import Title from 'title'
 
 export interface EmptyStateProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly image: string
   readonly text: string
   readonly button?: JSX.Element

--- a/src/hamburgerButton/HamburgerButton.tsx
+++ b/src/hamburgerButton/HamburgerButton.tsx
@@ -4,7 +4,7 @@ import cc from 'classcat'
 export interface HamburgerButtonProps {
   onClick: (event: React.MouseEvent<HTMLElement>) => void
   open?: boolean
-  readonly className?: Classcat.Class
+  readonly className?: string
 }
 
 const HamburgerButton = ({ open = false, onClick, className }: HamburgerButtonProps) => (

--- a/src/hint/HintBubble.tsx
+++ b/src/hint/HintBubble.tsx
@@ -14,7 +14,7 @@ export enum HintBubblePosition {
 
 export interface HintBubbleProps extends A11yProps {
   title: string
-  className?: Classcat.Class
+  className?: string
   onClose: () => void
   closeButtonTitle?: string
   description?: string

--- a/src/itemAction/index.tsx
+++ b/src/itemAction/index.tsx
@@ -9,7 +9,7 @@ import prefix from '_utils'
 export interface ItemActionProps extends A11yProps {
   readonly highlighted?: boolean
   readonly tag?: JSX.Element
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly href?: string | JSX.Element
   readonly action?: string
   readonly subLabel?: string

--- a/src/itemCheckbox/ItemCheckbox.tsx
+++ b/src/itemCheckbox/ItemCheckbox.tsx
@@ -15,7 +15,7 @@ export interface ItemCheckboxProps extends A11yProps {
   readonly label: string
   readonly name: string
   readonly data?: string
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly labelTitle?: string
   readonly dataInfo?: string
   readonly checked?: boolean

--- a/src/itemChoice/index.tsx
+++ b/src/itemChoice/index.tsx
@@ -22,7 +22,7 @@ export interface ItemChoiceProps extends A11yProps {
   readonly dataInfo?: string
   readonly leftAddon?: JSX.Element
   readonly rightAddon?: JSX.Element
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly href?: string | JSX.Element
   readonly status?: ItemStatus
   readonly style?: ItemChoiceStyle

--- a/src/itemData/index.tsx
+++ b/src/itemData/index.tsx
@@ -10,7 +10,7 @@ export interface ItemDataProps extends A11yProps {
   readonly dataStrikeThrough?: boolean
   readonly dataAriaLabel?: string
   readonly mainInfo: string
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly mainTitle?: string
   readonly mainTitleButtonAddon?: React.ReactElement<Button>
   readonly dataInfo?: string

--- a/src/itemInfo/index.tsx
+++ b/src/itemInfo/index.tsx
@@ -5,7 +5,7 @@ import { A11yProps, pickA11yProps } from '_utils/interfaces'
 
 export interface ItemInfoProps extends A11yProps {
   readonly mainInfo: string
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly icon?: React.ReactNode
   readonly mainTitle?: string
   readonly tag?: JSX.Element

--- a/src/itemRadio/ItemRadio.tsx
+++ b/src/itemRadio/ItemRadio.tsx
@@ -16,7 +16,7 @@ export interface ItemRadioProps extends A11yProps {
   readonly name: string
   readonly value: string | number
   readonly data?: string
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly labelTitle?: string
   readonly dataInfo?: string
   readonly checked?: boolean

--- a/src/itemRadioGroup/index.tsx
+++ b/src/itemRadioGroup/index.tsx
@@ -6,7 +6,7 @@ import ItemsList from 'itemsList'
 export interface ItemRadioGroupProps {
   readonly name: string
   readonly children: React.ReactElement<ItemRadioProps>[]
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly value?: string | number | boolean
   readonly onChange?: (obj: OnChangeParameters) => void
   readonly onClick?: (obj: OnChangeParameters) => void

--- a/src/itemsList/ItemsList.tsx
+++ b/src/itemsList/ItemsList.tsx
@@ -17,7 +17,7 @@ export type ItemsListChild =
 export interface ItemsListProps {
   readonly children: ItemsListChild[]
   readonly withSeparators?: boolean
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly keyGenerator?: (index: number) => string | number
   readonly role?: string
 }

--- a/src/itinerary/Itinerary.tsx
+++ b/src/itinerary/Itinerary.tsx
@@ -15,7 +15,7 @@ export interface ItineraryProps {
   readonly ariaLabelledBy?: string
   readonly ariaLabel?: string
   readonly places: Place[]
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly fromAddon?: string
   readonly toAddon?: string
   readonly fromAddonAriaLabel?: string

--- a/src/layout/column/column.tsx
+++ b/src/layout/column/column.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import cc from 'classcat'
 
 export interface ColumnProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly children?: React.ReactNode
   readonly key?: string
 }

--- a/src/layout/columns/columns.tsx
+++ b/src/layout/columns/columns.tsx
@@ -3,7 +3,7 @@ import cc from 'classcat'
 import { ColumnProps } from 'layout/column'
 
 export interface ColumnsProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly children: React.ReactElement<ColumnProps>[]
 }
 

--- a/src/layout/section/baseSection/baseSection.tsx
+++ b/src/layout/section/baseSection/baseSection.tsx
@@ -7,8 +7,8 @@ export enum SectionContentSize {
 }
 
 export interface BaseSectionProps {
-  readonly className?: Classcat.Class
-  readonly contentClassName?: Classcat.Class
+  readonly className?: string
+  readonly contentClassName?: string
   readonly backgroundStyle?: object
   readonly tagName?: string
   readonly role?: string

--- a/src/layout/section/cardsSection/CardsSection.tsx
+++ b/src/layout/section/cardsSection/CardsSection.tsx
@@ -8,7 +8,7 @@ type CardsProps = TripCardProps | QrCardProps
 
 export interface CardsSectionProps {
   readonly children: React.ReactElement<CardsProps>[] | React.ReactElement<CardsProps>
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly width?: string
 }
 

--- a/src/layout/section/columnedContentSection/columnedContentSection.tsx
+++ b/src/layout/section/columnedContentSection/columnedContentSection.tsx
@@ -7,7 +7,7 @@ import Text, { TextTagType } from 'text'
 import Title from 'title'
 
 export interface ColumnedContentSectionProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly title: string
   readonly topLinkLabel?: string
   readonly topLinkHref?: string | JSX.Element

--- a/src/layout/section/highlightSection/highlightSection.tsx
+++ b/src/layout/section/highlightSection/highlightSection.tsx
@@ -3,8 +3,8 @@ import BaseSection, { SectionContentSize } from 'layout/section/baseSection'
 import SubHeader from 'subHeader'
 
 export interface HighlightSectionProps {
-  readonly className?: Classcat.Class
-  readonly contentClassName?: Classcat.Class
+  readonly className?: string
+  readonly contentClassName?: string
   readonly children: React.ReactNode
   readonly title?: string
 }

--- a/src/layout/section/illustratedSection/illustratedSection.tsx
+++ b/src/layout/section/illustratedSection/illustratedSection.tsx
@@ -4,7 +4,7 @@ import Avatar from 'avatar'
 
 export interface IllustratedSectionProps {
   readonly children: React.ReactNode
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly illustrationUrl: string
   readonly illustrationAlt?: string
   readonly isAvatar?: boolean

--- a/src/layout/section/itemsSection/itemsSection.tsx
+++ b/src/layout/section/itemsSection/itemsSection.tsx
@@ -6,7 +6,7 @@ import BaseSection from 'layout/section/baseSection'
 
 export interface ItemsSectionProps {
   readonly children: React.ReactElement<ItemInfoProps>[]
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly tag?: JSX.Element
 }
 

--- a/src/layout/section/mediaContentSection/mediaContentSection.tsx
+++ b/src/layout/section/mediaContentSection/mediaContentSection.tsx
@@ -7,7 +7,7 @@ import Text, { TextTagType } from 'text'
 import Button from 'button'
 
 export interface MediaContentSectionProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly mediaUrl: string
   readonly title: string
   readonly content?: string

--- a/src/layout/section/mediaSection/mediaSection.tsx
+++ b/src/layout/section/mediaSection/mediaSection.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import cc from 'classcat'
 
 export interface MediaSectionProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly role?: string
   readonly children: React.ReactNode
 }

--- a/src/layout/section/tabsSection/tabsSection.tsx
+++ b/src/layout/section/tabsSection/tabsSection.tsx
@@ -3,7 +3,7 @@ import cc from 'classcat'
 import Tabs, { TabsProps } from 'tabs'
 
 export interface TabsSectionProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly tabsProps: TabsProps
 }
 

--- a/src/loader/Loader.tsx
+++ b/src/loader/Loader.tsx
@@ -21,7 +21,7 @@ export enum LoaderLayoutMode {
 }
 
 export interface LoaderProps {
-  className?: Classcat.Class
+  className?: string
   inline?: boolean // Deprecated, use layoutMode instead.
   size?: number
   done?: boolean

--- a/src/marketingMessage/MarketingMessage.tsx
+++ b/src/marketingMessage/MarketingMessage.tsx
@@ -3,7 +3,7 @@ import cc from 'classcat'
 
 export interface MarketingMessageProps {
   readonly children: React.ReactNode
-  readonly className?: Classcat.Class
+  readonly className?: string
 }
 
 const MarketingMessage = ({ children, className }: MarketingMessageProps) => (

--- a/src/menu/index.tsx
+++ b/src/menu/index.tsx
@@ -5,7 +5,7 @@ import ItemsList, { ItemsListDivider } from 'itemsList'
 
 export interface MenuProps {
   readonly children: React.ReactElement<ItemChoiceProps>[]
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly withSeparators?: boolean
 }
 

--- a/src/message/Message.tsx
+++ b/src/message/Message.tsx
@@ -11,7 +11,7 @@ export interface MessageProps {
   readonly date?: string
   readonly active?: boolean
   readonly author?: string | JSX.Element
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly messageAnnotation?: string
 }
 

--- a/src/messagingSummaryItem/MessagingSummaryItem.tsx
+++ b/src/messagingSummaryItem/MessagingSummaryItem.tsx
@@ -6,7 +6,7 @@ import { color } from '_utils/branding'
 import cc from 'classcat'
 
 export interface MessagingSummaryItemProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly url: string
   readonly pictureUrl: string
   readonly label: string

--- a/src/modal/Modal.tsx
+++ b/src/modal/Modal.tsx
@@ -23,8 +23,8 @@ export type ModalProps = Readonly<{
   onClose: () => void
   isOpen?: boolean
   children?: React.ReactNode
-  className?: Classcat.Class
-  modalContentClassName?: Classcat.Class
+  className?: string
+  modalContentClassName?: string
   closeOnEsc?: boolean
   closeOnOutsideClick?: boolean
   displayCloseButton?: boolean

--- a/src/paragraph/paragraph.tsx
+++ b/src/paragraph/paragraph.tsx
@@ -6,7 +6,7 @@ import Button, { ButtonStatus } from 'button'
 const DEFAULT_MAX_CHAR_SIZE = 180
 
 export interface ParagraphProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly children: string
   readonly isExpandable?: boolean
   readonly expandLabel?: string

--- a/src/phoneField/PhoneField.tsx
+++ b/src/phoneField/PhoneField.tsx
@@ -28,8 +28,8 @@ export interface PhoneFieldProps {
   readonly name: string
   readonly onChange: (obj: PhoneFieldOnChangeParameters) => void
   readonly id?: string
-  readonly className?: Classcat.Class
-  readonly innerWrapperClassName?: Classcat.Class
+  readonly className?: string
+  readonly innerWrapperClassName?: string
   readonly ariaLabelledBy?: string
   readonly selectFieldLabel?: string
   readonly textFieldTitle?: string

--- a/src/profile/profile.tsx
+++ b/src/profile/profile.tsx
@@ -8,7 +8,7 @@ import TextBody from 'typography/body'
 import cc from 'classcat'
 
 export interface ProfileProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly ariaLabel?: string
   readonly title: string
   readonly info?: string | JSX.Element

--- a/src/proximity/Proximity.tsx
+++ b/src/proximity/Proximity.tsx
@@ -45,7 +45,7 @@ const getColorAndTitle = (index: string, value: string, title: string) => {
 }
 
 export interface ProximityProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly value: Distances
   readonly title?: string
 }

--- a/src/pushInfo/PushInfo.tsx
+++ b/src/pushInfo/PushInfo.tsx
@@ -5,7 +5,7 @@ export const animationDuration = 700
 export const animationDelay = 300
 
 export interface PushInfoProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly icon?: React.ReactNode
   readonly headline: string
   readonly content?: string

--- a/src/qrCard/QrCard.tsx
+++ b/src/qrCard/QrCard.tsx
@@ -7,7 +7,7 @@ import SubHeader from 'subHeader'
 
 export interface QrCardProps {
   readonly ariaLabel?: string
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly imageUrl: string
   readonly itemMainTitle?: string
   readonly itemMainInfo?: string

--- a/src/rating/Rating.tsx
+++ b/src/rating/Rating.tsx
@@ -4,7 +4,7 @@ import cc from 'classcat'
 import Stars from 'stars'
 
 export interface RatingProps {
-  className?: Classcat.Class
+  className?: string
   score?: number
   ratings: number
   children: string

--- a/src/stars/Stars.tsx
+++ b/src/stars/Stars.tsx
@@ -3,7 +3,7 @@ import cc from 'classcat'
 import Star from 'icon/starIcon'
 
 export interface StarsProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly stars: number
 }
 

--- a/src/subHeader/SubHeader.tsx
+++ b/src/subHeader/SubHeader.tsx
@@ -3,7 +3,7 @@ import Title from 'title'
 import cc from 'classcat'
 
 export interface SubHeaderProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly children: string
 }
 

--- a/src/tabs/Tabs.tsx
+++ b/src/tabs/Tabs.tsx
@@ -22,8 +22,8 @@ export interface TabsProps {
   readonly activeTabId: string
   readonly onChange?: Function
   readonly status?: TabStatus
-  readonly className?: Classcat.Class
-  readonly tabsClassName?: Classcat.Class
+  readonly className?: string
+  readonly tabsClassName?: string
 }
 
 interface TabsState {

--- a/src/text/Text.tsx
+++ b/src/text/Text.tsx
@@ -23,7 +23,7 @@ export enum TextTagType {
 }
 
 export interface TextProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly children: string | number | React.ReactNode
   readonly display?: TextDisplayType
   readonly tag?: TextTagType

--- a/src/textField/TextField.tsx
+++ b/src/textField/TextField.tsx
@@ -54,8 +54,8 @@ export interface TextFieldProps extends CommonFormFields {
   labelledBy?: string
   onChange?: (obj: OnChangeParameters) => void
   onClear?: () => void
-  className?: Classcat.Class
-  errorClassName?: Classcat.Class
+  className?: string
+  errorClassName?: string
   error?: errorField
   addon?: JSX.Element
   label?: string

--- a/src/textarea/Textarea.tsx
+++ b/src/textarea/Textarea.tsx
@@ -30,8 +30,8 @@ export interface TextAreaProps extends CommonFormFields {
   defaultValue?: string
   labelledBy?: string
   onChange?: (obj: OnChangeParameters) => void
-  className?: Classcat.Class
-  errorClassName?: Classcat.Class
+  className?: string
+  errorClassName?: string
   error?: errorField
   label?: string
   focus?: boolean

--- a/src/theVoice/TheVoice.tsx
+++ b/src/theVoice/TheVoice.tsx
@@ -3,7 +3,7 @@ import Title from 'title'
 
 export interface TheVoiceProps {
   readonly id?: string
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly children: ReactNode
   readonly isInverted?: boolean
 }

--- a/src/timePicker/TimePicker.tsx
+++ b/src/timePicker/TimePicker.tsx
@@ -28,7 +28,7 @@ export const getTodayDate = () => {
 
 export interface TimePickerProps {
   readonly name: string
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly defaultValue?: string
   readonly disabled?: boolean
   readonly minuteStep?: number

--- a/src/title/Title.tsx
+++ b/src/title/Title.tsx
@@ -3,7 +3,7 @@ import cc from 'classcat'
 
 export interface TitleProps {
   readonly id?: string
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly children: ReactNode
   readonly headingLevel?: number | string
 }

--- a/src/topBar/TopBar.tsx
+++ b/src/topBar/TopBar.tsx
@@ -2,14 +2,14 @@ import React, { Fragment } from 'react'
 import cc from 'classcat'
 
 export interface TopBarProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly leftItem?: JSX.Element
   readonly rightItem?: JSX.Element
   readonly centerItem?: JSX.Element
   readonly fixed?: boolean
   readonly bgTransparent?: boolean
   readonly bgShadedTransparent?: boolean
-  readonly innerWrapperClassName?: Classcat.Class
+  readonly innerWrapperClassName?: string
 }
 
 const TopBar = ({

--- a/src/transitions/Transitions.tsx
+++ b/src/transitions/Transitions.tsx
@@ -9,7 +9,7 @@ export enum AnimationType {
 }
 
 export interface CustomTransitionProps {
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly children: JSX.Element
   readonly animationName?: AnimationType
   readonly delayEnter?: number

--- a/src/tripCard/TripCard.tsx
+++ b/src/tripCard/TripCard.tsx
@@ -47,7 +47,7 @@ export interface TripCardProps {
     autoApproval?: string
   }
   metaUrl?: string
-  className?: Classcat.Class
+  className?: string
   statusInformation?: {
     icon: JSX.Element
     text: string

--- a/src/typings/icons.d.ts
+++ b/src/typings/icons.d.ts
@@ -1,7 +1,7 @@
 declare interface Icon {
   readonly size?: number | string
-  readonly className?: Classcat.Class
-  readonly iconClassName?: Classcat.Class
+  readonly className?: string
+  readonly iconClassName?: string
   readonly title?: string
   readonly iconColor?: string
   readonly badgeAriaLabel?: string

--- a/src/uneditableTextField/UneditableTextField.tsx
+++ b/src/uneditableTextField/UneditableTextField.tsx
@@ -4,7 +4,7 @@ import isEmpty from 'lodash.isempty'
 
 export interface UneditableTextFieldProps {
   readonly children: JSX.Element | string
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly addOn?: JSX.Element
   readonly href?: JSX.Element | string
   readonly ellipsis?: boolean

--- a/src/why/Why.tsx
+++ b/src/why/Why.tsx
@@ -6,7 +6,7 @@ import QuestionIcon from 'icon/questionIcon'
 export interface WhyProps {
   readonly children: string
   readonly title: string
-  readonly className?: Classcat.Class
+  readonly className?: string
   readonly onClick?: () => void
 }
 


### PR DESCRIPTION
## Description

`Classcat.Class` is the parameter type of the classcat function, not the returned type.

## What has been done

I replaced all `className` type by `string` and updated the return value of the `prefix` function: instead of returning an array of prefixed classes it returns a single string of the concatenated prefixed classes. This update only affect _src/buttonGroup/ButtonGroup.tsx_ and _src/datePicker/DatePicker.tsx_ files.

## Things to consider

`Classcat.Class` is not used in Kairos so it wouldn't break anything but this still is a breaking change.

## How it was tested

Unit tests.