### PR TITLE
Add leftAddon option to Stepper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[NEW]** Add `leftAddon` prop to `Stepper`. Rendered only on small display.
 - [...]
 
 # v32.0.0 (06/05/2020)

--- a/src/pages/yourrides/offer/editOptions.story.tsx
+++ b/src/pages/yourrides/offer/editOptions.story.tsx
@@ -52,19 +52,15 @@ class EditOptions extends Component<{}, EditOptionsState> {
           <Section>
             <SubHeader>Passengers options</SubHeader>
 
-            <div style={{ display: 'flex' }}>
-              {/*
-                // @ts-ignore style is not defined in TextTitle props (BBC-7943) */}
-              <TextTitle style={{ flex: 1, lineHeight: '48px' }}>Number of passengers</TextTitle>
-              <div style={{ position: 'relative', right: '-14px' }}>
-                <Stepper
-                  name="stepper"
-                  value={1}
-                  display={StepperDisplay.SMALL}
-                  increaseLabel="Add a seat"
-                  decreaseLabel="Remove a seat"
-                />
-              </div>
+            <div style={{ marginRight: '-14px' }}>
+              <Stepper
+                name="stepper"
+                value={1}
+                display={StepperDisplay.SMALL}
+                increaseLabel="Add a seat"
+                decreaseLabel="Remove a seat"
+                leftAddon={<TextTitle>Number of passengers</TextTitle>}
+              />
             </div>
 
             <Divider />
@@ -111,7 +107,7 @@ class EditOptions extends Component<{}, EditOptionsState> {
         </Content>
         <BottomContent style={{ display: 'flex', justifyContent: 'center', padding: '16px' }}>
           <Button onClick={this.save} status={this.state.buttonStatus}>
-            Sauvegarder
+            Save
           </Button>
         </BottomContent>
       </MainContent>

--- a/src/pages/yourrides/offer/editPrice.story.tsx
+++ b/src/pages/yourrides/offer/editPrice.story.tsx
@@ -1,0 +1,102 @@
+/* eslint-disable react/jsx-curly-newline */
+import React, { Component, Fragment } from 'react'
+import { storiesOf } from '@storybook/react'
+
+import Button, { ButtonStatus } from 'button'
+import Divider from 'divider'
+import Itinerary from 'itinerary'
+import { BottomContent, Content, MainContent } from 'layout/content'
+import LayoutNormalizer from 'layout/layoutNormalizer'
+import Section from 'layout/section/baseSection'
+import Stepper, { StepperDisplay } from 'stepper'
+import SubHeader from 'subHeader'
+
+const stories = storiesOf('Pages|Your rides/Offer/Edit/Price', module)
+
+type EditPriceProps = Readonly<{
+  withStopovers?: boolean
+}>
+
+type EditPriceState = Readonly<{
+  buttonStatus: ButtonStatus
+}>
+
+const smallStepperProps = {
+  display: StepperDisplay.SMALL,
+  increaseLabel: 'Add a seat',
+  decreaseLabel: 'Remove a seat',
+  format: (price: number): string => `$${price}`,
+}
+
+class EditPrice extends Component<EditPriceProps, EditPriceState> {
+  static defaultProps: Partial<EditPriceProps> = {
+    withStopovers: false,
+  }
+
+  state: EditPriceState = {
+    buttonStatus: ButtonStatus.PRIMARY,
+  }
+
+  save = (): void => {
+    this.setState({ buttonStatus: ButtonStatus.LOADING })
+
+    setTimeout(() => this.setState({ buttonStatus: ButtonStatus.CHECKED }), 1000)
+    setTimeout(() => this.setState({ buttonStatus: ButtonStatus.PRIMARY }), 3000)
+  }
+
+  renderMultiple = (): JSX.Element => (
+    <Fragment>
+      <Stepper
+        {...smallStepperProps}
+        name="stepper-main"
+        value={56}
+        leftAddon={<Itinerary places={[{ mainLabel: 'Paris' }, { mainLabel: 'Marseilles' }]} />}
+      />
+
+      <Divider />
+
+      <Stepper
+        {...smallStepperProps}
+        name="stepper-1"
+        value={24}
+        leftAddon={<Itinerary places={[{ mainLabel: 'Paris' }, { mainLabel: 'Lyon' }]} />}
+      />
+
+      <Stepper
+        {...smallStepperProps}
+        name="stepper-2"
+        value={30}
+        leftAddon={<Itinerary places={[{ mainLabel: 'Lyon' }, { mainLabel: 'Marseilles' }]} />}
+      />
+    </Fragment>
+  )
+
+  renderSingle = (): JSX.Element => (
+    <Stepper {...smallStepperProps} display={StepperDisplay.LARGE} name="stepper-main" value={56} />
+  )
+
+  render = (): JSX.Element => (
+    <Fragment>
+      <LayoutNormalizer useLegacyNormalization />
+
+      <MainContent>
+        <Content>
+          <Section>
+            <SubHeader>Price per passenger</SubHeader>
+
+            {this.props.withStopovers && this.renderMultiple()}
+            {!this.props.withStopovers && this.renderSingle()}
+          </Section>
+        </Content>
+        <BottomContent style={{ display: 'flex', justifyContent: 'center', padding: '16px' }}>
+          <Button onClick={this.save} status={this.state.buttonStatus}>
+            Save
+          </Button>
+        </BottomContent>
+      </MainContent>
+    </Fragment>
+  )
+}
+
+stories.add('With stopovers', () => <EditPrice withStopovers />)
+stories.add('Without stopovers', () => <EditPrice />)

--- a/src/stepper/Stepper.tsx
+++ b/src/stepper/Stepper.tsx
@@ -1,6 +1,7 @@
 import React, { PureComponent, RefObject } from 'react'
 import cc from 'classcat'
 import { canUseDOM } from 'exenv'
+import isEmpty from 'lodash.isempty'
 
 import { isTouchEventsAvailable } from '_utils'
 import { color, delay, font, pxToInteger, space } from '_utils/branding'
@@ -38,6 +39,7 @@ export interface StepperProps {
   onChange?: (obj: OnChangeParameters) => void
   display?: StepperDisplay
   focus?: boolean
+  leftAddon?: React.ReactNode
 }
 
 interface StepperState {
@@ -174,9 +176,10 @@ export default class Stepper extends PureComponent<StepperProps, StepperState> {
         }
   }
 
-  render() {
+  render(): JSX.Element {
     const {
       className,
+      leftAddon,
       title,
       increaseLabel,
       decreaseLabel,
@@ -186,47 +189,53 @@ export default class Stepper extends PureComponent<StepperProps, StepperState> {
       valueClassName,
       display,
     } = this.props
+
     const isMax = this.state.value >= max
     const isMin = this.state.value <= min
     const buttonSize = StepperButtonSize[display]
+    const hasLeftAddon = display === StepperDisplay.SMALL && !isEmpty(leftAddon)
 
     return (
-      <div
-        className={cc(['kirk-stepper', `kirk-stepper-${display}`, className])}
-        ref={this.containerRef}
-        aria-label={title}
-        tabIndex={-1}
-      >
-        <Button
-          aria-label={decreaseLabel}
-          type="button"
-          className="kirk-stepper-decrement"
-          status={ButtonStatus.UNSTYLED}
-          disabled={isMin}
-          isBubble
-          {...this.createButtonListeners(this.decrement)}
-        >
-          <MinusIcon iconColor={isMin ? color.lightGray : color.blue} size={buttonSize} />
-        </Button>
+      <div className={cc(['kirk-stepper', `kirk-stepper-${display}`, className])}>
+        {hasLeftAddon && <div className="kirk-stepper-left-addon">{leftAddon}</div>}
+
         <div
-          aria-live="polite"
-          className={cc(['kirk-stepper-value', valueClassName])}
-          style={{ fontSize: `${this.state.fontSize}px` }}
-          ref={this.valueElementRef}
+          className="kirk-stepper-content"
+          ref={this.containerRef}
+          aria-label={title}
+          tabIndex={-1}
         >
-          {format(this.state.value)}
+          <Button
+            aria-label={decreaseLabel}
+            type="button"
+            className="kirk-stepper-decrement"
+            status={ButtonStatus.UNSTYLED}
+            disabled={isMin}
+            isBubble
+            {...this.createButtonListeners(this.decrement)}
+          >
+            <MinusIcon iconColor={isMin ? color.lightGray : color.blue} size={buttonSize} />
+          </Button>
+          <div
+            aria-live="polite"
+            className={cc(['kirk-stepper-value', valueClassName])}
+            style={{ fontSize: `${this.state.fontSize}px` }}
+            ref={this.valueElementRef}
+          >
+            {format(this.state.value)}
+          </div>
+          <Button
+            aria-label={increaseLabel}
+            type="button"
+            className="kirk-stepper-increment"
+            status={ButtonStatus.UNSTYLED}
+            disabled={isMax}
+            isBubble
+            {...this.createButtonListeners(this.increment)}
+          >
+            <PlusIcon iconColor={isMax ? color.lightGray : color.blue} size={buttonSize} />
+          </Button>
         </div>
-        <Button
-          aria-label={increaseLabel}
-          type="button"
-          className="kirk-stepper-increment"
-          status={ButtonStatus.UNSTYLED}
-          disabled={isMax}
-          isBubble
-          {...this.createButtonListeners(this.increment)}
-        >
-          <PlusIcon iconColor={isMax ? color.lightGray : color.blue} size={buttonSize} />
-        </Button>
       </div>
     )
   }

--- a/src/stepper/Stepper.unit.tsx
+++ b/src/stepper/Stepper.unit.tsx
@@ -4,6 +4,7 @@ import { mount, shallow } from 'enzyme'
 import Button from 'button'
 import MinusIcon from 'icon/minusIcon'
 import PlusIcon from 'icon/plusIcon'
+import Itinerary from 'itinerary'
 
 import Stepper, { StepperDisplay } from './Stepper'
 
@@ -37,7 +38,7 @@ it('Should have the default text & attributes', () => {
     />,
   )
 
-  expect(stepper.find('.kirk-stepper').prop('aria-label')).toEqual(
+  expect(stepper.find('.kirk-stepper-content').prop('aria-label')).toEqual(
     'Choose the number of passengers',
   )
   expect(
@@ -170,5 +171,31 @@ describe('handleFontSize', () => {
     spyHandleFontSize.mockClear()
     window.dispatchEvent(new Event('resize'))
     expect(spyHandleFontSize).toHaveBeenCalled()
+  })
+})
+
+describe('leftAddon', () => {
+  const itinerary = <Itinerary places={[{ mainLabel: 'Paris' }, { mainLabel: 'Nantes' }]} />
+
+  it('should not render leftAddon if not provided', () => {
+    const stepper = shallow(<Stepper {...defaultProps} display={StepperDisplay.SMALL} />)
+    expect(stepper.find('.kirk-stepper-left-addon').exists()).toBe(false)
+    expect(stepper.find(Itinerary).exists()).toBe(false)
+  })
+
+  it('should not render leftAddon on large display', () => {
+    const stepper = shallow(
+      <Stepper {...defaultProps} display={StepperDisplay.LARGE} leftAddon={itinerary} />,
+    )
+    expect(stepper.find('.kirk-stepper-left-addon').exists()).toBe(false)
+    expect(stepper.find(Itinerary).exists()).toBe(false)
+  })
+
+  it('should render leftAddon on small display', () => {
+    const stepper = shallow(
+      <Stepper {...defaultProps} display={StepperDisplay.SMALL} leftAddon={itinerary} />,
+    )
+    expect(stepper.find('.kirk-stepper-left-addon').exists()).toBe(true)
+    expect(stepper.find(Itinerary).exists()).toBe(true)
   })
 })

--- a/src/stepper/index.tsx
+++ b/src/stepper/index.tsx
@@ -4,14 +4,33 @@ import { color, space } from '_utils/branding'
 
 import Stepper, { StepperButtonSize, StepperDisplay } from './Stepper'
 
+// These components have a 12px vertical padding. We probably took a shortcut when creating our
+// sizes, as we should have handled 4px multiples (checked with @wakooka)
+const betweenMandL = '12px'
+
 const StyledStepper = styled(Stepper)`
   & {
     display: flex;
     position: relative;
   }
 
-  & button {
-    flex-shrink: 0;
+  & .kirk-stepper-content {
+    display: flex;
+    position: relative;
+    flex: 1;
+  }
+
+  & .kirk-stepper-left-addon {
+    // Vertical align the addon
+    display: flex;
+    align-items: center;
+
+    // Addon is expending, while stepper has a fixed size
+    flex: 1;
+  }
+
+  & .kirk-stepper-left-addon + .kirk-stepper-content {
+    flex: 0;
   }
 
   & .kirk-stepper-value {
@@ -27,13 +46,23 @@ const StyledStepper = styled(Stepper)`
 
   & .kirk-stepper-decrement,
   & .kirk-stepper-increment {
+    flex-shrink: 0;
     align-self: center;
     border: none;
+  }
+
+  &.kirk-stepper-small {
+    padding: ${betweenMandL} 0;
   }
 
   &.kirk-stepper-large .kirk-stepper-value {
     width: calc(100% - ${StepperButtonSize[StepperDisplay.LARGE]}px * 2);
     flex-grow: 0;
+  }
+
+  // Don't add the itinerary arrival padding to the one we handle with the Stepper
+  & .kirk-stepper-left-addon .kirk-itineraryLocation--arrival .kirk-itineraryLocation-label {
+    padding-bottom: 0;
   }
 `
 

--- a/src/stepper/story.tsx
+++ b/src/stepper/story.tsx
@@ -3,6 +3,7 @@ import { action } from '@storybook/addon-actions'
 import { number, select, text, withKnobs } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 
+import Itinerary from 'itinerary'
 import Section from 'layout/section/baseSection'
 import Stepper, { StepperDisplay } from 'stepper'
 
@@ -70,4 +71,21 @@ stories.add('Stepper with large formatted value', () => (
   </Section>
 ))
 
-/* Tests to build */
+stories.add('Stepper with left addon', () => (
+  <Section>
+    <Stepper
+      name="stepper2"
+      min={number('min', 0)}
+      max={number('max', 99999)}
+      step={number('step', 100)}
+      value={number('value', 8400)}
+      increaseLabel={text('increaseLabel', 'Increment')}
+      decreaseLabel={text('decreaseLabel', 'Decrement')}
+      format={value => `${value} грн.`}
+      onChange={action('changed')}
+      display={select('display', StepperDisplay, StepperDisplay.SMALL)}
+      title={text('children', 'Edit the price')}
+      leftAddon={<Itinerary places={[{ mainLabel: 'Paris' }, { mainLabel: 'Nantes' }]} />}
+    />
+  </Section>
+))

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -32,6 +32,7 @@ import '../src/pages/searchResults/tabs.story'
 import '../src/pages/yourrides/rides.story'
 import '../src/pages/yourrides/history.story'
 import '../src/pages/yourrides/offer/editOptions.story'
+import '../src/pages/yourrides/offer/editPrice.story'
 import '../src/pages/login/email.story'
 // Widgets
 import '../src/autoComplete/story'


### PR DESCRIPTION
## Description

Allows rendering a vertically-centered component on the left of small steppers.
- Updated example for Edit your trip options
- Add example for Edit your trip price (also used during publication)

<img width="376" alt="Capture d’écran 2020-05-06 à 17 56 19" src="https://user-images.githubusercontent.com/729186/81199443-f1b7bf80-8fc2-11ea-8e41-ad62092a093b.png">
<img width="374" alt="Capture d’écran 2020-05-06 à 17 56 09" src="https://user-images.githubusercontent.com/729186/81199446-f2505600-8fc2-11ea-8e42-f148a976ce60.png">

## What has been done

- Add `leftAddon` option to `Stepper`
- Updated unit tests
- Updated related pages
- Removed custom CSS!

## How it was tested

Storybook with small/large layouts, chrome + unit tests