### PR TITLE
Display "Continue" button at the bottom in number of passenger step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **[BREAKING CHANGE]** Export missing global types.
 - **[UPDATE]** Add `renderDatePickerComponent` prop in `SearchForm`.
 - **[FIX]** Add ellipsis for overflowing text in `SearchForm`.
+- **[FIX]** Display "Continue" button at the bottom in number of passenger step in `SearchForm`.
   [...]
 
 # v33.1.0 (18/05/2020)

--- a/src/searchForm/stepper/section/StepperSection.tsx
+++ b/src/searchForm/stepper/section/StepperSection.tsx
@@ -1,5 +1,7 @@
 import React, { useRef, useState } from 'react'
+import styled from 'styled-components'
 
+import { space } from '../../../_utils/branding'
 import Item from '../../../_utils/item'
 import { OnChangeParameters } from '../../../_utils/onChange'
 import { useFocusTrap } from '../../../_utils/useFocusTrap'
@@ -16,6 +18,27 @@ export interface StepperSectionProps extends StepperProps {
   onClose: () => void
   onConfirm?: (event: React.MouseEvent<HTMLElement>) => void
 }
+
+const FullHeightSection = styled(Section)`
+  height: 100%;
+
+  & .section-content {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+`
+
+const SectionContent = styled.div`
+  width: 100%;
+  flex: 1 0 auto;
+`
+
+const SectionFooter = styled.div`
+  margin-top: auto;
+  padding: ${space.l};
+`
 
 export const StepperSection = ({
   itemTitle,
@@ -35,21 +58,24 @@ export const StepperSection = ({
 
   return (
     <TransitionSection ref={ref} role="dialog" className={className}>
-      <Section>
-        <Item
-          leftAddon={<ChevronIcon left />}
-          leftTitle={itemTitleState}
-          tag={<button type="button" />}
-          onClick={onClose}
-        />
-        <Divider />
-        <Stepper {...props} onChange={setStepperValue} display={StepperDisplay.LARGE} />
-        <div className="kirk-stepperSection-submit">
+      <FullHeightSection>
+        <SectionContent>
+          <Item
+            leftAddon={<ChevronIcon left />}
+            leftTitle={itemTitleState}
+            tag={<button type="button" />}
+            onClick={onClose}
+          />
+          <Divider />
+          <Stepper {...props} onChange={setStepperValue} display={StepperDisplay.LARGE} />
+        </SectionContent>
+
+        <SectionFooter>
           <Button status={ButtonStatus.PRIMARY} onClick={() => onChange(stepperValue)}>
             {confirmLabel}
           </Button>
-        </div>
-      </Section>
+        </SectionFooter>
+      </FullHeightSection>
     </TransitionSection>
   )
 }

--- a/src/searchForm/stepper/section/index.tsx
+++ b/src/searchForm/stepper/section/index.tsx
@@ -7,10 +7,6 @@ const StyledStepperSection = styled(StepperSection)`
   & {
     ${sectionBaseStyle};
   }
-
-  & .kirk-stepperSection-submit {
-    text-align: center;
-  }
 `
 
 export default StyledStepperSection


### PR DESCRIPTION
## Description

Display "Continue" button at the bottom in number of passenger step in the search form for small screens.

## What has been done

Update styles to allow that.

**Before**

<img width="390" alt="Screenshot 2020-05-22 at 12 16 03" src="https://user-images.githubusercontent.com/17502801/82657743-287a1080-9c26-11ea-8b9c-0ed955793cef.png">

**After**

<img width="401" alt="Screenshot 2020-05-22 at 12 15 43" src="https://user-images.githubusercontent.com/17502801/82657756-2e6ff180-9c26-11ea-8a30-eb8700ce2a16.png">


## How it was tested

- Storybook (Chrome, Firefox, Safari)