### PR TITLE
Add renderDatePickerComponent prop in SearchForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **[FIX]** Make `heroImageUrl` prop optional in `HeroSection`
 - **[FIX]** Export `SearchForm`'s types.
 - **[BREAKING CHANGE]** Export missing global types.
+- **[UPDATE]** Add `renderDatePickerComponent` prop in `SearchForm`.
   [...]
 
 # v33.1.0 (18/05/2020)

--- a/src/searchForm/SearchForm.tsx
+++ b/src/searchForm/SearchForm.tsx
@@ -9,6 +9,7 @@ import { MediaSize, MediaSizeContext } from '../_utils/mediaSizeProvider'
 import { OnChangeParameters } from '../_utils/onChange'
 import { AutocompleteOnChange, AutoCompleteProps } from '../autoComplete'
 import Bullet, { BulletTypes } from '../bullet'
+import DatePicker from '../datePicker'
 import Divider from '../divider'
 import { CalendarIcon } from '../icon/calendarIcon'
 import { DoubleArrowIcon } from '../icon/doubleArrowIcon'
@@ -17,7 +18,7 @@ import { StandardSeat } from '../icon/standardSeat'
 import TextTitle from '../typography/title'
 import AutoCompleteOverlay, { AutoCompleteOverlayProps } from './autoComplete/overlay'
 import AutoCompleteSection from './autoComplete/section'
-import DatePickerOverlay from './datePicker/overlay'
+import DatePickerOverlay, { DatePickerOverlayProps } from './datePicker/overlay'
 import DatePickerSection from './datePicker/section'
 import Overlay from './overlay'
 import StepperOverlay from './stepper/overlay'
@@ -31,6 +32,7 @@ export interface SearchFormProps {
   autocompleteToPlaceholder: AutoCompleteProps['placeholder']
   renderAutocompleteFrom: AutoCompleteOverlayProps['renderAutocompleteComponent']
   renderAutocompleteTo: AutoCompleteOverlayProps['renderAutocompleteComponent']
+  renderDatePickerComponent?: DatePickerOverlayProps['renderDatePickerComponent']
   datepickerProps: SearchFormDatePickerProps
   stepperProps: SearchFormStepperProps
 }
@@ -72,6 +74,7 @@ const SearchForm = ({
   autocompleteToPlaceholder,
   renderAutocompleteFrom,
   renderAutocompleteTo,
+  renderDatePickerComponent = props => <DatePicker {...props} />,
   datepickerProps,
   stepperProps,
 }: SearchFormProps) => {
@@ -116,6 +119,7 @@ const SearchForm = ({
       closeOpenedElement()
       setFormValues({ ...formValues, [SearchFormElements.DATEPICKER]: value as string })
     },
+    renderDatePickerComponent,
   }
 
   const stepperConfig = {
@@ -288,7 +292,7 @@ const SearchForm = ({
           closeOnBlur={closeOpenedElement}
           className="kirk-searchForm-overlay kirk-searchForm-datepicker"
         >
-          <DatePickerOverlay {...datepickerConfig} closeOnBlur={closeOpenedElement} />
+          <DatePickerOverlay {...datepickerConfig} />
         </Overlay>
 
         {mediaSize === MediaSize.SMALL &&

--- a/src/searchForm/SearchForm.unit.tsx
+++ b/src/searchForm/SearchForm.unit.tsx
@@ -10,12 +10,12 @@ import TextTitle from '../typography/title'
 import AutoCompleteOverlay from './autoComplete/overlay'
 import DatePickerOverlay from './datePicker/overlay'
 import Overlay from './overlay'
-import SearchForm from './SearchForm'
+import SearchForm, { SearchFormProps } from './SearchForm'
 import StepperOverlay from './stepper/overlay'
 
 const today = new Date().toISOString()
 
-const defaultProps = {
+const defaultProps: SearchFormProps = {
   onSubmit: () => {},
   autocompleteFromPlaceholder: 'Leaving from',
   autocompleteToPlaceholder: 'Going to',

--- a/src/searchForm/datePicker/overlay/DatePickerOverlay.tsx
+++ b/src/searchForm/datePicker/overlay/DatePickerOverlay.tsx
@@ -2,28 +2,39 @@ import React from 'react'
 import cc from 'classcat'
 
 import Item from '../../../_utils/item'
-import Datepicker, { DatePickerOrientation, DatePickerProps } from '../../../datePicker'
+import { DatePickerOrientation, DatePickerProps } from '../../../datePicker'
 import Divider from '../../../divider'
 import CalendarIcon from '../../../icon/calendarIcon'
 
-export interface DatePickerOverlayProps extends DatePickerProps {
+export type DatePickerOverlayProps = Omit<
+  DatePickerProps,
+  'numberOfMonths' | 'className' | 'orientation' | 'focus'
+> & {
   title: string
-  closeOnBlur: () => void
+  renderDatePickerComponent: (props: DatePickerProps) => JSX.Element
+  className?: string
 }
 
 const NUMBER_OF_MONTHS = 1
 
-export const DatePickerOverlay = ({ title, closeOnBlur, ...props }: DatePickerOverlayProps) => (
-  <div className={cc(['kirk-datePickerOverlay', props.className])}>
+export const DatePickerOverlay = ({
+  title,
+  renderDatePickerComponent,
+  className,
+  ...props
+}: DatePickerOverlayProps) => (
+  <div className={cc(['kirk-datePickerOverlay', className])}>
     <Item leftAddon={<CalendarIcon />} leftTitle={title} />
+
     <Divider />
-    <Datepicker
-      {...props}
-      numberOfMonths={NUMBER_OF_MONTHS}
-      className="kirk-datePickerOverlay-datepicker"
-      orientation={DatePickerOrientation.HORIZONTAL}
-      focus
-    />
+
+    {renderDatePickerComponent({
+      ...props,
+      numberOfMonths: NUMBER_OF_MONTHS,
+      className: 'kirk-datePickerOverlay-datepicker',
+      orientation: DatePickerOrientation.HORIZONTAL,
+      focus: true,
+    })}
   </div>
 )
 

--- a/src/searchForm/datePicker/overlay/DatePickerOverlay.unit.tsx
+++ b/src/searchForm/datePicker/overlay/DatePickerOverlay.unit.tsx
@@ -8,13 +8,27 @@ import DatePickerOverlay from './DatePickerOverlay'
 
 describe('DatePickerOverlay', () => {
   it('should have a Item with a title and a calendar icon', () => {
-    const wrapper = shallow(<DatePickerOverlay title="Today" closeOnBlur={() => {}} />)
+    const wrapper = shallow(
+      <DatePickerOverlay
+        title="Today"
+        name="Name"
+        renderDatePickerComponent={props => <DatePicker {...props} />}
+      />,
+    )
+
     expect(wrapper.find(Item).prop('leftTitle')).toEqual('Today')
     expect(wrapper.find(Item).prop('leftAddon')).toEqual(<CalendarIcon />)
   })
 
   it('should have a DatePicker with 1 month displayed and in horizontal orientation', () => {
-    const wrapper = shallow(<DatePickerOverlay title="Today" closeOnBlur={() => {}} />)
+    const wrapper = shallow(
+      <DatePickerOverlay
+        title="Today"
+        name="name"
+        renderDatePickerComponent={props => <DatePicker {...props} />}
+      />,
+    )
+
     expect(wrapper.find(DatePicker).prop('numberOfMonths')).toEqual(1)
     expect(wrapper.find(DatePicker).prop('orientation')).toEqual(DatePickerOrientation.HORIZONTAL)
     expect(wrapper.find(DatePicker).prop('focus')).toBe(true)

--- a/src/searchForm/datePicker/overlay/index.tsx
+++ b/src/searchForm/datePicker/overlay/index.tsx
@@ -18,4 +18,5 @@ const StyledDatePickerOverlay = styled(DatePickerOverlay)`
   }
 `
 
+export { DatePickerOverlayProps } from './DatePickerOverlay'
 export default StyledDatePickerOverlay

--- a/src/searchForm/datePicker/section/DatePickerSection.tsx
+++ b/src/searchForm/datePicker/section/DatePickerSection.tsx
@@ -2,36 +2,46 @@ import React, { useRef } from 'react'
 
 import Item from '../../../_utils/item'
 import { useFocusTrap } from '../../../_utils/useFocusTrap'
-import Datepicker, { DatePickerOrientation, DatePickerProps } from '../../../datePicker'
+import { DatePickerOrientation, DatePickerProps } from '../../../datePicker'
 import Divider from '../../../divider'
 import ChevronIcon from '../../../icon/chevronIcon'
 import Section from '../../../layout/section/baseSection'
 import { TransitionSection } from '../../baseStyles'
 
-export interface DatePickerSectionProps extends DatePickerProps {
+export type DatePickerSectionProps = Omit<DatePickerProps, 'className' | 'orientation'> & {
   title: string
   onClose: () => void
+  renderDatePickerComponent: (props: DatePickerProps) => JSX.Element
+  className?: string
 }
 
-export const DatePickerSection = ({ onClose, ...props }: DatePickerSectionProps) => {
+export const DatePickerSection = ({
+  title,
+  onClose,
+  renderDatePickerComponent,
+  className,
+  ...props
+}: DatePickerSectionProps) => {
   const ref = useRef<HTMLDivElement>(null)
   useFocusTrap(ref, onClose)
 
   return (
-    <TransitionSection ref={ref} role="dialog" className={props.className}>
+    <TransitionSection ref={ref} role="dialog" className={className}>
       <Section>
         <Item
           leftAddon={<ChevronIcon left />}
-          leftTitle={props.title}
+          leftTitle={title}
           tag={<button type="button" />}
           onClick={onClose}
         />
+
         <Divider />
-        <Datepicker
-          {...props}
-          className="kirk-datePickerSection-datepicker"
-          orientation={DatePickerOrientation.VERTICAL}
-        />
+
+        {renderDatePickerComponent({
+          ...props,
+          className: 'kirk-datePickerSection-datepicker',
+          orientation: DatePickerOrientation.VERTICAL,
+        })}
       </Section>
     </TransitionSection>
   )

--- a/src/searchForm/datePicker/section/DatePickerSection.unit.tsx
+++ b/src/searchForm/datePicker/section/DatePickerSection.unit.tsx
@@ -9,7 +9,15 @@ import DatePickerSection from './DatePickerSection'
 describe('DatePickerSection', () => {
   it('should have a clickable Item with a title and chevron icon', () => {
     const onClick = jest.fn()
-    const wrapper = shallow(<DatePickerSection title="Today" onClose={onClick} />)
+    const wrapper = shallow(
+      <DatePickerSection
+        title="Today"
+        onClose={onClick}
+        name="Name"
+        renderDatePickerComponent={props => <DatePicker {...props} />}
+      />,
+    )
+
     expect(wrapper.find(Item).prop('leftTitle')).toEqual('Today')
     expect(wrapper.find(Item).prop('leftAddon')).toEqual(<ChevronIcon left />)
     expect(wrapper.find(Item).prop('tag')).toEqual(<button type="button" />)
@@ -18,7 +26,15 @@ describe('DatePickerSection', () => {
   })
 
   it('should have a DatePicker in vertical orientation', () => {
-    const wrapper = shallow(<DatePickerSection title="Today" />)
+    const wrapper = shallow(
+      <DatePickerSection
+        title="Today"
+        name="Name"
+        renderDatePickerComponent={props => <DatePicker {...props} />}
+        onClose={() => {}}
+      />,
+    )
+
     expect(wrapper.find(DatePicker).prop('orientation')).toEqual(DatePickerOrientation.VERTICAL)
   })
 })

--- a/src/searchForm/story.tsx
+++ b/src/searchForm/story.tsx
@@ -4,6 +4,7 @@ import { storiesOf } from '@storybook/react'
 
 import MediaSizeProvider from '../_utils/mediaSizeProvider'
 import { AutoCompleteExample } from '../autoComplete/story'
+import DatePicker from '../datePicker'
 import CrossIcon from '../icon/crossIcon'
 import BaseSection, { SectionContentSize } from '../layout/section/baseSection'
 import AutoCompleteOverlay from './autoComplete/overlay'
@@ -16,14 +17,26 @@ import StepperOverlay from './stepper/overlay'
 import StepperSection from './stepper/section'
 
 const stories = storiesOf('Widgets|SearchForm', module)
+
 stories.addDecorator(withKnobs)
 
 stories.add('DatepickerOverlay', () => (
-  <DatePickerOverlay name="Datepicker" title="Today" closeOnBlur={() => {}} />
+  <DatePickerOverlay
+    name="Datepicker"
+    title="Today"
+    renderDatePickerComponent={props => <DatePicker {...props} />}
+  />
 ))
+
 stories.add('DatePickerSection', () => (
-  <DatePickerSection name="Datepicker" title="Today" onClose={() => {}} />
+  <DatePickerSection
+    name="Datepicker"
+    title="Today"
+    onClose={() => {}}
+    renderDatePickerComponent={props => <DatePicker {...props} />}
+  />
 ))
+
 stories.add('StepperOverlay', () => (
   <StepperOverlay
     name="Stepper"
@@ -35,6 +48,7 @@ stories.add('StepperOverlay', () => (
     decreaseLabel="Decrease"
   />
 ))
+
 stories.add('StepperSection', () => (
   <StepperSection
     name="Stepper"
@@ -46,9 +60,11 @@ stories.add('StepperSection', () => (
     onClose={() => {}}
   />
 ))
+
 stories.add('AutoCompleteOverlay', () => (
   <AutoCompleteOverlay name="from" renderAutocompleteComponent={() => <AutoCompleteExample />} />
 ))
+
 stories.add('AutoCompleteSection', () => (
   <AutoCompleteSection
     name="from"


### PR DESCRIPTION
## Description

Support custom `DatePicker` component in `SearchForm`.

## What has been done

An optional `renderDatePickerComponent` has been added.

## Things to consider

Nothing.

## How it was tested

- Unit tests
- Local build in Kairos