### PR TITLE
Fix back button alignment in SearchForm autocomplete sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Fix back button alignment in `SearchForm` autocomplete sections.
 [...]
 
 # v34.1.0 (27/05/2020)

--- a/src/searchForm/autoComplete/section/AutoCompleteSection.tsx
+++ b/src/searchForm/autoComplete/section/AutoCompleteSection.tsx
@@ -1,11 +1,21 @@
 import React, { useRef } from 'react'
+import styled from 'styled-components'
 
+import { space } from '../../../_utils/branding'
 import { useFocusTrap } from '../../../_utils/useFocusTrap'
 import { AutoCompleteProps } from '../../../autoComplete'
 import Button, { ButtonStatus } from '../../../button'
-import Icon from '../../../icon/chevronIcon'
+import ChevronIcon from '../../../icon/chevronIcon'
 import Section from '../../../layout/section/baseSection'
 import { TransitionSection } from '../../baseStyles'
+
+const BackButton = styled(Button)`
+  &.kirk-button-bubble {
+    margin-right: ${space.l};
+    width: auto;
+    border: none;
+  }
+`
 
 export type AutoCompleteSectionProps = Omit<
   AutoCompleteProps,
@@ -30,9 +40,9 @@ export const AutoCompleteSection = ({
   useFocusTrap(ref, onClose)
 
   const backButton = (
-    <Button status={ButtonStatus.UNSTYLED} isBubble onClick={onClose}>
-      <Icon size="18" left />
-    </Button>
+    <BackButton status={ButtonStatus.UNSTYLED} isBubble onClick={onClose}>
+      <ChevronIcon size="24" left />
+    </BackButton>
   )
 
   return (

--- a/src/searchForm/story.tsx
+++ b/src/searchForm/story.tsx
@@ -62,13 +62,16 @@ stories.add('StepperSection', () => (
 ))
 
 stories.add('AutoCompleteOverlay', () => (
-  <AutoCompleteOverlay name="from" renderAutocompleteComponent={() => <AutoCompleteExample />} />
+  <AutoCompleteOverlay
+    name="from"
+    renderAutocompleteComponent={props => <AutoCompleteExample {...props} />}
+  />
 ))
 
 stories.add('AutoCompleteSection', () => (
   <AutoCompleteSection
     name="from"
-    renderAutocompleteComponent={() => <AutoCompleteExample />}
+    renderAutocompleteComponent={props => <AutoCompleteExample {...props} />}
     onClose={() => {}}
   />
 ))


### PR DESCRIPTION
## Description

Fix the alignment of the back button in the search form autocomplete sections.

**Before**

<img width="384" alt="Screenshot 2020-06-01 at 11 11 56" src="https://user-images.githubusercontent.com/17502801/83394953-c9708480-a3f9-11ea-99e7-c248f4e39ffd.png">

**After**

<img width="387" alt="Screenshot 2020-06-01 at 11 02 03" src="https://user-images.githubusercontent.com/17502801/83394997-d2f9ec80-a3f9-11ea-8c2f-181f3cc10363.png">

## What has been done

Override the button styles for this "specific" usage. It doesn't look supported 🤷‍♂️.

## Things to consider

Don't we have a generic component for this?

## How it was tested

- Storybook