### PR TITLE
Releases/34.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 [...]
 
-# v34.2.0 (27/05/2020)
+# v34.2.0 (02/06/2020)
 
 - **[NEW]** Add `disabled` prop to `Stepper`
 - **[UPDATE]** Only show the `SearchForm` switch button when at least FROM or TO is selected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Unreleased
 
-- **[NEW]** Add `disabled` prop to `Stepper`
-- **[FIX]** Fix back button alignment in `SearchForm` autocomplete sections.
-- **[UPDATE]** Only show the `SearchForm` switch button when at least FROM or TO is selected.
 [...]
+
+# v34.2.0 (27/05/2020)
+
+- **[NEW]** Add `disabled` prop to `Stepper`
+- **[UPDATE]** Only show the `SearchForm` switch button when at least FROM or TO is selected.
 - **[FIX]** Remove hover color & pointer when `disabled` is passed to `ItemCheckbox`/`ItemRadio`
+- **[FIX]** Fix back button alignment in `SearchForm` autocomplete sections.
 
 # v34.1.0 (27/05/2020)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "34.1.0",
+  "version": "34.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "34.1.0",
+  "version": "34.2.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# v34.2.0 (02/06/2020)

- **[NEW]** Add `disabled` prop to `Stepper`
- **[UPDATE]** Only show the `SearchForm` switch button when at least FROM or TO is selected.
- **[FIX]** Remove hover color & pointer when `disabled` is passed to `ItemCheckbox`/`ItemRadio`
- **[FIX]** Fix back button alignment in `SearchForm` autocomplete sections.