### PR TITLE
Add disabled prop to Stepper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[NEW]** Add `disabled` prop to `Stepper`
 [...]
 
 # v34.1.0 (27/05/2020)

--- a/src/stepper/Stepper.tsx
+++ b/src/stepper/Stepper.tsx
@@ -41,6 +41,7 @@ export interface StepperProps {
   display?: StepperDisplay
   focus?: boolean
   leftAddon?: React.ReactNode
+  disabled?: boolean
 }
 
 interface StepperState {
@@ -189,6 +190,7 @@ export default class Stepper extends PureComponent<StepperProps, StepperState> {
       max,
       valueClassName,
       display,
+      disabled,
     } = this.props
 
     const isMax = this.state.value >= max
@@ -211,11 +213,11 @@ export default class Stepper extends PureComponent<StepperProps, StepperState> {
             type="button"
             className="kirk-stepper-decrement"
             status={ButtonStatus.UNSTYLED}
-            disabled={isMin}
+            disabled={disabled || isMin}
             isBubble
             {...this.createButtonListeners(this.decrement)}
           >
-            <MinusIcon iconColor={isMin ? color.lightGray : color.blue} size={buttonSize} />
+            <MinusIcon iconColor={color.blue} size={buttonSize} isDisabled={disabled || isMin} />
           </Button>
           <div
             aria-live="polite"
@@ -230,11 +232,11 @@ export default class Stepper extends PureComponent<StepperProps, StepperState> {
             type="button"
             className="kirk-stepper-increment"
             status={ButtonStatus.UNSTYLED}
-            disabled={isMax}
+            disabled={disabled || isMax}
             isBubble
             {...this.createButtonListeners(this.increment)}
           >
-            <PlusIcon iconColor={isMax ? color.lightGray : color.blue} size={buttonSize} />
+            <PlusIcon iconColor={color.blue} size={buttonSize} isDisabled={disabled || isMax} />
           </Button>
         </div>
       </div>

--- a/src/stepper/Stepper.unit.tsx
+++ b/src/stepper/Stepper.unit.tsx
@@ -137,6 +137,40 @@ it('Should not call onChange on componentDidMount', () => {
   expect(onChange).toHaveBeenCalledTimes(0)
 })
 
+it('Should disable buttons if disabled is true', () => {
+  const stepper = shallow(<Stepper {...defaultProps} value={5} min={1} max={10} />)
+  expect(
+    stepper
+      .find(Button)
+      .at(0)
+      .prop('disabled'),
+  ).toBeFalsy()
+  expect(
+    stepper
+      .find(Button)
+      .at(1)
+      .prop('disabled'),
+  ).toBeFalsy()
+  expect(stepper.find(MinusIcon).prop('isDisabled')).toBeFalsy()
+  expect(stepper.find(PlusIcon).prop('isDisabled')).toBeFalsy()
+
+  stepper.setProps({ disabled: true })
+  expect(
+    stepper
+      .find(Button)
+      .at(0)
+      .prop('disabled'),
+  ).toBeTruthy()
+  expect(
+    stepper
+      .find(Button)
+      .at(1)
+      .prop('disabled'),
+  ).toBeTruthy()
+  expect(stepper.find(MinusIcon).prop('isDisabled')).toBeTruthy()
+  expect(stepper.find(PlusIcon).prop('isDisabled')).toBeTruthy()
+})
+
 describe('display', () => {
   it('should render SMALL display', () => {
     const stepper = shallow(<Stepper {...defaultProps} display={StepperDisplay.SMALL} />)

--- a/src/stepper/story.tsx
+++ b/src/stepper/story.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { action } from '@storybook/addon-actions'
-import { number, select, text, withKnobs } from '@storybook/addon-knobs'
+import { boolean, number, select, text, withKnobs } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 
 import Itinerary from '../itinerary'
@@ -26,6 +26,7 @@ stories.add(
         onChange={action('changed')}
         display={select('display', StepperDisplay, StepperDisplay.SMALL)}
         title={text('children', 'Number of seats')}
+        disabled={boolean('disabled', false)}
       />
     </Section>
   ),
@@ -48,6 +49,7 @@ stories.add('Stepper with formatted value', () => (
       onChange={action('changed')}
       display={select('display', StepperDisplay, StepperDisplay.SMALL)}
       title={text('children', 'Edit the price')}
+      disabled={boolean('disabled', false)}
     />
   </Section>
 ))
@@ -66,6 +68,7 @@ stories.add('Stepper with large formatted value', () => (
       onChange={action('changed')}
       display={select('display', StepperDisplay, StepperDisplay.LARGE)}
       title={text('children', 'Edit the price')}
+      disabled={boolean('disabled', false)}
     />
   </Section>
 ))
@@ -85,6 +88,7 @@ stories.add('Stepper with left addon', () => (
       display={select('display', StepperDisplay, StepperDisplay.SMALL)}
       title={text('children', 'Edit the price')}
       leftAddon={<Itinerary places={[{ mainLabel: 'Paris' }, { mainLabel: 'Nantes' }]} />}
+      disabled={boolean('disabled', false)}
     />
   </Section>
 ))


### PR DESCRIPTION
## Description

For trip edit, we need to be able to disable the stepper (i.e., the driver can't update the seat count if a booking is in progress).
We could cheat by setting min/max values equal to the selected value, but MEH.

## What has been done

Added `disabled` prop to the `Stepper` component

## Things to consider

Reusing the disabled display we have when hitting min/max values

## How it was tested

Storybook on chrome
