### PR TITLE
[BBC-5902] Allow break-lines on `Message`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - **[NEW]** Add `leftAddon` prop to `Stepper`. Rendered only on small display.
 - **[FIX]** Change `labelInfo` type to `React.ReactNode` in `ItemChoice`
 - **[FIX]** Change `mainInfo` type to `React.ReactNode` in `ItemData`
+- **[UPDATE]** `Message` respects break-lines character
 - [...]
 
 # v32.0.0 (06/05/2020)

--- a/src/message/index.tsx
+++ b/src/message/index.tsx
@@ -47,6 +47,7 @@ const StyledMessage = styled(Message)`
 
   & .kirk-label p {
     margin: 0;
+    white-space: pre-line;
   }
 
   &.kirk-active .kirk-label {


### PR DESCRIPTION
## Description

<!-- Give some context of this PR. Illustrate with screenshots or a video (gif, loom, etc.) -->
<img width="776" alt="Screenshot 2020-05-07 at 12 48 52" src="https://user-images.githubusercontent.com/2952998/81286478-69d4c280-9061-11ea-9080-e99ff858ed40.png">


## What has been done

<!-- How do you solve the problem? -->
Allow break-lines via CSS

## How it was tested

<!-- Local environment with ui-library only, integrated within the main project, on which browsers, etc. -->
_Storybook_ 📕
