### PR TITLE
Fix MainContent Form props and a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 - **[NEW]** Allow icons in `ItemCheckbox` component using `leftAddon` prop
 - **[BREAKING CHANGE]** Responsive `ConfirmationModal`: remove `size` from it.
+- **[UPDATE]** Add support for Form attributes on `MainContent`
+- **[FIX]** Remove role presentation on `MainContent`
 - **[FIX]** `TheVoice` spacing.
-  [...]
+- [...]
 
 # v31.0.3 (04/05/2020)
 

--- a/src/layout/content/content.tsx
+++ b/src/layout/content/content.tsx
@@ -3,12 +3,16 @@ import React, { Component } from 'react'
 import '_utils/closest'
 import { componentSizes, pxToInteger } from '_utils/branding'
 
-export interface MainContentProps {
+export type MainContentProps = Readonly<{
   readonly children: React.ReactNode
   readonly topBarSelector?: string // document query selector
   readonly topBarHeight?: string // ex: "24px" - for CSS only
   readonly tag?: string
-}
+  // Allow <Form> related attribute to be set.
+  readonly onSubmit?: (e: React.FormEvent) => void
+  readonly noValidate?: string
+  readonly method?: string
+}>
 
 export class MainContent extends Component<MainContentProps> {
   mainContentRef = React.createRef<HTMLDivElement>()
@@ -67,7 +71,6 @@ export class MainContent extends Component<MainContentProps> {
       {
         ref: this.mainContentRef,
         className: 'page-wrapper',
-        role: 'presentation',
         ...props,
       },
       children,

--- a/src/layout/content/story.tsx
+++ b/src/layout/content/story.tsx
@@ -14,7 +14,7 @@ const stories = storiesOf('Sections|Content', module)
 stories.addDecorator(withKnobs)
 
 stories.add('default', () => (
-  <MainContent>
+  <MainContent onSubmit={() => {}} noValidate="" method="POST">
     <Content>
       <Section>
         <SubHeader>Some Lorem ipsum content</SubHeader>


### PR DESCRIPTION
- Fixed the role='presentation' that was breaking the a11y of the MainContent when used as a <Form> (most of our cases are doing this)
- Added new Form specific attributes to avoid TypeScript errors on unknown attributes.

TESTED=Locally
