### PR TITLE
Add optional prop to set a global className with FocusVisibleProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
 
 - **[UPDATE]** Added animations on Search form for media large
-  [...]
+- **[UPDATE]** Add `setGlobalClassName` prop to `FocusVisibleProvider`
+- [...]
 
 # v32.2.0 (07/05/2020)
 

--- a/src/_utils/focusVisibleProvider/index.tsx
+++ b/src/_utils/focusVisibleProvider/index.tsx
@@ -17,15 +17,29 @@ const pointerMoveEventList = [
 
 const pointerDownEventList = ['mousedown', 'pointerdown', 'touchstart']
 
+export const FOCUS_VISIBLE_CSS_CLASS = 'focus-visible'
+
 type FocusVisibleProviderProps = {
   children: ReactNode
+  // Provide a global css selector for legacy components.
+  setGlobalClassName?: boolean
 }
 
 export const FocusVisibleContext = createContext(false)
 
-export const FocusVisibleProvider = ({ children }: FocusVisibleProviderProps) => {
-  /* When the provider first loads, assume the user is in pointer modality. */
+export const FocusVisibleProvider = ({
+  children,
+  setGlobalClassName,
+}: FocusVisibleProviderProps) => {
+  // When the provider first loads, assume the user is in pointer modality.
   const [hadKeyboardEvent, setHadKeyboardEvent] = useState(false)
+
+  if (setGlobalClassName) {
+    useEffect(() => {
+      // Add a 'focus-visible' CSS class on the <body> element.
+      document.body.classList.toggle(FOCUS_VISIBLE_CSS_CLASS, hadKeyboardEvent)
+    }, [hadKeyboardEvent])
+  }
 
   useEffect(() => {
     let lastClientX: Number

--- a/src/_utils/focusVisibleProvider/index.unit.tsx
+++ b/src/_utils/focusVisibleProvider/index.unit.tsx
@@ -4,7 +4,7 @@ import { mount, ReactWrapper } from 'enzyme'
 
 import { KEYS } from '_utils/keycodes'
 
-import FocusVisibleProvider, { FocusVisibleContext } from '.'
+import FocusVisibleProvider, { FOCUS_VISIBLE_CSS_CLASS, FocusVisibleContext } from '.'
 
 let focusVisibleContext = null
 let wrapper: ReactWrapper
@@ -29,6 +29,16 @@ describe('FocusVisibleProvider', () => {
     expect(focusVisibleContext).toEqual(false)
   })
 
+  it("Shouldn't apply className on the body element by default", () => {
+    expect(document.body.className).toEqual('')
+    act(() => {
+      document.body.dispatchEvent(new KeyboardEvent('keydown', { key: KEYS.TAB }))
+    })
+    wrapper.update()
+    expect(focusVisibleContext).toEqual(true)
+    expect(document.body.className).toEqual('')
+  })
+
   it('Should update the context value by switching from keyboard to pointer interaction', () => {
     act(() => {
       document.body.dispatchEvent(new KeyboardEvent('keydown', { key: KEYS.TAB }))
@@ -49,5 +59,31 @@ describe('FocusVisibleProvider', () => {
     })
     wrapper.update()
     expect(focusVisibleContext).toEqual(false)
+  })
+  describe('FocusVisibleProvider with hasGlobalClassName', () => {
+    beforeEach(() => {
+      wrapper = mount(
+        <FocusVisibleProvider setGlobalClassName>
+          <ChildComponent />
+        </FocusVisibleProvider>,
+      )
+    })
+    afterEach(() => {
+      focusVisibleContext = null
+    })
+    it('Should update the body className by switching from keyboard to pointer interaction', () => {
+      expect(document.body.className).toEqual('')
+      act(() => {
+        document.body.dispatchEvent(new KeyboardEvent('keydown', { key: KEYS.TAB }))
+      })
+      wrapper.update()
+      expect(document.body.className).toEqual(FOCUS_VISIBLE_CSS_CLASS)
+
+      act(() => {
+        document.body.dispatchEvent(new MouseEvent('mousedown'))
+      })
+      wrapper.update()
+      expect(document.body.className).toEqual('')
+    })
   })
 })

--- a/src/_utils/focusVisibleProvider/useFocusVisible.unit.tsx
+++ b/src/_utils/focusVisibleProvider/useFocusVisible.unit.tsx
@@ -4,14 +4,18 @@ import { mount, ReactWrapper } from 'enzyme'
 
 import { KEYS } from '_utils/keycodes'
 
-import FocusVisibleProvider from '.'
+import FocusVisibleProvider, { FOCUS_VISIBLE_CSS_CLASS } from '.'
 import { useFocusVisible } from './useFocusVisible'
 
 let wrapper: ReactWrapper
 const ButtonComponent = () => {
   const { focusVisible, onFocus, onBlur } = useFocusVisible()
   return (
-    <button className={focusVisible ? 'focus-visible' : null} onFocus={onFocus} onBlur={onBlur}>
+    <button
+      className={focusVisible ? FOCUS_VISIBLE_CSS_CLASS : null}
+      onFocus={onFocus}
+      onBlur={onBlur}
+    >
       Test
     </button>
   )
@@ -34,7 +38,7 @@ describe('useFocusVisible', () => {
     expect(wrapper.find('button').prop('className')).toEqual(null)
 
     wrapper.find('button').simulate('focus')
-    expect(wrapper.find('button').prop('className')).toEqual('focus-visible')
+    expect(wrapper.find('button').prop('className')).toEqual(FOCUS_VISIBLE_CSS_CLASS)
   })
   it('Should have `focusVisible` falsy value when use not whitelisted key', () => {
     wrapper.find('button').simulate('focus')


### PR DESCRIPTION
## What has been done

Add optional prop to set a global className with FocusVisibleProvider
It provide a global selector for Components/Elements which not use the focusContext for now.
It merge the behavior we already have on Kairos.

## How it was tested

- Locally with the Why component which already use the context 
- Unit tests with/without the new prop added
