### PR TITLE
Fix mainInfo prop type in ItemData (from string to React.ReactNode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 - **[NEW]** Add `leftAddon` prop to `Stepper`. Rendered only on small display.
+- **[FIX]** Change `labelInfo` type to `React.ReactNode` in `ItemChoice`
+- **[FIX]** Change `mainInfo` type to `React.ReactNode` in `ItemData`
 - [...]
 
 # v32.0.0 (06/05/2020)

--- a/src/itemChoice/index.tsx
+++ b/src/itemChoice/index.tsx
@@ -17,7 +17,7 @@ export const ItemChoiceStatus = ItemStatus
 
 export interface ItemChoiceProps extends A11yProps {
   readonly label?: string
-  readonly labelInfo?: string
+  readonly labelInfo?: React.ReactNode
   readonly data?: string
   readonly dataInfo?: string
   readonly leftAddon?: JSX.Element

--- a/src/itemData/index.tsx
+++ b/src/itemData/index.tsx
@@ -9,7 +9,7 @@ export interface ItemDataProps extends A11yProps {
   readonly data: string | JSX.Element
   readonly dataStrikeThrough?: boolean
   readonly dataAriaLabel?: string
-  readonly mainInfo: string
+  readonly mainInfo: React.ReactNode
   readonly className?: string
   readonly mainTitle?: string
   readonly mainTitleButtonAddon?: React.ReactElement<Button>


### PR DESCRIPTION
## Description

Update `mainInfo` type from `string` to `React.ReactNode`
