### PR TITLE
Fix crash on IE11 with MainContent component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Fix crash on IE11 for `MainContent` component
 - **[FIX]** Added missing padding-top on `TripCard` price
 - **[FIX]** Make `heroImageUrl` prop optional in `HeroSection`
 - **[FIX]** Export `SearchForm`'s types.

--- a/src/_utils/closest.tsx
+++ b/src/_utils/closest.tsx
@@ -13,7 +13,20 @@ function closest(s: string): HTMLElement | null {
   return null
 }
 
+function matches(s: string): boolean {
+  const m = (this.document || this.ownerDocument).querySelectorAll(s)
+  let i = m.length - 1
+  while (i >= 0 && m.item(i) !== this) {
+    i -= 1
+  }
+  return i > -1
+}
+
 // Checking window for SSR
 if (typeof window !== 'undefined' && !Element.prototype.closest) {
   Element.prototype.closest = closest
+}
+
+if (typeof window !== 'undefined' && !Element.prototype.matches) {
+  Element.prototype.matches = matches
 }


### PR DESCRIPTION
## Description

MainContent component was crashing on IE11 with an error on `matches` function from the `closest` polyfill.

## What has been done

Event though the polyfill was taken from Mozilla, we didn't check that everything was compatible with IE11 (and the `matches` function wasn't). So I've added the polyfill for it since it was pretty simple.

## How it was tested

Tested locally on IE11 through Saucelab. Prod version was crashing, while new version wasn't, so I guess it's ok ^^
