### PR TITLE
[BBC-7928] Allow icon in ItemCheckbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[NEW]** Allow icons in `ItemCheckbox` component using `leftAddon` prop
 - **[BREAKING CHANGE]** Responsive `ConfirmationModal`: remove `size` from it.
 - **[FIX]** `TheVoice` spacing.
   [...]

--- a/src/itemCheckbox/ItemCheckbox.tsx
+++ b/src/itemCheckbox/ItemCheckbox.tsx
@@ -16,6 +16,7 @@ export interface ItemCheckboxProps extends A11yProps {
   readonly name: string
   readonly data?: string
   readonly className?: string
+  readonly leftAddon?: React.ReactNode
   readonly labelTitle?: string
   readonly dataInfo?: string
   readonly checked?: boolean
@@ -43,6 +44,7 @@ class ItemCheckbox extends Component<ItemCheckboxProps> {
       data,
       className,
       labelTitle,
+      leftAddon,
       dataInfo,
       checked,
       disabled,
@@ -68,6 +70,7 @@ class ItemCheckbox extends Component<ItemCheckboxProps> {
         className={cc(['kirk-item-checkbox', className])}
         leftTitle={labelTitle}
         leftBody={label}
+        leftAddon={leftAddon}
         rightTitle={data}
         rightTitleDisplay={TextDisplayType.SUBHEADERSTRONG}
         rightBody={dataInfo}

--- a/src/itemCheckbox/story.tsx
+++ b/src/itemCheckbox/story.tsx
@@ -3,6 +3,7 @@ import { action } from '@storybook/addon-actions'
 import { boolean, select, text, withKnobs } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 
+import LadyIcon from 'icon/ladyIcon'
 import ItemCheckbox, { ItemCheckboxStatus } from 'itemCheckbox'
 import Section from 'layout/section/baseSection'
 
@@ -24,6 +25,7 @@ stories.add(
           name={text('Name', 'InputName')}
           data={text('Data', 'Data')}
           labelTitle={isMainTitle ? text('Label title', 'Title') : null}
+          leftAddon={boolean('with icon', false) ? <LadyIcon /> : null}
           dataInfo={isDataInfo ? text('Data info', 'Info') : null}
           onChange={action('changed')}
           checked={boolean('isChecked', false)}

--- a/src/itemInfo/index.tsx
+++ b/src/itemInfo/index.tsx
@@ -4,7 +4,7 @@ import { A11yProps, pickA11yProps } from '_utils/interfaces'
 import Item from '_utils/item'
 
 export interface ItemInfoProps extends A11yProps {
-  readonly mainInfo: string
+  readonly mainInfo?: string
   readonly className?: string
   readonly icon?: React.ReactNode
   readonly mainTitle?: string

--- a/src/pages/yourrides/offer/editOptions.story.tsx
+++ b/src/pages/yourrides/offer/editOptions.story.tsx
@@ -1,0 +1,122 @@
+/* eslint-disable react/jsx-curly-newline */
+import React, { Component, Fragment } from 'react'
+import { storiesOf } from '@storybook/react'
+
+import Button, { ButtonStatus } from 'button'
+import Divider from 'divider'
+import ComfortIcon from 'icon/comfortIcon'
+import LadyIcon from 'icon/ladyIcon'
+import LightningIcon from 'icon/lightningIcon'
+import ItemCheckbox from 'itemCheckbox'
+import ItemInfo from 'itemInfo'
+import { BottomContent, Content, MainContent } from 'layout/content'
+import LayoutNormalizer from 'layout/layoutNormalizer'
+import Section from 'layout/section/baseSection'
+import Stepper, { StepperDisplay } from 'stepper'
+import SubHeader from 'subHeader'
+import Textarea from 'textarea'
+import TextTitle from 'typography/title'
+
+const stories = storiesOf('Pages|Your rides/Offer/Edit/Options', module)
+
+type EditOptionsState = Readonly<{
+  isComfort: boolean
+  isLadyOnly: boolean
+  isInstantBooking: boolean
+  buttonStatus: ButtonStatus
+}>
+
+// Note: some hard-coded styles will be removed with the following tickets: BBC-7943, BBC-7944
+
+class EditOptions extends Component<{}, EditOptionsState> {
+  state: EditOptionsState = {
+    isComfort: false,
+    isLadyOnly: false,
+    isInstantBooking: false,
+    buttonStatus: ButtonStatus.PRIMARY,
+  }
+
+  save = (): void => {
+    this.setState({ buttonStatus: ButtonStatus.LOADING })
+
+    setTimeout(() => this.setState({ buttonStatus: ButtonStatus.CHECKED }), 1000)
+    setTimeout(() => this.setState({ buttonStatus: ButtonStatus.PRIMARY }), 3000)
+  }
+
+  render = (): JSX.Element => (
+    <Fragment>
+      <LayoutNormalizer useLegacyNormalization />
+
+      <MainContent>
+        <Content>
+          <Section>
+            <SubHeader>Passengers options</SubHeader>
+
+            <div style={{ display: 'flex' }}>
+              {/*
+                // @ts-ignore style is not defined in TextTitle props (BBC-7943) */}
+              <TextTitle style={{ flex: 1, lineHeight: '48px' }}>Number of passengers</TextTitle>
+              <div style={{ position: 'relative', right: '-14px' }}>
+                <Stepper
+                  name="stepper"
+                  value={1}
+                  display={StepperDisplay.SMALL}
+                  increaseLabel="Add a seat"
+                  decreaseLabel="Remove a seat"
+                />
+              </div>
+            </div>
+
+            <Divider />
+
+            <ItemCheckbox
+              onChange={() =>
+                this.setState((prevState: EditOptionsState) => ({
+                  isComfort: !prevState.isComfort,
+                }))
+              }
+              leftAddon={<ComfortIcon />}
+              labelTitle="Max. 2 in the back seats"
+              checked={this.state.isComfort}
+            />
+            <ItemCheckbox
+              onChange={() =>
+                this.setState((prevState: EditOptionsState) => ({
+                  isLadyOnly: !prevState.isLadyOnly,
+                }))
+              }
+              leftAddon={<LadyIcon />}
+              labelTitle="Ladies only"
+              checked={this.state.isLadyOnly}
+            />
+            <ItemCheckbox
+              onChange={() =>
+                this.setState((prevState: EditOptionsState) => ({
+                  isInstantBooking: !prevState.isInstantBooking,
+                }))
+              }
+              leftAddon={<LightningIcon />}
+              labelTitle="Instant booking"
+              checked={this.state.isInstantBooking}
+            />
+
+            <Divider />
+            <ItemInfo mainTitle="Additional details" id="textarea-label" />
+            <Textarea
+              placeholder="Flexible about where and when to meet? Not taking the motorway? Got limited space in your boot? Keep passengers in the loop."
+              onChange={() => {}}
+              labelledBy="textarea-label"
+            />
+          </Section>
+        </Content>
+        <BottomContent style={{ display: 'flex', justifyContent: 'center', padding: '16px' }}>
+          <Button onClick={this.save} status={this.state.buttonStatus}>
+            Sauvegarder
+          </Button>
+        </BottomContent>
+      </MainContent>
+    </Fragment>
+  )
+}
+
+stories.add('Default', () => <EditOptions />)

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -1,8 +1,6 @@
 import './stories.css'
-
 // DESIGN TOKENS
 import '../src/_utils/story'
-
 import '../src/typography/story'
 import '../src/typography/display2/story'
 import '../src/typography/display1/story'
@@ -12,9 +10,7 @@ import '../src/typography/title/story'
 import '../src/typography/titleStrong/story'
 import '../src/typography/body/story'
 import '../src/typography/bodyStrong/story'
-
 import '../src/icon/story'
-
 // Sections
 import '../src/layout/section/baseSection/story'
 import '../src/layout/section/heroSection/story'
@@ -27,7 +23,6 @@ import '../src/layout/section/illustratedSection/story'
 import '../src/layout/section/itemsSection/story'
 import '../src/layout/section/mediaSection/story'
 import '../src/layout/content/story'
-
 // Pages
 import '../src/pages/messaging/inbox.story'
 import '../src/pages/messaging/brazemarketing.story'
@@ -36,8 +31,8 @@ import '../src/pages/ridedetails/bus.story'
 import '../src/pages/searchResults/tabs.story'
 import '../src/pages/yourrides/rides.story'
 import '../src/pages/yourrides/history.story'
+import '../src/pages/yourrides/offer/editOptions.story'
 import '../src/pages/login/email.story'
-
 // Widgets
 import '../src/autoComplete/story'
 import '../src/avatar/story'


### PR DESCRIPTION
## Description

- Add the `leftAddon` option to `ItemCheckbox` to allow having an icon.
- Add edit your publication options screen in storybook

<img width="374" alt="Capture d’écran 2020-05-06 à 10 40 01" src="https://user-images.githubusercontent.com/729186/81156240-075ac400-8f86-11ea-8a17-dfe611dcf4d5.png">

## Things to consider

They're is still hard-coded styles in the story. I'll need to update this in other PRs

## How it was tested

Storybook, mobile & desktop layout, chrome.