### PR TITLE
Make Paragraph resilient to long unbreakable text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Make `Paragraph` layout resilient to long strings without spaces.
 [...]
 
 # v34.4.0 (18/06/2020)

--- a/src/paragraph/index.tsx
+++ b/src/paragraph/index.tsx
@@ -8,6 +8,7 @@ const StyledParagraph = styled(Paragraph)`
     display: flex;
     flex-direction: column;
     padding: ${space.m} 0;
+    word-break: break-word;
   }
 
   & .kirk-button {

--- a/src/paragraph/story.tsx
+++ b/src/paragraph/story.tsx
@@ -9,8 +9,8 @@ const stories = storiesOf('Widgets|Paragraph', module)
 stories.addDecorator(withKnobs)
 
 const shortText = 'Short text (below max char)'
-const longText =
-  'Long text (above max char) - Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+const longText = 'Long text (above max char) '.repeat(20)
+const longTextWithoutSpaces = `http://${'long_url_without_spaces'.repeat(20)}.com`
 
 stories.add('Long text', () => (
   <Section>
@@ -26,5 +26,11 @@ stories.add('Long text', () => (
 stories.add('Short text', () => (
   <Section>
     <Paragraph>{shortText}</Paragraph>
+  </Section>
+))
+
+stories.add('Long unbreakable text', () => (
+  <Section>
+    <Paragraph>{longTextWithoutSpaces}</Paragraph>
   </Section>
 ))

--- a/src/review/__snapshots__/Review.unit.tsx.snap
+++ b/src/review/__snapshots__/Review.unit.tsx.snap
@@ -88,6 +88,7 @@ Array [
   -ms-flex-direction: column;
   flex-direction: column;
   padding: 8px 0;
+  word-break: break-word;
 }
 
 .c2 .kirk-button {
@@ -242,6 +243,7 @@ Array [
   -ms-flex-direction: column;
   flex-direction: column;
   padding: 8px 0;
+  word-break: break-word;
 }
 
 .c2 .kirk-button {


### PR DESCRIPTION
## Description
Paragraph is not breaking anymore when puttin long unbreakable strings (like urls)

TESTED=Locally in stories. new story added to cover this case.
