### PR TITLE
Add aria-busy, aria-live and aria-label on the Loader component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-[...]
+- **[UPDATE]** Add aria-busy, aria-live and aria-label on the `Loader` component
+  [...]
 
 # v34.4.0 (18/06/2020)
 

--- a/src/_utils/checkboxIcon/__snapshots__/index.unit.tsx.snap
+++ b/src/_utils/checkboxIcon/__snapshots__/index.unit.tsx.snap
@@ -186,6 +186,8 @@ exports[`CheckboxIcon Should render a loader if isLoading and isChecked are set 
   className="c0 kirk-loader--inline"
 >
   <div
+    aria-busy={true}
+    aria-live="polite"
     className=""
     style={
       Object {
@@ -334,6 +336,8 @@ exports[`CheckboxIcon Should render a loader if isLoading is set to true 1`] = `
   className="c0 kirk-loader--inline"
 >
   <div
+    aria-busy={true}
+    aria-live="polite"
     className=""
     style={
       Object {

--- a/src/_utils/radioIcon/__snapshots__/index.unit.tsx.snap
+++ b/src/_utils/radioIcon/__snapshots__/index.unit.tsx.snap
@@ -202,6 +202,8 @@ exports[`RadioIcon Should render a loader if isLoading and isChecked are set to 
   className="c0 kirk-loader--inline"
 >
   <div
+    aria-busy={true}
+    aria-live="polite"
     className=""
     style={
       Object {
@@ -350,6 +352,8 @@ exports[`RadioIcon Should render a loader if isLoading is set to true 1`] = `
   className="c0 kirk-loader--inline"
 >
   <div
+    aria-busy={true}
+    aria-live="polite"
     className=""
     style={
       Object {

--- a/src/itemCheckbox/__snapshots__/ItemCheckbox.unit.tsx.snap
+++ b/src/itemCheckbox/__snapshots__/ItemCheckbox.unit.tsx.snap
@@ -640,6 +640,8 @@ button:focus:not(.focus-visible).c0 {
       className="c2 kirk-loader--inline"
     >
       <div
+        aria-busy={true}
+        aria-live="polite"
         className=""
         style={
           Object {

--- a/src/itemChoice/__snapshots__/index.unit.tsx.snap
+++ b/src/itemChoice/__snapshots__/index.unit.tsx.snap
@@ -415,6 +415,8 @@ button:focus:not(.focus-visible).c0 {
       className="c3 kirk-loader--inline"
     >
       <div
+        aria-busy={true}
+        aria-live="polite"
         className=""
         style={
           Object {
@@ -850,6 +852,8 @@ button:focus:not(.focus-visible).c0 {
       className="c3 kirk-loader--inline"
     >
       <div
+        aria-busy={false}
+        aria-live="polite"
         className="kirk-loader--done"
         style={
           Object {

--- a/src/itemRadio/__snapshots__/ItemRadio.unit.tsx.snap
+++ b/src/itemRadio/__snapshots__/ItemRadio.unit.tsx.snap
@@ -664,6 +664,8 @@ button:focus:not(.focus-visible).c0 {
       className="c2 kirk-loader--inline"
     >
       <div
+        aria-busy={true}
+        aria-live="polite"
         className=""
         style={
           Object {

--- a/src/loader/Loader.tsx
+++ b/src/loader/Loader.tsx
@@ -26,6 +26,7 @@ export interface LoaderProps {
   size?: number
   done?: boolean
   layoutMode?: LoaderLayoutMode
+  ariaLabel?: string
   onDoneAnimationEnd?: () => void
 }
 
@@ -79,7 +80,7 @@ export class Loader extends PureComponent<LoaderProps> {
   }
 
   render() {
-    const { className, size, done } = this.props
+    const { className, size, done, ariaLabel } = this.props
     const iconSize = {
       width: `${size}px`,
       height: `${size}px`,
@@ -87,7 +88,13 @@ export class Loader extends PureComponent<LoaderProps> {
 
     return (
       <div className={cc([className, this.computeLayoutClass()])}>
-        <div className={cc([{ 'kirk-loader--done': done }])} style={iconSize}>
+        <div
+          className={cc([{ 'kirk-loader--done': done }])}
+          aria-busy={!done}
+          aria-live="polite"
+          aria-label={ariaLabel}
+          style={iconSize}
+        >
           {!done && <CircleIcon iconColor={color.green} size={size} spinning />}
           {done && <CheckIcon iconColor={color.white} size={size / 2} validate />}
         </div>

--- a/src/loader/Loader.unit.tsx
+++ b/src/loader/Loader.unit.tsx
@@ -1,64 +1,79 @@
 import React from 'react'
-import { mount } from 'enzyme'
 
-import { CheckIcon as StyledCheckIcon } from '../icon/checkIcon'
-import { CircleIcon as StyledCircleIcon } from '../icon/circleIcon'
+import { render, screen } from '@testing-library/react'
+
 import { Loader, LoaderLayoutMode } from './Loader'
 
 jest.useFakeTimers()
 
 describe('Loader', () => {
-  it('Should have a custom className', () => {
-    const customClassName = 'custom-loader'
-    const wrapper = mount(<Loader className={customClassName} />)
-    expect(wrapper.hasClass(customClassName)).toBe(true)
+  it('render the loader with aria attributes', () => {
+    render(<Loader done={false} ariaLabel="loader" />)
+
+    const loader = screen.getByLabelText('loader')
+    expect(loader).toHaveAttribute('aria-busy', 'true')
+    expect(loader).toHaveAttribute('aria-live', 'polite')
   })
 
-  it('Should have a custom size', () => {
-    const size = 100
-    const wrapper = mount(<Loader size={size} />)
-    expect(wrapper.find(StyledCircleIcon).prop('size')).toBe(size)
+  it('render the check icon with aria attributes', () => {
+    render(<Loader done ariaLabel="loader" />)
+
+    const loader = screen.getByLabelText('loader')
+    expect(loader).toHaveAttribute('aria-busy', 'false')
+    expect(loader).toHaveAttribute('aria-live', 'polite')
+  })
+
+  it('Should have a custom className', () => {
+    const customClassName = 'custom-loader'
+
+    render(<Loader className={customClassName} ariaLabel="loader" />)
+
+    const loader = screen.getByLabelText('loader')
+    expect(loader.parentElement.className).toBe(`${customClassName} kirk-loader--fullScreen`)
   })
 
   it('Should be fullscreen by default', () => {
-    const wrapper = mount(<Loader />)
-    expect(wrapper.find('.kirk-loader--fullScreen').exists()).toBe(true)
+    render(<Loader ariaLabel="loader" />)
+    const loader = screen.getByLabelText('loader')
+    expect(loader.parentElement.className).toBe('kirk-loader--fullScreen')
   })
 
   it('Should be inline when using the prop', () => {
-    const wrapper = mount(<Loader inline />)
-    expect(wrapper.find('.kirk-loader--inline').exists()).toBe(true)
+    render(<Loader ariaLabel="loader" inline />)
+    const loader = screen.getByLabelText('loader')
+    expect(loader.parentElement.className).toBe('kirk-loader--inline')
   })
 
   it('Should override layoutMode when inline prop is set', () => {
-    const wrapper = mount(<Loader inline layoutMode={LoaderLayoutMode.BLOCK} />)
-    expect(wrapper.find('.kirk-loader--inline').exists()).toBe(true)
+    render(<Loader ariaLabel="loader" inline layoutMode={LoaderLayoutMode.BLOCK} />)
+    const loader = screen.getByLabelText('loader')
+    expect(loader.parentElement.className).toBe('kirk-loader--inline')
   })
 
   it('Should use correctly inline layout mode', () => {
-    const wrapper = mount(<Loader layoutMode={LoaderLayoutMode.INLINE} />)
-    expect(wrapper.find('.kirk-loader--inline').exists()).toBe(true)
+    render(<Loader ariaLabel="loader" layoutMode={LoaderLayoutMode.INLINE} />)
+    const loader = screen.getByLabelText('loader')
+    expect(loader.parentElement.className).toBe('kirk-loader--inline')
   })
 
   it('Should use correctly block layout mode', () => {
-    const wrapper = mount(<Loader layoutMode={LoaderLayoutMode.BLOCK} />)
-    expect(wrapper.find('.kirk-loader--block').exists()).toBe(true)
+    render(<Loader ariaLabel="loader" layoutMode={LoaderLayoutMode.BLOCK} />)
+    const loader = screen.getByLabelText('loader')
+    expect(loader.parentElement.className).toBe('kirk-loader--block')
   })
 
   it('Should use correctly fullscreen layout mode', () => {
-    const wrapper = mount(<Loader layoutMode={LoaderLayoutMode.FULLSCREEN} />)
-    expect(wrapper.find('.kirk-loader--fullScreen').exists()).toBe(true)
-  })
-
-  it('Should show the done icon', () => {
-    const wrapper = mount(<Loader done />)
-    expect(wrapper.find(StyledCheckIcon).exists()).toBe(true)
+    render(<Loader ariaLabel="loader" layoutMode={LoaderLayoutMode.FULLSCREEN} />)
+    const loader = screen.getByLabelText('loader')
+    expect(loader.parentElement.className).toBe('kirk-loader--fullScreen')
   })
 
   it('Should fire the callback event when done', () => {
     const callback = jest.fn()
-    const wrapper = mount(<Loader onDoneAnimationEnd={callback} />)
-    wrapper.setProps({ done: true })
+    const { rerender } = render(<Loader onDoneAnimationEnd={callback} />)
+
+    rerender(<Loader onDoneAnimationEnd={callback} done />)
+
     expect(callback).not.toBeCalled()
     jest.advanceTimersByTime(1500)
     expect(callback).toBeCalled()


### PR DESCRIPTION
## Description

Add the `aria-busy` on the loader component to indicates its loading states along with a `aria-live="polite"` attribute.

Ressources: https://www.accessibilityresources.org/aria-busy

## What has been done

* Add aria attributes
* Rewrite the tests with RTL

## Things to consider

* nothing in particular

## How it was tested

* unit tests
