### PR TITLE
Remove memoization on icons

### DIFF
--- a/src/icon/airConditioning.tsx
+++ b/src/icon/airConditioning.tsx
@@ -15,4 +15,4 @@ export const AirConditioning = (props: IconPropsWithStatus) => (
 
 AirConditioning.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(AirConditioning)
+export default AirConditioning

--- a/src/icon/aloneInTheBackIcon.tsx
+++ b/src/icon/aloneInTheBackIcon.tsx
@@ -15,4 +15,4 @@ export const AloneInTheBackIcon = (props: Icon) => (
 
 AloneInTheBackIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(AloneInTheBackIcon)
+export default AloneInTheBackIcon

--- a/src/icon/arrowIcon.tsx
+++ b/src/icon/arrowIcon.tsx
@@ -28,4 +28,4 @@ ArrowIcon.defaultProps = {
   right: false,
 }
 
-export default React.memo(ArrowIcon)
+export default ArrowIcon

--- a/src/icon/audio.tsx
+++ b/src/icon/audio.tsx
@@ -15,4 +15,4 @@ export const Audio = (props: IconPropsWithStatus) => (
 
 Audio.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(Audio)
+export default Audio

--- a/src/icon/avatarIcon.tsx
+++ b/src/icon/avatarIcon.tsx
@@ -16,4 +16,4 @@ export const AvatarIcon = (props: Icon) => (
 
 AvatarIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(AvatarIcon)
+export default AvatarIcon

--- a/src/icon/banIcon.tsx
+++ b/src/icon/banIcon.tsx
@@ -17,4 +17,4 @@ export const BanIcon = (props: Icon) => (
 
 BanIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(BanIcon)
+export default BanIcon

--- a/src/icon/bankIcon.tsx
+++ b/src/icon/bankIcon.tsx
@@ -19,4 +19,4 @@ export const BankIcon = (props: Icon) => (
 
 BankIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(BankIcon)
+export default BankIcon

--- a/src/icon/bellIcon.tsx
+++ b/src/icon/bellIcon.tsx
@@ -11,4 +11,4 @@ export const BellIcon = (props: Icon) => (
 
 BellIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(BellIcon)
+export default BellIcon

--- a/src/icon/bikeArea.tsx
+++ b/src/icon/bikeArea.tsx
@@ -15,4 +15,4 @@ export const BikeArea = (props: IconPropsWithStatus) => (
 
 BikeArea.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(BikeArea)
+export default BikeArea

--- a/src/icon/blanket.tsx
+++ b/src/icon/blanket.tsx
@@ -15,4 +15,4 @@ export const Blanket = (props: IconPropsWithStatus) => (
 
 Blanket.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(Blanket)
+export default Blanket

--- a/src/icon/bubbleIcon.tsx
+++ b/src/icon/bubbleIcon.tsx
@@ -11,4 +11,4 @@ export const BubbleIcon = (props: Icon) => (
 
 BubbleIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(BubbleIcon)
+export default BubbleIcon

--- a/src/icon/busIcon.tsx
+++ b/src/icon/busIcon.tsx
@@ -39,4 +39,4 @@ StyledBusIcon.defaultProps = {
   ...BaseIconDefaultProps,
 }
 
-export default React.memo(StyledBusIcon)
+export default StyledBusIcon

--- a/src/icon/calendarIcon.tsx
+++ b/src/icon/calendarIcon.tsx
@@ -29,4 +29,4 @@ export const CalendarIcon = (props: Icon) => (
 
 CalendarIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(CalendarIcon)
+export default CalendarIcon

--- a/src/icon/callIcon.tsx
+++ b/src/icon/callIcon.tsx
@@ -18,4 +18,4 @@ export const CallIcon = (props: Icon) => (
 
 CallIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(CallIcon)
+export default CallIcon

--- a/src/icon/carIcon.tsx
+++ b/src/icon/carIcon.tsx
@@ -17,4 +17,4 @@ export const CarIcon = (props: Icon) => (
 
 CarIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(CarIcon)
+export default CarIcon

--- a/src/icon/carpoolIcon.tsx
+++ b/src/icon/carpoolIcon.tsx
@@ -31,4 +31,4 @@ StyledCarpoolIcon.defaultProps = {
   ...BaseIconDefaultProps,
 }
 
-export default React.memo(StyledCarpoolIcon)
+export default StyledCarpoolIcon

--- a/src/icon/checkIcon.tsx
+++ b/src/icon/checkIcon.tsx
@@ -94,4 +94,4 @@ StyledCheckIcon.defaultProps = {
   thin: false,
 }
 
-export default React.memo(StyledCheckIcon)
+export default StyledCheckIcon

--- a/src/icon/checkShieldIcon.tsx
+++ b/src/icon/checkShieldIcon.tsx
@@ -14,4 +14,4 @@ export const CheckShieldIcon = (props: Icon) => (
 
 CheckShieldIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(CheckShieldIcon)
+export default CheckShieldIcon

--- a/src/icon/chevronIcon.tsx
+++ b/src/icon/chevronIcon.tsx
@@ -29,4 +29,4 @@ ChevronIcon.defaultProps = {
   left: false,
 }
 
-export default React.memo(ChevronIcon)
+export default ChevronIcon

--- a/src/icon/child.tsx
+++ b/src/icon/child.tsx
@@ -16,4 +16,4 @@ export const Child = (props: IconPropsWithStatus) => (
 
 Child.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(Child)
+export default Child

--- a/src/icon/circleIcon.tsx
+++ b/src/icon/circleIcon.tsx
@@ -104,4 +104,4 @@ StyledCircleIcon.defaultProps = {
   innerDisc: false,
 }
 
-export default React.memo(StyledCircleIcon)
+export default StyledCircleIcon

--- a/src/icon/clockIcon.tsx
+++ b/src/icon/clockIcon.tsx
@@ -15,4 +15,4 @@ export const ClockIcon = (props: Icon) => (
 
 ClockIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(ClockIcon)
+export default ClockIcon

--- a/src/icon/clockMapIcon.tsx
+++ b/src/icon/clockMapIcon.tsx
@@ -14,4 +14,4 @@ export const ClockMapIcon = (props: Icon) => (
 
 ClockMapIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(ClockMapIcon)
+export default ClockMapIcon

--- a/src/icon/coinIcon.tsx
+++ b/src/icon/coinIcon.tsx
@@ -24,4 +24,4 @@ export const CoinIcon = (props: Icon) => (
 
 CoinIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(CoinIcon)
+export default CoinIcon

--- a/src/icon/comfortIcon.tsx
+++ b/src/icon/comfortIcon.tsx
@@ -25,4 +25,4 @@ export const ComfortIcon = (props: Icon) => (
 
 ComfortIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(ComfortIcon)
+export default ComfortIcon

--- a/src/icon/comfortSeat.tsx
+++ b/src/icon/comfortSeat.tsx
@@ -19,4 +19,4 @@ export const ComfortSeat = (props: IconPropsWithStatus) => (
 
 ComfortSeat.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(ComfortSeat)
+export default ComfortSeat

--- a/src/icon/creditCardIcon.tsx
+++ b/src/icon/creditCardIcon.tsx
@@ -20,4 +20,4 @@ export const CreditCardIcon = (props: Icon) => (
 
 CreditCardIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(CreditCardIcon)
+export default CreditCardIcon

--- a/src/icon/crew.tsx
+++ b/src/icon/crew.tsx
@@ -15,4 +15,4 @@ export const Crew = (props: IconPropsWithStatus) => (
 
 Crew.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(Crew)
+export default Crew

--- a/src/icon/crossDiscIcon.tsx
+++ b/src/icon/crossDiscIcon.tsx
@@ -14,4 +14,4 @@ export const CrossDiscIcon = (props: Icon) => (
 
 CrossDiscIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(CrossDiscIcon)
+export default CrossDiscIcon

--- a/src/icon/crossIcon.tsx
+++ b/src/icon/crossIcon.tsx
@@ -18,4 +18,4 @@ export const CrossIcon = (props: Icon) => (
 
 CrossIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(CrossIcon)
+export default CrossIcon

--- a/src/icon/crosshairIcon.tsx
+++ b/src/icon/crosshairIcon.tsx
@@ -17,4 +17,4 @@ export const CrossHairIcon = (props: Icon) => (
 
 CrossHairIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(CrossHairIcon)
+export default CrossHairIcon

--- a/src/icon/departureIcon.tsx
+++ b/src/icon/departureIcon.tsx
@@ -15,4 +15,4 @@ export const DepartureIcon = (props: Icon) => (
 
 DepartureIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(DepartureIcon)
+export default DepartureIcon

--- a/src/icon/detourIcon.tsx
+++ b/src/icon/detourIcon.tsx
@@ -26,4 +26,4 @@ export const DetourIcon = (props: Icon) => (
 
 DetourIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(DetourIcon)
+export default DetourIcon

--- a/src/icon/directionIcon.tsx
+++ b/src/icon/directionIcon.tsx
@@ -11,4 +11,4 @@ export const DirectionIcon = (props: Icon) => (
 
 DirectionIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(DirectionIcon)
+export default DirectionIcon

--- a/src/icon/doubleArrowIcon.tsx
+++ b/src/icon/doubleArrowIcon.tsx
@@ -15,4 +15,4 @@ export const DoubleArrowIcon = (props: Icon) => (
 
 DoubleArrowIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(DoubleArrowIcon)
+export default DoubleArrowIcon

--- a/src/icon/drink.tsx
+++ b/src/icon/drink.tsx
@@ -15,4 +15,4 @@ export const Drink = (props: IconPropsWithStatus) => (
 
 Drink.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(Drink)
+export default Drink

--- a/src/icon/exclamationIcon.tsx
+++ b/src/icon/exclamationIcon.tsx
@@ -29,4 +29,4 @@ export const ExclamationIcon = (props: Icon) => (
 
 ExclamationIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(ExclamationIcon)
+export default ExclamationIcon

--- a/src/icon/eyeIcon.tsx
+++ b/src/icon/eyeIcon.tsx
@@ -37,4 +37,4 @@ EyeIcon.defaultProps = {
   off: false,
 }
 
-export default React.memo(EyeIcon)
+export default EyeIcon

--- a/src/icon/facebookIcon.tsx
+++ b/src/icon/facebookIcon.tsx
@@ -18,4 +18,4 @@ FacebookIcon.defaultProps = {
   iconColor: color.facebookBrand,
 }
 
-export default React.memo(FacebookIcon)
+export default FacebookIcon

--- a/src/icon/flagsIcon.tsx
+++ b/src/icon/flagsIcon.tsx
@@ -23,4 +23,4 @@ export const FlagsIcon = (props: Icon) => (
 
 FlagsIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(FlagsIcon)
+export default FlagsIcon

--- a/src/icon/genericAmenity.tsx
+++ b/src/icon/genericAmenity.tsx
@@ -15,4 +15,4 @@ export const GenericAmenity = (props: IconPropsWithStatus) => (
 
 GenericAmenity.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(GenericAmenity)
+export default GenericAmenity

--- a/src/icon/giftIcon.tsx
+++ b/src/icon/giftIcon.tsx
@@ -20,4 +20,4 @@ export const GiftIcon = (props: Icon) => (
 
 GiftIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(GiftIcon)
+export default GiftIcon

--- a/src/icon/handLuggage.tsx
+++ b/src/icon/handLuggage.tsx
@@ -15,4 +15,4 @@ export const HandLuggage = (props: IconPropsWithStatus) => (
 
 HandLuggage.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(HandLuggage)
+export default HandLuggage

--- a/src/icon/holdLuggage.tsx
+++ b/src/icon/holdLuggage.tsx
@@ -15,4 +15,4 @@ export const HoldLuggage = (props: IconPropsWithStatus) => (
 
 HoldLuggage.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(HoldLuggage)
+export default HoldLuggage

--- a/src/icon/homeIcon.tsx
+++ b/src/icon/homeIcon.tsx
@@ -14,4 +14,4 @@ export const HomeIcon = (props: Icon) => (
 
 HomeIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(HomeIcon)
+export default HomeIcon

--- a/src/icon/hourglassIcon.tsx
+++ b/src/icon/hourglassIcon.tsx
@@ -18,4 +18,4 @@ export const HourglassIcon = (props: Icon) => (
 
 HourglassIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(HourglassIcon)
+export default HourglassIcon

--- a/src/icon/idCardVerifiedIcon.tsx
+++ b/src/icon/idCardVerifiedIcon.tsx
@@ -23,4 +23,4 @@ export const IdCardVerifiedIcon = (props: Icon) => (
 
 IdCardVerifiedIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(IdCardVerifiedIcon)
+export default IdCardVerifiedIcon

--- a/src/icon/idCheckIcon.tsx
+++ b/src/icon/idCheckIcon.tsx
@@ -33,4 +33,4 @@ export const IdCheckIcon = (props: Icon) => (
 
 IdCheckIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(IdCheckIcon)
+export default IdCheckIcon

--- a/src/icon/infoIcon.tsx
+++ b/src/icon/infoIcon.tsx
@@ -23,4 +23,4 @@ export const InfoIcon = (props: Icon) => (
 
 InfoIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(InfoIcon)
+export default InfoIcon

--- a/src/icon/instagramIcon.tsx
+++ b/src/icon/instagramIcon.tsx
@@ -28,4 +28,4 @@ export const InstagramIcon = (props: Icon) => (
 
 InstagramIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(InstagramIcon)
+export default InstagramIcon

--- a/src/icon/ladyIcon.tsx
+++ b/src/icon/ladyIcon.tsx
@@ -20,4 +20,4 @@ export const LadyIcon = (props: Icon) => (
 
 LadyIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(LadyIcon)
+export default LadyIcon

--- a/src/icon/legRest.tsx
+++ b/src/icon/legRest.tsx
@@ -15,4 +15,4 @@ export const LegRest = (props: IconPropsWithStatus) => (
 
 LegRest.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(LegRest)
+export default LegRest

--- a/src/icon/legRoom.tsx
+++ b/src/icon/legRoom.tsx
@@ -15,4 +15,4 @@ export const LegRoom = (props: IconPropsWithStatus) => (
 
 LegRoom.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(LegRoom)
+export default LegRoom

--- a/src/icon/light.tsx
+++ b/src/icon/light.tsx
@@ -15,4 +15,4 @@ export const Light = (props: IconPropsWithStatus) => (
 
 Light.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(Light)
+export default Light

--- a/src/icon/lightningIcon.tsx
+++ b/src/icon/lightningIcon.tsx
@@ -18,4 +18,4 @@ export const LightningIcon = (props: Icon) => (
 
 LightningIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(LightningIcon)
+export default LightningIcon

--- a/src/icon/lockIcon.tsx
+++ b/src/icon/lockIcon.tsx
@@ -15,4 +15,4 @@ export const LockIcon = (props: Icon) => (
 
 LockIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(LockIcon)
+export default LockIcon

--- a/src/icon/magazine.tsx
+++ b/src/icon/magazine.tsx
@@ -28,4 +28,4 @@ export const Magazine = (props: IconPropsWithStatus) => (
 
 Magazine.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(Magazine)
+export default Magazine

--- a/src/icon/mailIcon.tsx
+++ b/src/icon/mailIcon.tsx
@@ -16,4 +16,4 @@ export const MailIcon = (props: Icon) => (
 
 MailIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(MailIcon)
+export default MailIcon

--- a/src/icon/mapIcon.tsx
+++ b/src/icon/mapIcon.tsx
@@ -18,4 +18,4 @@ export const MapIcon = (props: Icon) => (
 
 MapIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(MapIcon)
+export default MapIcon

--- a/src/icon/meal.tsx
+++ b/src/icon/meal.tsx
@@ -15,4 +15,4 @@ export const Meal = (props: IconPropsWithStatus) => (
 
 Meal.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(Meal)
+export default Meal

--- a/src/icon/meetingPoint.tsx
+++ b/src/icon/meetingPoint.tsx
@@ -41,4 +41,4 @@ MeetingPointIcon.defaultProps = {
   shadowed: false,
 }
 
-export default React.memo(MeetingPointIcon)
+export default MeetingPointIcon

--- a/src/icon/minusIcon.tsx
+++ b/src/icon/minusIcon.tsx
@@ -20,4 +20,4 @@ export const MinusIcon = (props: Icon) => (
 
 MinusIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(MinusIcon)
+export default MinusIcon

--- a/src/icon/musicIcon.tsx
+++ b/src/icon/musicIcon.tsx
@@ -11,4 +11,4 @@ export const MusicIcon = (props: IconPropsWithStatus) => (
 
 MusicIcon.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(MusicIcon)
+export default MusicIcon

--- a/src/icon/myRides.tsx
+++ b/src/icon/myRides.tsx
@@ -37,4 +37,4 @@ MyRidesIcon.defaultProps = {
   active: false,
 }
 
-export default React.memo(MyRidesIcon)
+export default MyRidesIcon

--- a/src/icon/newspaperIcon.tsx
+++ b/src/icon/newspaperIcon.tsx
@@ -18,4 +18,4 @@ export const NewspaperIcon = (props: Icon) => (
 
 NewspaperIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(NewspaperIcon)
+export default NewspaperIcon

--- a/src/icon/odnoklassnikiIcon.tsx
+++ b/src/icon/odnoklassnikiIcon.tsx
@@ -16,4 +16,4 @@ export const OdnoklassnikiIcon = (props: Icon) => (
 
 OdnoklassnikiIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(OdnoklassnikiIcon)
+export default OdnoklassnikiIcon

--- a/src/icon/pet.tsx
+++ b/src/icon/pet.tsx
@@ -15,4 +15,4 @@ export const PetIcon = (props: IconPropsWithStatus) => (
 
 PetIcon.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(PetIcon)
+export default PetIcon

--- a/src/icon/photoIcon.tsx
+++ b/src/icon/photoIcon.tsx
@@ -16,4 +16,4 @@ export const PhotoIcon = (props: Icon) => (
 
 PhotoIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(PhotoIcon)
+export default PhotoIcon

--- a/src/icon/pinIcon.tsx
+++ b/src/icon/pinIcon.tsx
@@ -23,4 +23,4 @@ PinIcon.defaultProps = {
   strokeColor: color.lightMidnightGreen,
 }
 
-export default React.memo(PinIcon)
+export default PinIcon

--- a/src/icon/pinterestIcon.tsx
+++ b/src/icon/pinterestIcon.tsx
@@ -15,4 +15,4 @@ export const PinterestIcon = (props: Icon) => (
 
 PinterestIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(PinterestIcon)
+export default PinterestIcon

--- a/src/icon/plugUsbSocket.tsx
+++ b/src/icon/plugUsbSocket.tsx
@@ -15,4 +15,4 @@ export const PlugUsbSocket = (props: IconPropsWithStatus) => (
 
 PlugUsbSocket.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(PlugUsbSocket)
+export default PlugUsbSocket

--- a/src/icon/plusIcon.tsx
+++ b/src/icon/plusIcon.tsx
@@ -20,4 +20,4 @@ export const PlusIcon = (props: Icon) => (
 
 PlusIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(PlusIcon)
+export default PlusIcon

--- a/src/icon/priorityService.tsx
+++ b/src/icon/priorityService.tsx
@@ -15,4 +15,4 @@ export const PriorityServiceIcon = (props: IconPropsWithStatus) => (
 
 PriorityServiceIcon.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(PriorityServiceIcon)
+export default PriorityServiceIcon

--- a/src/icon/profileIcon.tsx
+++ b/src/icon/profileIcon.tsx
@@ -14,4 +14,4 @@ export const ProfileIcon = (props: Icon) => (
 
 ProfileIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(ProfileIcon)
+export default ProfileIcon

--- a/src/icon/proximityIcon.tsx
+++ b/src/icon/proximityIcon.tsx
@@ -14,4 +14,4 @@ export const ProximityIcon = (props: Icon) => (
 
 ProximityIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(ProximityIcon)
+export default ProximityIcon

--- a/src/icon/qrCode.tsx
+++ b/src/icon/qrCode.tsx
@@ -15,4 +15,4 @@ export const QrCode = (props: IconPropsWithStatus) => (
 
 QrCode.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(QrCode)
+export default QrCode

--- a/src/icon/questionIcon.tsx
+++ b/src/icon/questionIcon.tsx
@@ -15,4 +15,4 @@ export const QuestionIcon = (props: Icon) => (
 
 QuestionIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(QuestionIcon)
+export default QuestionIcon

--- a/src/icon/quiet.tsx
+++ b/src/icon/quiet.tsx
@@ -15,4 +15,4 @@ export const PlugUsbSocket = (props: IconPropsWithStatus) => (
 
 PlugUsbSocket.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(PlugUsbSocket)
+export default PlugUsbSocket

--- a/src/icon/recliningSeat.tsx
+++ b/src/icon/recliningSeat.tsx
@@ -15,4 +15,4 @@ export const QrCode = (props: IconPropsWithStatus) => (
 
 QrCode.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(QrCode)
+export default QrCode

--- a/src/icon/rotateIcon.tsx
+++ b/src/icon/rotateIcon.tsx
@@ -20,4 +20,4 @@ export const RotateIcon = (props: Icon) => (
 
 RotateIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(RotateIcon)
+export default RotateIcon

--- a/src/icon/searchIcon.tsx
+++ b/src/icon/searchIcon.tsx
@@ -27,4 +27,4 @@ SearchIcon.defaultProps = {
   strokeWidth: '1',
 }
 
-export default React.memo(SearchIcon)
+export default SearchIcon

--- a/src/icon/seatBelt.tsx
+++ b/src/icon/seatBelt.tsx
@@ -15,4 +15,4 @@ export const SeatBelt = (props: IconPropsWithStatus) => (
 
 SeatBelt.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(SeatBelt)
+export default SeatBelt

--- a/src/icon/seatSliding.tsx
+++ b/src/icon/seatSliding.tsx
@@ -15,4 +15,4 @@ export const SeatSliding = (props: IconPropsWithStatus) => (
 
 SeatSliding.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(SeatSliding)
+export default SeatSliding

--- a/src/icon/seatWithTable.tsx
+++ b/src/icon/seatWithTable.tsx
@@ -15,4 +15,4 @@ export const SeatWithTable = (props: Icon) => (
 
 SeatWithTable.defaultProps = BaseIconDefaultProps
 
-export default React.memo(SeatWithTable)
+export default SeatWithTable

--- a/src/icon/sendIcon.tsx
+++ b/src/icon/sendIcon.tsx
@@ -19,4 +19,4 @@ export const SendIcon = (props: Icon) => (
 
 SendIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(SendIcon)
+export default SendIcon

--- a/src/icon/sendMessageIcon.tsx
+++ b/src/icon/sendMessageIcon.tsx
@@ -17,4 +17,4 @@ export const SendMessageIcon = (props: Icon) => (
 
 SendMessageIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(SendMessageIcon)
+export default SendMessageIcon

--- a/src/icon/shareIcon.tsx
+++ b/src/icon/shareIcon.tsx
@@ -15,4 +15,4 @@ export const ShareIcon = (props: Icon) => (
 
 ShareIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(ShareIcon)
+export default ShareIcon

--- a/src/icon/sleep.tsx
+++ b/src/icon/sleep.tsx
@@ -15,4 +15,4 @@ export const Sleep = (props: IconPropsWithStatus) => (
 
 Sleep.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(Sleep)
+export default Sleep

--- a/src/icon/smokeIcon.tsx
+++ b/src/icon/smokeIcon.tsx
@@ -17,4 +17,4 @@ export const SmokeIcon = (props: IconPropsWithStatus) => (
 
 SmokeIcon.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(SmokeIcon)
+export default SmokeIcon

--- a/src/icon/snack.tsx
+++ b/src/icon/snack.tsx
@@ -15,4 +15,4 @@ export const Snack = (props: IconPropsWithStatus) => (
 
 Snack.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(Snack)
+export default Snack

--- a/src/icon/speakIcon.tsx
+++ b/src/icon/speakIcon.tsx
@@ -77,4 +77,4 @@ export const SpeakIcon = (props: IconPropsWithStatus) => (
 
 SpeakIcon.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(SpeakIcon)
+export default SpeakIcon

--- a/src/icon/standardSeat.tsx
+++ b/src/icon/standardSeat.tsx
@@ -15,4 +15,4 @@ export const StandardSeat = (props: IconPropsWithStatus) => (
 
 StandardSeat.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(StandardSeat)
+export default StandardSeat

--- a/src/icon/starIcon.tsx
+++ b/src/icon/starIcon.tsx
@@ -39,4 +39,4 @@ StarIcon.defaultProps = {
   fill: 0,
 }
 
-export default React.memo(StarIcon)
+export default StarIcon

--- a/src/icon/story/index.tsx
+++ b/src/icon/story/index.tsx
@@ -58,7 +58,7 @@ stories.add(
   () => {
     const iconList = Object.entries(icons).map(([name, Component]) => (
       <div key={name} style={styles.iconItem}>
-        <Component {...Component.type.defaultProps} />
+        <Component {...Component.defaultProps} />
         <br />
         {name}
       </div>
@@ -71,6 +71,6 @@ stories.add(
 
 Object.entries(icons).forEach(([name, Component]) => {
   stories.add(name.replace('Icon', ''), () => (
-    <Component {...createIconKnobs(Component.type.defaultProps)} />
+    <Component {...createIconKnobs(Component.defaultProps)} />
   ))
 })

--- a/src/icon/ticketIcon.tsx
+++ b/src/icon/ticketIcon.tsx
@@ -21,4 +21,4 @@ export const TicketIcon = (props: Icon) => (
 
 TicketIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(TicketIcon)
+export default TicketIcon

--- a/src/icon/trashIcon.tsx
+++ b/src/icon/trashIcon.tsx
@@ -16,4 +16,4 @@ export const TrashIcon = (props: Icon) => (
 
 TrashIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(TrashIcon)
+export default TrashIcon

--- a/src/icon/twitterIcon.tsx
+++ b/src/icon/twitterIcon.tsx
@@ -15,4 +15,4 @@ export const TwitterIcon = (props: Icon) => (
 
 TwitterIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(TwitterIcon)
+export default TwitterIcon

--- a/src/icon/videoSystem.tsx
+++ b/src/icon/videoSystem.tsx
@@ -15,4 +15,4 @@ export const VideoSystem = (props: IconPropsWithStatus) => (
 
 VideoSystem.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(VideoSystem)
+export default VideoSystem

--- a/src/icon/vipLounge.tsx
+++ b/src/icon/vipLounge.tsx
@@ -15,4 +15,4 @@ export const VipLounge = (props: IconPropsWithStatus) => (
 
 VipLounge.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(VipLounge)
+export default VipLounge

--- a/src/icon/vkontakteIcon.tsx
+++ b/src/icon/vkontakteIcon.tsx
@@ -20,4 +20,4 @@ VkontakteIcon.defaultProps = {
   iconColor: color.vkBrand,
 }
 
-export default React.memo(VkontakteIcon)
+export default VkontakteIcon

--- a/src/icon/warningIcon.tsx
+++ b/src/icon/warningIcon.tsx
@@ -16,4 +16,4 @@ export const WarningIcon = (props: Icon) => (
 
 WarningIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(WarningIcon)
+export default WarningIcon

--- a/src/icon/wc.tsx
+++ b/src/icon/wc.tsx
@@ -15,4 +15,4 @@ export const WC = (props: IconPropsWithStatus) => (
 
 WC.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(WC)
+export default WC

--- a/src/icon/wheelchair.tsx
+++ b/src/icon/wheelchair.tsx
@@ -15,4 +15,4 @@ export const WheelchairIcon = (props: IconPropsWithStatus) => (
 
 WheelchairIcon.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(WheelchairIcon)
+export default WheelchairIcon

--- a/src/icon/wifi.tsx
+++ b/src/icon/wifi.tsx
@@ -15,4 +15,4 @@ export const Wifi = (props: IconPropsWithStatus) => (
 
 Wifi.defaultProps = StatusIcon.defaultProps
 
-export default React.memo(Wifi)
+export default Wifi

--- a/src/icon/youtubeIcon.tsx
+++ b/src/icon/youtubeIcon.tsx
@@ -15,4 +15,4 @@ export const YoutubeIcon = (props: Icon) => (
 
 YoutubeIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(YoutubeIcon)
+export default YoutubeIcon

--- a/src/icon/zoomIn.tsx
+++ b/src/icon/zoomIn.tsx
@@ -14,4 +14,4 @@ export const ZoomInIcon = (props: Icon) => (
 
 ZoomInIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(ZoomInIcon)
+export default ZoomInIcon

--- a/src/icon/zoomOut.tsx
+++ b/src/icon/zoomOut.tsx
@@ -14,4 +14,4 @@ export const ZoomOutIcon = (props: Icon) => (
 
 ZoomOutIcon.defaultProps = BaseIconDefaultProps
 
-export default React.memo(ZoomOutIcon)
+export default ZoomOutIcon


### PR DESCRIPTION
## Description

[`React.memo`](https://reactjs.org/docs/react-api.html#reactmemo) is a performance optimisation feature that skips an update if the props haven't changed. This works great for _heavy_ components with few props.

This PR remove calls to `React.memo` for the following reasons:
1. Our icons are quite small, memoizing them is not a real performance gain.
2. It looks like Enzyme's `find()` function doesn't work with memoized components which forces us to have multiple exports for tests.

## What has been done

Remove all `React.memo` in icons (it was only used there).

## Things to consider

This PR will ease the refactoring to use named exports instead of default exports because there will be less exported symbols for the tests (see _2._ above).

## How it was tested

- Unit tests
- Storybook