### PR TITLE
Remove hover & pointer on disabled ItemCheckbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 [...]
+- **[FIX]** Remove hover color & pointer when `disabled` is passed to `ItemCheckbox`/`ItemRadio`
 
 # v34.1.0 (27/05/2020)
 

--- a/src/itemCheckbox/ItemCheckbox.tsx
+++ b/src/itemCheckbox/ItemCheckbox.tsx
@@ -82,7 +82,7 @@ class ItemCheckbox extends Component<ItemCheckboxProps> {
         // eslint-disable-next-line jsx-a11y/label-has-associated-control
         tag={<label />}
         rightAddon={checkbox}
-        isClickable
+        isClickable={!disabled}
         disabled={disabled}
         {...a11yAttrs}
       />

--- a/src/itemCheckbox/ItemCheckbox.unit.tsx
+++ b/src/itemCheckbox/ItemCheckbox.unit.tsx
@@ -51,6 +51,15 @@ describe('ItemCheckbox', () => {
       value: true,
     })
   })
+  it('Should handle disabled prop', () => {
+    const itemCheckbox = shallow(<ItemCheckbox {...defaultProps} />)
+    expect(itemCheckbox.find(Item).prop('isClickable')).toBeTruthy()
+    expect(itemCheckbox.find(Item).prop('disabled')).toBeFalsy()
+
+    itemCheckbox.setProps({ disabled: true })
+    expect(itemCheckbox.find(Item).prop('isClickable')).toBeFalsy()
+    expect(itemCheckbox.find(Item).prop('disabled')).toBeTruthy()
+  })
   it('Should call the onChange prop with name and value when the input changes (uncheck)', () => {
     const onChangeMock = jest.fn()
     const itemCheckbox = shallow(<ItemCheckbox {...defaultProps} onChange={onChangeMock} checked />)

--- a/src/itemCheckbox/index.tsx
+++ b/src/itemCheckbox/index.tsx
@@ -4,7 +4,7 @@ import ItemCheckbox from './ItemCheckbox'
 
 const StyledItemCheckbox = styled(ItemCheckbox)`
   & {
-    cursor: pointer;
+    cursor: ${props => (props.disabled ? 'default' : 'pointer')};
   }
 
   & input {

--- a/src/itemRadio/ItemRadio.tsx
+++ b/src/itemRadio/ItemRadio.tsx
@@ -120,7 +120,7 @@ class ItemRadio extends Component<ItemRadioProps> {
           rightAddon={radio}
           chevron={chevron && !isLoading}
           highlighted={highlighted}
-          isClickable
+          isClickable={!disabled}
           disabled={disabled}
           {...a11yAttrs}
         />

--- a/src/itemRadio/ItemRadio.unit.tsx
+++ b/src/itemRadio/ItemRadio.unit.tsx
@@ -40,6 +40,15 @@ describe('ItemRadio', () => {
       .toJSON()
     expect(itemRadio).toMatchSnapshot()
   })
+  it('Should handle disabled prop', () => {
+    const itemRadio = shallow(<ItemRadio {...defaultProps} />)
+    expect(itemRadio.find(Item).prop('isClickable')).toBeTruthy()
+    expect(itemRadio.find(Item).prop('disabled')).toBeFalsy()
+
+    itemRadio.setProps({ disabled: true })
+    expect(itemRadio.find(Item).prop('isClickable')).toBeFalsy()
+    expect(itemRadio.find(Item).prop('disabled')).toBeTruthy()
+  })
 
   describe('a11y', () => {
     it('Should have a label tag as wrapper to associate content text to input radio', () => {

--- a/src/itemRadio/index.tsx
+++ b/src/itemRadio/index.tsx
@@ -9,7 +9,7 @@ const StyledItemRadio = styled(ItemRadio)`
     clip: rect(0, 0, 0, 0);
   }
   & {
-    cursor: pointer;
+    cursor: ${props => (props.disabled ? 'default' : 'pointer')};
     border: ${inputBorderSize.focus} solid transparent;
     padding: calc(${space.l} - ${inputBorderSize.focus}) 0;
   }


### PR DESCRIPTION
## Description

Impact both `ItemCheckbox` & `ItemRadio` components. Demo for `ItemCheckbox`:

Before:
![before](https://user-images.githubusercontent.com/729186/83428686-29cfe800-a433-11ea-8d00-93db52d66a2f.gif)

After:
![after](https://user-images.githubusercontent.com/729186/83428683-289ebb00-a433-11ea-9362-69a2d6458746.gif)

## What has been done

- Remove `cursor: pointer` when `disabled` is true
- Set `isClickable` prop to false when `disabled` is true to remove the background 

## Things to consider

Some snapshots will be updated when upgrading kairos

## How it was tested

With storybook
