### PR TITLE
Add invert animation in the search form

### DIFF
--- a/.storybook/knobs.ts
+++ b/.storybook/knobs.ts
@@ -1,0 +1,98 @@
+import { select } from '@storybook/addon-knobs'
+
+/**
+ * Numeric enums include a reverse mapping which is present in the JavaScript
+ * object at runtime.
+ * This function return an object without these mappings so it can be used to
+ * enumerate the enum members.
+ *
+ * @see {@link https://www.typescriptlang.org/docs/handbook/enums.html#reverse-mappings|Enum reverse mappings}
+ * @see {@link https://stackoverflow.com/a/50396312|Generic type to get enum keys as union string in typescript?}
+ */
+function removeReverseMappingFromEnum<TypeEnum>(
+  enumObject: TypeEnum,
+): { [key in keyof TypeEnum]: TypeEnum[key] } {
+  const keys = (Object.keys(enumObject) as Array<keyof TypeEnum>)
+    // Remove the keys used by reverse mapping.
+    // An enum member cannot have a numeric name (ts(2452)).
+    .filter(key => Number.isNaN(Number(key)))
+
+  return keys.reduce(
+    (acc, key) => ({ ...acc, [key]: enumObject[key] }),
+    {} as { [key in keyof TypeEnum]: TypeEnum[key] },
+  )
+}
+
+export type KnobEnumOptionsForOptionalProp<TypeEnum> = {
+  isPropOptional: true
+  initialValue?: TypeEnum[keyof TypeEnum]
+}
+
+export type KnobEnumOptionsForRequiredProp<TypeEnum> = {
+  isPropOptional?: false
+  initialValue: TypeEnum[keyof TypeEnum]
+}
+
+export type KnobEnumOptions<TypeEnum> = (
+  | KnobEnumOptionsForOptionalProp<TypeEnum>
+  | KnobEnumOptionsForRequiredProp<TypeEnum>
+) & {
+  group?: string
+}
+
+const KNOB_ENUM_USE_DEFAULT_VALUE = 'USE_DEFAULT_VALUE'
+
+/**
+ * Create a knob to list all entries of an enum.
+ *
+ * @example
+ * enum Status {
+ *   VALID,
+ *   ERROR,
+ * }
+ *
+ * // Display a select with "VALID" and "ERROR" options.
+ * const status: Status = knobEnum('status', Status, {
+ *   initialValue: Status.VALID
+ * })
+ *
+ * // Let the component use it's default value when a prop is optional.
+ * // A "Use default value" option is added which, when chosen, will be evaluated
+ * // to `undefined` to let JavaScript fallback to default values.
+ * const status: Status | undefined = knobEnum('status', Status, {
+ *   isPropOptional: true,
+ * })
+ */
+export function knobEnum<TypeEnum>(
+  label: string,
+  enumObject: TypeEnum,
+  { isPropOptional = false, initialValue, group }: KnobEnumOptions<TypeEnum>,
+): TypeEnum[keyof TypeEnum] | undefined {
+  const enumObjectWithoutReverseMapping = removeReverseMappingFromEnum(enumObject)
+
+  let options: typeof enumObjectWithoutReverseMapping & {
+    'Use default value'?: typeof KNOB_ENUM_USE_DEFAULT_VALUE
+  }
+
+  if (isPropOptional) {
+    options = {
+      // We can't directly use `undefined` as value because `select` return it
+      // as an empty string which can, theorically, be a valid member value in
+      // a string enum.
+      'Use default value': KNOB_ENUM_USE_DEFAULT_VALUE,
+
+      ...enumObjectWithoutReverseMapping,
+    }
+  } else {
+    options = enumObjectWithoutReverseMapping
+  }
+
+  const value: TypeEnum[keyof TypeEnum] | typeof KNOB_ENUM_USE_DEFAULT_VALUE = select(
+    label,
+    options,
+    initialValue ?? KNOB_ENUM_USE_DEFAULT_VALUE,
+    group,
+  )
+
+  return value === KNOB_ENUM_USE_DEFAULT_VALUE ? undefined : value
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-[...]
+- **[UPDATE]** Add invert animation in the `SearchForm`.
+  [...]
 
 # v34.4.2 (22/06/2020)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3119,6 +3119,7 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
       "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -6017,9 +6018,9 @@
       }
     },
     "@types/react-transition-group": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-2.0.16.tgz",
-      "integrity": "sha512-FUJEx2BGJPU1qVQoWd9v7wpOwnCPTWhcE4iTaU5prry9SvwiI11lCXOci8Nz9cM/Fuf650l7Skg6nlVeCYjPFA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
+      "integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -11199,11 +11200,32 @@
       }
     },
     "dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.4.tgz",
+      "integrity": "sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==",
       "requires": {
-        "@babel/runtime": "^7.1.2"
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^2.6.7"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.3.tgz",
+          "integrity": "sha512-RzGO0RLSdokm9Ipe/YD+7ww8X2Ro79qiXZF3HU9ljrM+qnJmH1Vqth+hbiQZy761LnMJTMitHDuKVYTk3k4dLw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "csstype": {
+          "version": "2.6.10",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.10.tgz",
+          "integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        }
       }
     },
     "dom-serializer": {
@@ -13462,8 +13484,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -13484,14 +13505,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -13506,20 +13525,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -13636,8 +13652,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -13649,7 +13664,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -13664,7 +13678,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -13672,14 +13685,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -13698,7 +13709,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -13788,8 +13798,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -13801,7 +13810,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -13887,8 +13895,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -13924,7 +13931,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -13944,7 +13950,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -13988,14 +13993,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -20703,7 +20706,8 @@
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "dev": true
     },
     "react-popper": {
       "version": "1.3.3",
@@ -20805,6 +20809,29 @@
         "prop-types": "^15.6.0",
         "react-input-autosize": "^2.2.2",
         "react-transition-group": "^2.2.1"
+      },
+      "dependencies": {
+        "dom-helpers": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+          "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.1.2"
+          }
+        },
+        "react-transition-group": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+          "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+          "dev": true,
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        }
       }
     },
     "react-sizeme": {
@@ -20863,14 +20890,29 @@
       }
     },
     "react-transition-group": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.6.1.tgz",
-      "integrity": "sha512-9DHwCy0aOYEe35frlEN68N9ut/THDQBLnVoQuKTvzF4/s3tk7lqkefCqxK2Nv96fOh6JXk6tQtliygk6tl3bQA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
       "requires": {
-        "dom-helpers": "^3.3.1",
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2",
-        "react-lifecycles-compat": "^3.0.4"
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.3.tgz",
+          "integrity": "sha512-RzGO0RLSdokm9Ipe/YD+7ww8X2Ro79qiXZF3HU9ljrM+qnJmH1Vqth+hbiQZy761LnMJTMitHDuKVYTk3k4dLw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        }
       }
     },
     "reactcss": {
@@ -21060,7 +21102,8 @@
     "regenerator-runtime": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@types/react-color": "3.0.1",
     "@types/react-dom": "16.9.4",
     "@types/react-test-renderer": "16.9.1",
-    "@types/react-transition-group": "2.0.16",
+    "@types/react-transition-group": "4.4.0",
     "@types/storybook__react": "5.2.1",
     "@types/styled-components": "4.1.8",
     "@types/uuid": "3.4.6",
@@ -119,7 +119,7 @@
     "lodash.isstring": "4.0.1",
     "lodash.uniqueid": "4.0.1",
     "react-day-picker": "7.3.0",
-    "react-transition-group": "2.6.1",
+    "react-transition-group": "4.4.1",
     "uuid": "3.3.3"
   },
   "peerDependencies": {

--- a/src/_utils/branding.ts
+++ b/src/_utils/branding.ts
@@ -81,10 +81,16 @@ export const radius: defaultBranding = {
   xl: '24px',
 }
 
+// In milliseconds.
+export enum TransitionDuration {
+  BASE = 200,
+  FAST = 500,
+}
+
 export const transition = {
   duration: {
-    base: '200ms',
-    fast: '500ms',
+    base: `${TransitionDuration.BASE}ms`,
+    fast: `${TransitionDuration.FAST}ms`,
   },
   easing: {
     default: 'ease-in',

--- a/src/searchForm/SearchForm.unit.tsx
+++ b/src/searchForm/SearchForm.unit.tsx
@@ -55,7 +55,7 @@ describe('searchForm', () => {
 
       it('should open the autocomplete from overlay and close it on blur', () => {
         expect(wrapper.find(AutoCompleteOverlay).exists()).toBe(false)
-        wrapper.find('.kirk-searchForm-from > .kirk-search-button').simulate('click')
+        wrapper.find('.kirk-searchForm-from .kirk-search-button').simulate('click')
         expect(wrapper.find(AutoCompleteOverlay).exists()).toBe(true)
         expect(
           wrapper
@@ -77,7 +77,7 @@ describe('searchForm', () => {
 
       it('should open the autocomplete to overlay', () => {
         expect(wrapper.find(AutoCompleteOverlay).exists()).toBe(false)
-        wrapper.find('.kirk-searchForm-to > .kirk-search-button').simulate('click')
+        wrapper.find('.kirk-searchForm-to .kirk-search-button').simulate('click')
         expect(wrapper.find(AutoCompleteOverlay).exists()).toBe(true)
         expect(
           wrapper
@@ -113,7 +113,7 @@ describe('searchForm', () => {
             .first()
             .prop('in'),
         ).toBe(false)
-        wrapper.find('.kirk-searchForm-from > .kirk-search-button').simulate('click')
+        wrapper.find('.kirk-searchForm-from .kirk-search-button').simulate('click')
         expect(
           wrapper
             .find(CSSTransition)
@@ -129,7 +129,7 @@ describe('searchForm', () => {
             .at(1)
             .prop('in'),
         ).toBe(false)
-        wrapper.find('.kirk-searchForm-to > .kirk-search-button').simulate('click')
+        wrapper.find('.kirk-searchForm-to .kirk-search-button').simulate('click')
         expect(
           wrapper
             .find(CSSTransition)

--- a/src/searchForm/SlideSwitchTransition.tsx
+++ b/src/searchForm/SlideSwitchTransition.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react'
+import { CSSTransition, SwitchTransition } from 'react-transition-group'
+import styled from 'styled-components'
+
+import { TransitionDuration } from '../_utils/branding'
+
+export enum SlideSwitchTransitionSide {
+  TOP = 'top',
+  RIGHT = 'right',
+  BOTTOM = 'bottom',
+  LEFT = 'left',
+}
+
+const DIRECTION_TRANSFORM_VALUES: {
+  [key in SlideSwitchTransitionSide]: AnimatedSpanProps['transform']
+} = {
+  [SlideSwitchTransitionSide.TOP]: { in: 'translateY(0)', out: 'translateY(-100%)' },
+  [SlideSwitchTransitionSide.RIGHT]: { in: 'translateX(0)', out: 'translateX(100%)' },
+  [SlideSwitchTransitionSide.BOTTOM]: { in: 'translateY(0)', out: 'translateY(100%)' },
+  [SlideSwitchTransitionSide.LEFT]: { in: 'translateX(0)', out: 'translateX(-100%)' },
+}
+
+type AnimatedSpanProps = {
+  transitionDuration: TransitionDuration
+  transform: {
+    /**
+     * CSS transformation to apply when the element is in the screen (visible).
+     */
+    in: string
+
+    /**
+     * CSS transformation to apply when the element is out of screen (hidden).
+     */
+    out: string
+  }
+}
+
+const AnimatedSpan = styled.span<AnimatedSpanProps>`
+  display: inline-block;
+  opacity: 1;
+  transform: ${p => p.transform.in};
+  transition-property: opacity, transform;
+  transition-duration: ${p => p.transitionDuration}ms;
+
+  &.slide-enter {
+    opacity: 0;
+    transform: ${p => p.transform.out};
+  }
+
+  &.slide-enter-active {
+    opacity: 1;
+    transform: ${p => p.transform.in};
+    transition-timing-function: ease-out;
+  }
+
+  &.slide-exit {
+    opacity: 1;
+    transform: ${p => p.transform.in};
+  }
+
+  &.slide-exit-active {
+    opacity: 0;
+    transform: ${p => p.transform.out};
+    transition-timing-function: ease-in;
+  }
+`
+
+export type SlideSwitchTransitionProps = {
+  /**
+   * Key of the current children used to identify them.
+   * When the key changes, the previous children will be animated out and the
+   * new ones will be animated in.
+   */
+  childrenKey: React.Key
+  side?: SlideSwitchTransitionSide
+  transitionDuration?: TransitionDuration
+  children?: React.ReactNode
+}
+
+export function SlideSwitchTransition({
+  childrenKey,
+  side = SlideSwitchTransitionSide.BOTTOM,
+  transitionDuration = TransitionDuration.BASE,
+  children,
+}: SlideSwitchTransitionProps) {
+  return (
+    <SwitchTransition>
+      <CSSTransition key={childrenKey} timeout={transitionDuration} classNames="slide">
+        <AnimatedSpan
+          transform={DIRECTION_TRANSFORM_VALUES[side]}
+          transitionDuration={transitionDuration}
+        >
+          {children}
+        </AnimatedSpan>
+      </CSSTransition>
+    </SwitchTransition>
+  )
+}

--- a/src/searchForm/index.tsx
+++ b/src/searchForm/index.tsx
@@ -42,6 +42,17 @@ const StyledSearchForm = styled(SearchForm)`
     display: flex;
   }
 
+  & .kirk-searchForm-from,
+  & .kirk-searchForm-to {
+    /* Hide the overflowing parts of the button during the animation. */
+    overflow: hidden;
+  }
+
+  & .kirk-searchForm-to,
+  & .kirk-searchForm-seats {
+    border-left: 1px solid ${color.lightGray};
+  }
+
   & .kirk-searchForm-textfield .kirk-textField-wrapper {
     height: auto;
     background: none;
@@ -58,10 +69,6 @@ const StyledSearchForm = styled(SearchForm)`
 
   & .kirk-searchForm-button {
     color: ${color.lightMidnightGreen};
-  }
-
-  & .kirk-searchForm-invert {
-    border-right: 1px solid ${color.lightGray};
   }
 
   & .kirk-searchForm-invert .kirk-icon {
@@ -94,7 +101,6 @@ const StyledSearchForm = styled(SearchForm)`
   & .kirk-searchForm-from .kirk-search-button,
   & .kirk-searchForm-to .kirk-search-button {
     width: ${primaryFieldsWidth};
-    border-right: 1px solid ${color.lightGray};
     padding-left: ${space.m};
     line-height: ${componentSizes.bulletSizeSearch};
   }
@@ -116,12 +122,8 @@ const StyledSearchForm = styled(SearchForm)`
     padding-left: ${space.m};
   }
 
-  & .kirk-searchForm-from .kirk-search-button {
-    border-right: none;
-  }
-
-  & .kirk-searchForm-date .kirk-search-button {
-    border-right: 1px solid ${color.lightGray};
+  & .kirk-searchForm-date {
+    border-left: 1px solid ${color.lightGray};
   }
 
   & .kirk-searchForm-submit .kirk-search-button {
@@ -194,8 +196,8 @@ const StyledSearchForm = styled(SearchForm)`
       margin-right: 0;
     }
 
-    & .kirk-searchForm-date {
-      margin-right: ${space.m};
+    & .kirk-searchForm-seats {
+      padding-left: ${space.m};
     }
 
     & .kirk-searchForm-from {
@@ -205,10 +207,10 @@ const StyledSearchForm = styled(SearchForm)`
 
     & .kirk-searchForm-invert {
       padding: 0;
-      border: none;
     }
 
-    & .kirk-searchForm-to .kirk-search-button {
+    & .kirk-searchForm-to,
+    & .kirk-searchForm-date {
       border: none;
     }
 

--- a/src/searchForm/overlay/index.tsx
+++ b/src/searchForm/overlay/index.tsx
@@ -15,6 +15,9 @@ import { Overlay } from './Overlay'
  * Some of them are adding more transitions (e.g. stepperOverlay)
  */
 const StyledOverlay = styled(Overlay)`
+  /* Above the search form. */
+  z-index: 1;
+
   & .${TRANSITION_OVERLAY_CLASS_NAME}-enter {
     opacity: 0;
     width: 0;

--- a/src/searchForm/story.tsx
+++ b/src/searchForm/story.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 import { text, withKnobs } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 
+import { TransitionDuration } from '../_utils/branding'
 import { MediaSizeProvider } from '../_utils/mediaSizeProvider'
+import { knobEnum } from '../../.storybook/knobs'
 import { AutoCompleteExample } from '../autoComplete/story'
 import { DatePicker } from '../datePicker'
 import { CrossIcon } from '../icon/crossIcon'
@@ -12,6 +14,7 @@ import { AutoCompleteSection } from './autoComplete/section'
 import { DatePickerOverlay } from './datePicker/overlay'
 import { DatePickerSection } from './datePicker/section'
 import { SearchForm } from './index'
+import { SlideSwitchTransition, SlideSwitchTransitionSide } from './SlideSwitchTransition'
 import { searchFormDocumentation } from './specifications/searchForm.md'
 import { StepperOverlay } from './stepper/overlay'
 import { StepperSection } from './stepper/section'
@@ -111,3 +114,19 @@ stories.add(
     readme: { content: searchFormDocumentation },
   },
 )
+
+stories.add('SlideSwitchTransition', () => {
+  const children = text('children', 'Some text')
+
+  return (
+    <SlideSwitchTransition
+      transitionDuration={knobEnum('transitionDuration', TransitionDuration, {
+        isPropOptional: true,
+      })}
+      side={knobEnum('side', SlideSwitchTransitionSide, { isPropOptional: true })}
+      childrenKey={children}
+    >
+      {children}
+    </SlideSwitchTransition>
+  )
+})


### PR DESCRIPTION
## Description

Add animation between "from" and "to" fields in the `SearchForm` when the user click on the invert button.

## What has been done

- Create a `SlideSwitchTransition` component to manage this CSS transition.
- Use it in the `SearchForm`.

**Result**

![Kapture 2020-06-22 at 13 48 22](https://user-images.githubusercontent.com/17502801/85284470-8d2bc380-b48f-11ea-89f1-ed0231da54cb.gif)

![Kapture 2020-06-22 at 13 53 47](https://user-images.githubusercontent.com/17502801/85284662-da0f9a00-b48f-11ea-8525-47bd9cd3f0dc.gif)

## Things to consider

react-transition-group had to be updated to the last version to use `SwitchTransition`.

## How it was tested

- Storybook: Chrome, Firefox, Safari, Edge
- Unit tests