### PR TITLE
Added padding-top on Itinerary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-[...]
+- **[FIX]** Add `padding-top` on `Itinerary`
+  [...]
 
 # v33.0.1 (15/05/2020)
 

--- a/src/itinerary/index.tsx
+++ b/src/itinerary/index.tsx
@@ -16,6 +16,9 @@ const StyledItinerary = styled(Itinerary)`
     position: relative;
     list-style-type: none;
   }
+  & {
+    padding-top: ${space.m};
+  }
 
   & .kirk-itinerary--highlightRoad .kirk-itineraryLocation-road {
     background-color: ${color.midnightGreen};


### PR DESCRIPTION
## Description

We have inconsistency on vertical spacing on Itinerary in the SPA. To fix that we should use the vertical spacing given by the specs and set it in the component itself. Once done we need to remove custom styles that we set on SPA

## What has been done

Adding top padding on Itinerary component

## How it was tested

Tested on storybook