### PR TITLE
Simplify CSS prefix function

### DIFF
--- a/src/_utils/index.tsx
+++ b/src/_utils/index.tsx
@@ -1,12 +1,18 @@
 import React, { Fragment } from 'react'
 import { canUseDOM } from 'exenv'
 
-export const prefix = (
-  modifiers: Classcat.ClassObject = {},
-  baseClass: string = 'kirk',
-): string => {
+const DEFAULT_CLASS_PREFIX = 'kirk'
+
+export const prefix = (modifiers: Classcat.ClassObject, baseClass?: string): string => {
   const mods = Object.keys(modifiers).filter(elem => modifiers[elem])
-  return mods.map(modifier => `${baseClass}-${modifier}`).join(' ')
+
+  let classPrefix = DEFAULT_CLASS_PREFIX
+
+  if (baseClass != null) {
+    classPrefix = `${classPrefix}-${baseClass}`
+  }
+
+  return mods.map(modifier => `${classPrefix}-${modifier}`).join(' ')
 }
 
 export const isTouchEventsAvailable = () =>

--- a/src/_utils/index.unit.tsx
+++ b/src/_utils/index.unit.tsx
@@ -10,11 +10,24 @@ line3`
 const multipleLineTextWithBR = replaceNewLineWithBR(multipleLineText)
 
 describe('prefix', () => {
-  it('Should render prefix syntax with the base class', () => {
-    expect(prefix({}, 'base')).toEqual('')
-    expect(prefix({ modifiers: true }, 'base')).toEqual('base-modifiers')
-    expect(prefix({ modifiers: false }, 'base')).toEqual('')
-    expect(prefix({ 'modifier-1': true, 'modifier-2': false }, 'base')).toEqual('base-modifier-1')
+  it('Should add a prefix to all classes', () => {
+    expect(prefix({ 'modifier-1': true, 'modifier-2': true })).toEqual(
+      'kirk-modifier-1 kirk-modifier-2',
+    )
+  })
+
+  it('Should add a base class to the prefix', () => {
+    expect(prefix({ 'modifier-1': true, 'modifier-2': true }, 'base-class')).toEqual(
+      'kirk-base-class-modifier-1 kirk-base-class-modifier-2',
+    )
+  })
+
+  it('Should ignore falsy conditions', () => {
+    expect(prefix({ a: false, b: 0, c: null, d: undefined, e: '' })).toEqual('')
+  })
+
+  it('Should include truthy conditions', () => {
+    expect(prefix({ a: true, b: 1, c: 'c', d: {} })).toEqual('kirk-a kirk-b kirk-c kirk-d')
   })
 })
 

--- a/src/avatar/Avatar.tsx
+++ b/src/avatar/Avatar.tsx
@@ -49,7 +49,7 @@ const Avatar = ({
 }: AvatarProps) => (
   <div
     className={cc([
-      prefix({ small: isSmall, medium: isMedium, large: isLarge, image: !!image }, 'kirk-avatar-'),
+      prefix({ small: isSmall, medium: isMedium, large: isLarge, image: !!image }, 'avatar-'),
       className,
       'kirk-avatar',
     ])}

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -178,7 +178,7 @@ export default class Button extends PureComponent<ButtonProps, ButtonState> {
             bubble: isBubble || hasLoader,
             shadowed,
           },
-          'kirk-button',
+          'button',
         ),
         className,
       ]),

--- a/src/buttonGroup/ButtonGroup.tsx
+++ b/src/buttonGroup/ButtonGroup.tsx
@@ -13,7 +13,7 @@ export interface ButtonGroupProps {
   readonly loadingIndex?: string
 }
 
-const BASE_CLASSNAME = prefix({ 'button-group': true })
+const BASE_CLASSNAME = 'button-group'
 
 const ButtonGroup = ({
   children,

--- a/src/datePicker/DatePicker.tsx
+++ b/src/datePicker/DatePicker.tsx
@@ -7,7 +7,7 @@ import { color } from '_utils/branding'
 import ArrowIcon from 'icon/arrowIcon'
 import Button, { ButtonStatus } from 'button'
 
-const BASE_CLASSNAME = prefix({ datepicker: true })
+const BASE_CLASSNAME = 'datepicker'
 
 const defaultWeekdaysLong = [0, 1, 2, 3, 4, 5, 6].map(weekday =>
   DayPicker.LocaleUtils.formatWeekdayLong(weekday),


### PR DESCRIPTION
## Description

Simplify the `prefix` usages for custom prefixes.

## What has been done

The `baseClass` parameter of `prefix` is now added to the `'kirk'` prefix instead of replacing it.

```ts
const BASE_CLASSNAME = prefix({ 'button-group': true })
// ↓↓↓
const BASE_CLASSNAME = 'button-group'
```

## Things to consider

I also split the tests into specific unit tests.

## How it was tested

Unit tests.