### PR TITLE
Add ellipsis for overflowing text in SearchForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **[FIX]** Export `SearchForm`'s types.
 - **[BREAKING CHANGE]** Export missing global types.
 - **[UPDATE]** Add `renderDatePickerComponent` prop in `SearchForm`.
+- **[FIX]** Add ellipsis for overflowing text in `SearchForm`.
   [...]
 
 # v33.1.0 (18/05/2020)

--- a/src/searchForm/SearchForm.tsx
+++ b/src/searchForm/SearchForm.tsx
@@ -199,7 +199,12 @@ const SearchForm = ({
             <span className="kirk-bullet--searchForm">
               <Bullet type={BulletTypes.SEARCH} />
             </span>
-            <TextTitle className={cc({ 'kirk-search-placeholder': !autocompleteFromValue })}>
+            <TextTitle
+              className={cc([
+                'kirk-search-ellipsis',
+                { 'kirk-search-placeholder': !autocompleteFromValue },
+              ])}
+            >
               {autocompleteFromValue?.item.label || autocompleteFromPlaceholder}
             </TextTitle>
           </button>
@@ -244,7 +249,12 @@ const SearchForm = ({
           <span className="kirk-bullet--searchForm">
             <Bullet type={BulletTypes.SEARCH} />
           </span>
-          <TextTitle className={cc({ 'kirk-search-placeholder': !autocompleteToValue })}>
+          <TextTitle
+            className={cc([
+              'kirk-search-ellipsis',
+              { 'kirk-search-placeholder': !autocompleteToValue },
+            ])}
+          >
             {autocompleteToValue?.item.label || autocompleteToPlaceholder}
           </TextTitle>
         </button>
@@ -281,7 +291,7 @@ const SearchForm = ({
             onClick={() => setElementOpened(SearchFormElements.DATEPICKER)}
           >
             <CalendarIcon />
-            <TextTitle>{getDatepickerFormattedValue()}</TextTitle>
+            <TextTitle className="kirk-search-ellipsis">{getDatepickerFormattedValue()}</TextTitle>
           </button>
         </div>
 
@@ -314,7 +324,7 @@ const SearchForm = ({
             onClick={() => setElementOpened(SearchFormElements.STEPPER)}
           >
             <StandardSeat />
-            <TextTitle>{getStepperFormattedValue()}</TextTitle>
+            <TextTitle className="kirk-search-ellipsis">{getStepperFormattedValue()}</TextTitle>
           </button>
         </div>
       </div>

--- a/src/searchForm/index.tsx
+++ b/src/searchForm/index.tsx
@@ -60,10 +60,6 @@ const StyledSearchForm = styled(SearchForm)`
     color: ${color.lightMidnightGreen};
   }
 
-  & .kirk-bullet--searchForm {
-    margin-right: ${space.m};
-  }
-
   & .kirk-searchForm-invert {
     border-right: 1px solid ${color.lightGray};
   }
@@ -84,9 +80,15 @@ const StyledSearchForm = styled(SearchForm)`
     box-sizing: border-box;
     line-height: ${font.l.lineHeight};
     width: 100%;
+    min-width: 0;
+    text-align: left;
     white-space: nowrap;
     overflow: hidden;
     align-items: center;
+
+    & > *:not(:first-child) {
+      margin-left: ${space.m};
+    }
   }
 
   & .kirk-searchForm-from .kirk-search-button,
@@ -98,7 +100,9 @@ const StyledSearchForm = styled(SearchForm)`
   }
 
   & .kirk-searchForm-invert .kirk-search-button {
+    width: initial;
     padding: 0;
+    margin: 0 ${space.m};
   }
 
   & .kirk-searchForm-date .kirk-search-button,
@@ -121,6 +125,7 @@ const StyledSearchForm = styled(SearchForm)`
     border-radius: 0 ${radius.l} ${radius.l} 0;
     background-color: ${color.blue};
     padding: 0;
+    justify-content: center;
   }
 
   & .kirk-searchForm-submit .kirk-icon {
@@ -128,12 +133,7 @@ const StyledSearchForm = styled(SearchForm)`
   }
 
   & .kirk-search-button svg {
-    margin: 0;
-    margin-right: ${space.m};
-  }
-
-  & .kirk-searchForm-submit .kirk-icon {
-    flex: 1;
+    flex: none;
   }
 
   & .kirk-searchForm-overlay {
@@ -151,6 +151,14 @@ const StyledSearchForm = styled(SearchForm)`
 
   & .kirk-searchForm-datepicker {
     left: ${positionDateStepper};
+  }
+
+  & .kirk-search-ellipsis {
+    flex: 0 1 auto;
+    min-width: 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
   }
 
   @media (${responsiveBreakpoints.isMediaSmall}) {
@@ -176,12 +184,18 @@ const StyledSearchForm = styled(SearchForm)`
       padding-bottom: ${space.m};
     }
 
+    & .kirk-searchForm-invert .kirk-search-button {
+      width: initial;
+      margin-right: 0;
+    }
+
     & .kirk-searchForm-date {
       margin-right: ${space.m};
     }
 
     & .kirk-searchForm-from {
-      flex-grow: 1;
+      flex: 1;
+      min-width: 0;
     }
 
     & .kirk-searchForm-invert {
@@ -196,6 +210,7 @@ const StyledSearchForm = styled(SearchForm)`
     & .kirk-searchForm-date,
     & .kirk-searchForm-seats {
       flex: 1;
+      min-width: 0;
     }
 
     & .kirk-searchForm-dateSeat-container {

--- a/src/searchForm/story.tsx
+++ b/src/searchForm/story.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { withKnobs } from '@storybook/addon-knobs'
+import { text, withKnobs } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 
 import MediaSizeProvider from '../_utils/mediaSizeProvider'
@@ -80,8 +80,8 @@ stories.add(
       <BaseSection contentSize={SectionContentSize.LARGE}>
         <SearchForm
           onSubmit={() => {}}
-          autocompleteFromPlaceholder="Leaving From"
-          autocompleteToPlaceholder="Going to"
+          autocompleteFromPlaceholder={text('autocompleteFromPlaceholder', 'Leaving From')}
+          autocompleteToPlaceholder={text('autocompleteToPlaceholder', 'Going to')}
           renderAutocompleteFrom={props => (
             <AutoCompleteExample inputAddon={<CrossIcon />} autoFocus={false} {...props} />
           )}


### PR DESCRIPTION
## Description

When departure and arrival addresses are too long they overflow.

## What has been done

Update styles to add ellipsis on the texts.

**Before**

<img width="265" alt="Screenshot 2020-05-20 at 15 15 31" src="https://user-images.githubusercontent.com/17502801/82450606-30627500-9aad-11ea-804d-f2f5a167a7e8.png">
<img width="941" alt="Screenshot 2020-05-20 at 15 16 05" src="https://user-images.githubusercontent.com/17502801/82450642-4112eb00-9aad-11ea-9283-04fa06900ee2.png">

**After**

<img width="252" alt="Screenshot 2020-05-20 at 15 14 46" src="https://user-images.githubusercontent.com/17502801/82450713-55ef7e80-9aad-11ea-9678-e096e31d1372.png">
<img width="954" alt="Screenshot 2020-05-20 at 15 16 34" src="https://user-images.githubusercontent.com/17502801/82450728-5be55f80-9aad-11ea-8017-06c176abe19b.png">


## How it was tested

- Storybook (Chrome, Firefox, Safari)