### PR TITLE
Only show the search form switch button when at least FROM or TO is s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - **[FIX]** Fix back button alignment in `SearchForm` autocomplete sections.
+- **[UPDATE]** Only show the `SearchForm` switch button when at least FROM or TO is selected.
 [...]
 
 # v34.1.0 (27/05/2020)

--- a/src/searchForm/SearchForm.tsx
+++ b/src/searchForm/SearchForm.tsx
@@ -177,6 +177,10 @@ const SearchForm = ({
   ] as AutocompleteOnChange
   const autocompleteToValue = formValues[SearchFormElements.AUTOCOMPLETE_TO] as AutocompleteOnChange
 
+  const showInvertButton =
+    formValues[SearchFormElements.AUTOCOMPLETE_FROM] != null ||
+    formValues[SearchFormElements.AUTOCOMPLETE_TO] != null
+
   return (
     <form
       action=""
@@ -210,8 +214,15 @@ const SearchForm = ({
           </button>
           {mediaSize === MediaSize.SMALL && <Divider />}
         </div>
+
         <div className="kirk-searchForm-invert">
-          <button type="button" className="kirk-search-button" onClick={invertFromTo}>
+          <button
+            type="button"
+            className="kirk-search-button"
+            onClick={invertFromTo}
+            // We need to keep it the DOM to preserve the form size.
+            disabled={!showInvertButton}
+          >
             <DoubleArrowIcon iconColor={color.blue} />
           </button>
           {mediaSize === MediaSize.SMALL && <Divider />}

--- a/src/searchForm/index.tsx
+++ b/src/searchForm/index.tsx
@@ -102,7 +102,12 @@ const StyledSearchForm = styled(SearchForm)`
   & .kirk-searchForm-invert .kirk-search-button {
     width: initial;
     padding: 0;
-    margin: 0 ${space.m};
+    margin-right: ${space.m};
+
+    &:disabled {
+      opacity: 0;
+      cursor: default;
+    }
   }
 
   & .kirk-searchForm-date .kirk-search-button,


### PR DESCRIPTION
## Description

Only show the `SearchForm` switch button when at least FROM or TO is filled.

**Before**

<img width="949" alt="Screenshot 2020-06-01 at 14 23 35" src="https://user-images.githubusercontent.com/17502801/83410376-9092d880-a416-11ea-9e42-e279d87e0eac.png">

<img width="342" alt="Screenshot 2020-06-01 at 14 23 25" src="https://user-images.githubusercontent.com/17502801/83410381-94265f80-a416-11ea-8f5d-a78d10465149.png">

**After**

<img width="945" alt="Screenshot 2020-06-01 at 14 22 37" src="https://user-images.githubusercontent.com/17502801/83410394-9be60400-a416-11ea-8c4b-e15b5f31f1ad.png">

<img width="343" alt="Screenshot 2020-06-01 at 14 23 04" src="https://user-images.githubusercontent.com/17502801/83410396-9ee0f480-a416-11ea-9fcd-61dd939a050c.png">

## What has been done

Show or hide the switch button when needed.

## How it was tested

- Storybook