### PR TITLE
Release/32.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Unreleased
 
+- [...]
+
+# v32.1.0 (07/05/2020)
+
 - **[NEW]** Add `leftAddon` prop to `Stepper`. Rendered only on small display.
 - **[FIX]** Change `labelInfo` type to `React.ReactNode` in `ItemChoice`
 - **[FIX]** Change `mainInfo` type to `React.ReactNode` in `ItemData`
 - **[UPDATE]** `Message` respects break-lines character
-- [...]
 
 # v32.0.0 (06/05/2020)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "32.0.0",
+  "version": "32.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "32.0.0",
+  "version": "32.1.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
- **[NEW]** Add `leftAddon` prop to `Stepper`. Rendered only on small display.
- **[FIX]** Change `labelInfo` type to `React.ReactNode` in `ItemChoice`
- **[FIX]** Change `mainInfo` type to `React.ReactNode` in `ItemData`
- **[UPDATE]** `Message` respects break-lines character