### PR TITLE
Release/34.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Unreleased
 
+[...]
+
+# v34.3.0 (05/06/2020)
+
 - **[FIX]** Clickable `Item` always uses cursor pointer style.
 - **[UPDATE]** Add onClick callback to `ItemEdtableInfo` widget.
-[...]
 
 # v34.2.0 (02/06/2020)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "34.2.0",
+  "version": "34.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "34.2.0",
+  "version": "34.3.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# v34.3.0 (05/06/2020)

- **[FIX]** Clickable `Item` always uses cursor pointer style.
- **[UPDATE]** Add onClick callback to `ItemEdtableInfo` widget.