### PR TITLE
Release/34.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Unreleased
 
+[...]
+
+# v34.4.2 (22/06/2020)
+
 - **[FIX]** Make `Paragraph` layout resilient to long strings without spaces.
 - **[FIX]** Fix `PetIcon` stroke fill color.
-[...]
+
+# v34.4.1 (18/06/2020)
+
+Release created by accident. Do not use published npm package.
 
 # v34.4.0 (18/06/2020)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "34.4.0",
+  "version": "34.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "34.4.0",
+  "version": "34.4.2",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
- **[FIX]** Make `Paragraph` layout resilient to long strings without spaces.
- **[FIX]** Fix `PetIcon` stroke fill color.