### PR TITLE
Make heroImageUrl prop optional in HeroSection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Make `heroImageUrl` prop optional in `HeroSection`
 [...]
 
 # v33.1.0 (18/05/2020)

--- a/src/layout/section/heroSection/heroSection.tsx
+++ b/src/layout/section/heroSection/heroSection.tsx
@@ -6,7 +6,7 @@ import TextTitle from '../../../typography/title'
 
 export type HeroSectionProps = {
   className?: string
-  heroImageUrl: string
+  heroImageUrl?: string
   heroImageUrlLarge: string
   heroText?: string
   heroDescription?: string


### PR DESCRIPTION
## Description

The new `HeroSection` no longer use a _small_ image  for small screen.

## What has been done

Make `heroImageUrl` optional.

## Things to consider

`heroImageUrl` is only used in the deprecated small styles.

## How it was tested

With the TS Compiler.