### PR TITLE
Fix missing CSS prefix for DatePicker and ButtonGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-[...]
+- **[FIX]** Add missing "kirk" prefix to base class name of `DatePicker` and `ButtonGroup`.
+  [...]
 
 # v31.0.1 (30/04/2020)
 

--- a/src/buttonGroup/ButtonGroup.tsx
+++ b/src/buttonGroup/ButtonGroup.tsx
@@ -23,7 +23,7 @@ const ButtonGroup = ({
   loadingIndex = null,
 }: ButtonGroupProps) => {
   const classNames = [
-    BASE_CLASSNAME,
+    `kirk-${BASE_CLASSNAME}`,
     className,
     prefix(
       {

--- a/src/buttonGroup/ButtonGroup.unit.tsx
+++ b/src/buttonGroup/ButtonGroup.unit.tsx
@@ -1,10 +1,23 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 
 import ButtonGroup from './ButtonGroup'
 import Button, { ButtonStatus } from 'button'
 
 describe('Button Group', () => {
+  it('Should apply the base className ', () => {
+    const btnGroup = mount(
+      <ButtonGroup>
+        <Button>Hello</Button>
+        <Button>Hello</Button>
+      </ButtonGroup>,
+    )
+
+    // Can't use `expect(btnGroup.prop('className')).toContain('kirk-button-group')`
+    // because `kirk-button-group` is contained in `kirk-button-group-column`.
+    expect(btnGroup.getDOMNode().classList.contains('kirk-button-group')).toBe(true)
+  })
+
   it('Should apply the row className if the inline prop is set to true', () => {
     const btnGroup = shallow(
       <ButtonGroup isInline>

--- a/src/datePicker/DatePicker.tsx
+++ b/src/datePicker/DatePicker.tsx
@@ -215,7 +215,7 @@ export class DatePicker extends PureComponent<DatePickerProps, DatePickerState> 
       <div
         ref={this.dayPickerContainer}
         className={cc([
-          BASE_CLASSNAME,
+          `kirk-${BASE_CLASSNAME}`,
           className,
           prefix({ [orientation]: true }, BASE_CLASSNAME),
           prefix({ [layoutClassName]: true }, BASE_CLASSNAME),

--- a/src/datePicker/DatePicker.unit.tsx
+++ b/src/datePicker/DatePicker.unit.tsx
@@ -5,6 +5,11 @@ import DayPicker, { NavbarElementProps, CaptionElementProps } from 'react-day-pi
 import DatePicker, { DatePickerOrientation } from './DatePicker'
 
 describe('DatePicker', () => {
+  it('Should apply the base className ', () => {
+    const datepicker = shallow(<DatePicker />)
+    expect(datepicker.prop('className')).toContain('kirk-datepicker')
+  })
+
   describe('renderNavbar', () => {
     const navbarProps: Partial<NavbarElementProps> = {
       className: '',


### PR DESCRIPTION
## Description

The base class name of `DatePicker` and `ButtonGroup` are missing the "kirk" prefix.

## What has been done

Add the missing prefix to the component's base class names.

## Things to consider

🤷‍♂️

## How it was tested

I added a test for that in each component.