### PR TITLE
Restoring Icons Fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - [...]
+- **[FIX]** Revert icons `fill` properties instead of `strokes`.
 
 # v34.5.0 (24/06/2020)
 

--- a/src/_utils/checkboxIcon/__snapshots__/index.unit.tsx.snap
+++ b/src/_utils/checkboxIcon/__snapshots__/index.unit.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`CheckboxIcon Should render a check icon if isChecked is set to true 1`] = `
 .c1 {
-  stroke: #FFF;
+  fill: #FFF;
 }
 
 .c1.kirk-icon-wrapper {
@@ -69,7 +69,7 @@ exports[`CheckboxIcon Should render a check icon if isChecked is set to true 1`]
 
 exports[`CheckboxIcon Should render a loader if isLoading and isChecked are set to true 1`] = `
 .c2 {
-  stroke: #5DD167;
+  fill: #5DD167;
 }
 
 .c2.kirk-icon-wrapper {
@@ -217,7 +217,7 @@ exports[`CheckboxIcon Should render a loader if isLoading and isChecked are set 
 
 exports[`CheckboxIcon Should render a loader if isLoading is set to true 1`] = `
 .c2 {
-  stroke: #5DD167;
+  fill: #5DD167;
 }
 
 .c2.kirk-icon-wrapper {
@@ -365,7 +365,7 @@ exports[`CheckboxIcon Should render a loader if isLoading is set to true 1`] = `
 
 exports[`CheckboxIcon Should render an empty circle by default 1`] = `
 .c1 {
-  stroke: #00AFF5;
+  fill: #00AFF5;
 }
 
 .c1.kirk-icon-wrapper {

--- a/src/_utils/icon/index.tsx
+++ b/src/_utils/icon/index.tsx
@@ -4,7 +4,7 @@ import { color, shadow } from '../branding'
 import { BaseIcon } from './BaseIcon'
 
 const StyledBaseIcon = styled(BaseIcon)`
-  stroke: ${props => props.iconColor ?? color.lightMidnightGreen};
+  fill: ${props => props.iconColor ?? color.lightMidnightGreen};
 
   &,
   & rect,
@@ -13,7 +13,7 @@ const StyledBaseIcon = styled(BaseIcon)`
   & polyline,
   & path,
   & g {
-    stroke: ${props => (props.isDisabled ? color.gray : '')};
+    fill: ${props => (props.isDisabled ? color.gray : '')};
   }
 
   &.kirk-icon-wrapper {

--- a/src/_utils/item/__snapshots__/Item.unit.tsx.snap
+++ b/src/_utils/item/__snapshots__/Item.unit.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Item Should not have changed 1`] = `
 .c2 {
-  stroke: #708C91;
+  fill: #708C91;
 }
 
 .c2.kirk-icon-wrapper {

--- a/src/_utils/radioIcon/__snapshots__/index.unit.tsx.snap
+++ b/src/_utils/radioIcon/__snapshots__/index.unit.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`RadioIcon Should render a check icon if isChecked is set to true 1`] = `
 .c1 {
-  stroke: #00AFF5;
+  fill: #00AFF5;
 }
 
 .c1.kirk-icon-wrapper {
@@ -85,7 +85,7 @@ exports[`RadioIcon Should render a check icon if isChecked is set to true 1`] = 
 
 exports[`RadioIcon Should render a loader if isLoading and isChecked are set to true 1`] = `
 .c2 {
-  stroke: #5DD167;
+  fill: #5DD167;
 }
 
 .c2.kirk-icon-wrapper {
@@ -233,7 +233,7 @@ exports[`RadioIcon Should render a loader if isLoading and isChecked are set to 
 
 exports[`RadioIcon Should render a loader if isLoading is set to true 1`] = `
 .c2 {
-  stroke: #5DD167;
+  fill: #5DD167;
 }
 
 .c2.kirk-icon-wrapper {
@@ -381,7 +381,7 @@ exports[`RadioIcon Should render a loader if isLoading is set to true 1`] = `
 
 exports[`RadioIcon Should render an empty circle by default 1`] = `
 .c1 {
-  stroke: #00AFF5;
+  fill: #00AFF5;
 }
 
 .c1.kirk-icon-wrapper {

--- a/src/datePicker/__snapshots__/DatePicker.unit.tsx.snap
+++ b/src/datePicker/__snapshots__/DatePicker.unit.tsx.snap
@@ -18,7 +18,7 @@ exports[`DatePicker renderCaption Should render the given month title with year 
 
 exports[`DatePicker renderNavbar Should render the previous/next buttons in horizontal mode 1`] = `
 .c1 {
-  stroke: #00AFF5;
+  fill: #00AFF5;
 }
 
 .c1.kirk-icon-wrapper {

--- a/src/hint/__snapshots__/index.unit.tsx.snap
+++ b/src/hint/__snapshots__/index.unit.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Hint Default rendering (above) 1`] = `
 .c4 {
-  stroke: #FFF;
+  fill: #FFF;
 }
 
 .c4.kirk-icon-wrapper {
@@ -354,7 +354,7 @@ exports[`Hint Default rendering (above) 1`] = `
 
 exports[`Hint Default rendering (below) 1`] = `
 .c4 {
-  stroke: #FFF;
+  fill: #FFF;
 }
 
 .c4.kirk-icon-wrapper {

--- a/src/itemCheckbox/__snapshots__/ItemCheckbox.unit.tsx.snap
+++ b/src/itemCheckbox/__snapshots__/ItemCheckbox.unit.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ItemCheckbox Should display a CheckIcon when the input is checked 1`] = `
 .c3 {
-  stroke: #FFF;
+  fill: #FFF;
 }
 
 .c3.kirk-icon-wrapper {
@@ -297,7 +297,7 @@ button:focus:not(.focus-visible).c0 {
 
 exports[`ItemCheckbox Should display a Loader when the component is in loading status 1`] = `
 .c4 {
-  stroke: #5DD167;
+  fill: #5DD167;
 }
 
 .c4.kirk-icon-wrapper {
@@ -673,7 +673,7 @@ button:focus:not(.focus-visible).c0 {
 
 exports[`ItemCheckbox Should forward its props to the Item component 1`] = `
 .c3 {
-  stroke: #00AFF5;
+  fill: #00AFF5;
 }
 
 .c3.kirk-icon-wrapper {

--- a/src/itemChoice/__snapshots__/index.unit.tsx.snap
+++ b/src/itemChoice/__snapshots__/index.unit.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ItemChoice Should display a Loader when the component is in loading status 1`] = `
 .c1 {
-  stroke: #708C91;
+  fill: #708C91;
 }
 
 .c1.kirk-icon-wrapper {
@@ -22,7 +22,7 @@ exports[`ItemChoice Should display a Loader when the component is in loading sta
 }
 
 .c5 {
-  stroke: #5DD167;
+  fill: #5DD167;
 }
 
 .c5.kirk-icon-wrapper {
@@ -448,7 +448,7 @@ button:focus:not(.focus-visible).c0 {
 
 exports[`ItemChoice Should display a done Loader when the component is in checked status 1`] = `
 .c1 {
-  stroke: #708C91;
+  fill: #708C91;
 }
 
 .c1.kirk-icon-wrapper {
@@ -468,7 +468,7 @@ exports[`ItemChoice Should display a done Loader when the component is in checke
 }
 
 .c5 {
-  stroke: #FFF;
+  fill: #FFF;
 }
 
 .c5.kirk-icon-wrapper {
@@ -884,7 +884,7 @@ button:focus:not(.focus-visible).c0 {
 
 exports[`ItemChoice Should forward its props to the Item component 1`] = `
 .c1 {
-  stroke: #708C91;
+  fill: #708C91;
 }
 
 .c1.kirk-icon-wrapper {
@@ -1237,7 +1237,7 @@ button:focus:not(.focus-visible).c0 {
 
 exports[`ItemChoice Should support a disabled state 1`] = `
 .c1 {
-  stroke: #708C91;
+  fill: #708C91;
 }
 
 .c1.kirk-icon-wrapper {
@@ -1257,7 +1257,7 @@ exports[`ItemChoice Should support a disabled state 1`] = `
 }
 
 .c3 {
-  stroke: #DDD;
+  fill: #DDD;
 }
 
 .c3.kirk-icon-wrapper {
@@ -1612,7 +1612,7 @@ button:focus:not(.focus-visible).c0 {
 
 exports[`ItemChoice Should use a button tag if no href is given 1`] = `
 .c1 {
-  stroke: #708C91;
+  fill: #708C91;
 }
 
 .c1.kirk-icon-wrapper {

--- a/src/itemRadio/__snapshots__/ItemRadio.unit.tsx.snap
+++ b/src/itemRadio/__snapshots__/ItemRadio.unit.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ItemRadio Should display a CircleIcon with an innerDisc when the input is checked 1`] = `
 .c3 {
-  stroke: #00AFF5;
+  fill: #00AFF5;
 }
 
 .c3.kirk-icon-wrapper {
@@ -317,7 +317,7 @@ button:focus:not(.focus-visible).c0 {
 
 exports[`ItemRadio Should display a Loader when the component is in loading status 1`] = `
 .c4 {
-  stroke: #5DD167;
+  fill: #5DD167;
 }
 
 .c4.kirk-icon-wrapper {
@@ -697,7 +697,7 @@ button:focus:not(.focus-visible).c0 {
 
 exports[`ItemRadio Should forward its props to the Item component 1`] = `
 .c3 {
-  stroke: #00AFF5;
+  fill: #00AFF5;
 }
 
 .c3.kirk-icon-wrapper {

--- a/src/itemRadioGroup/__snapshots__/index.unit.tsx.snap
+++ b/src/itemRadioGroup/__snapshots__/index.unit.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ItemRadioGroup Should map its children and render them with specific props 1`] = `
 .c5 {
-  stroke: #00AFF5;
+  fill: #00AFF5;
 }
 
 .c5.kirk-icon-wrapper {

--- a/src/itemsList/__snapshots__/ItemsList.unit.tsx.snap
+++ b/src/itemsList/__snapshots__/ItemsList.unit.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ItemsList Should render an unordered list 1`] = `
 .c3 {
-  stroke: #708C91;
+  fill: #708C91;
 }
 
 .c3.kirk-icon-wrapper {
@@ -370,7 +370,7 @@ button:focus:not(.focus-visible).c1 {
 
 exports[`ItemsList Should render an unordered list with some separators 1`] = `
 .c3 {
-  stroke: #708C91;
+  fill: #708C91;
 }
 
 .c3.kirk-icon-wrapper {
@@ -755,7 +755,7 @@ button:focus:not(.focus-visible).c1 {
 
 exports[`ItemsList Should render an unordered list with the separators classname 1`] = `
 .c3 {
-  stroke: #708C91;
+  fill: #708C91;
 }
 
 .c3.kirk-icon-wrapper {

--- a/src/messagingSummaryItem/__snapshots__/MessagingSummaryItem.unit.tsx.snap
+++ b/src/messagingSummaryItem/__snapshots__/MessagingSummaryItem.unit.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Should render properly with read messages 1`] = `
 .c3 {
-  stroke: #708C91;
+  fill: #708C91;
 }
 
 .c3.kirk-icon-wrapper {
@@ -369,7 +369,7 @@ button:focus:not(.focus-visible).c0 {
 
 exports[`Should render properly with unread messages 1`] = `
 .c3 {
-  stroke: #708C91;
+  fill: #708C91;
 }
 
 .c3.kirk-icon-wrapper {

--- a/src/modal/__snapshots__/Modal.unit.tsx.snap
+++ b/src/modal/__snapshots__/Modal.unit.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Modal should not have changed 1`] = `
 .c3 {
-  stroke: #00AFF5;
+  fill: #00AFF5;
 }
 
 .c3.kirk-icon-wrapper {

--- a/src/phoneField/__snapshots__/PhoneField.unit.tsx.snap
+++ b/src/phoneField/__snapshots__/PhoneField.unit.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PhoneField should have the expected markup in the DOM with custom settings 1`] = `
 .c2 {
-  stroke: #708C91;
+  fill: #708C91;
 }
 
 .c2.kirk-icon-wrapper {
@@ -598,7 +598,7 @@ exports[`PhoneField should have the expected markup in the DOM with custom setti
 
 exports[`PhoneField should have the expected markup in the DOM with default settings 1`] = `
 .c2 {
-  stroke: #708C91;
+  fill: #708C91;
 }
 
 .c2.kirk-icon-wrapper {

--- a/src/proximity/__snapshots__/Proximity.unit.tsx.snap
+++ b/src/proximity/__snapshots__/Proximity.unit.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Should highlight CLOSE and have a title 1`] = `
 .c1 {
-  stroke: #EDEDED;
+  fill: #EDEDED;
 }
 
 .c1.kirk-icon-wrapper {
@@ -22,7 +22,7 @@ exports[`Should highlight CLOSE and have a title 1`] = `
 }
 
 .c0 {
-  stroke: #5DD167;
+  fill: #5DD167;
 }
 
 .c0.kirk-icon-wrapper {
@@ -93,7 +93,7 @@ exports[`Should highlight CLOSE and have a title 1`] = `
 
 exports[`Should highlight FAR and have a title 1`] = `
 .c0 {
-  stroke: #EDEDED;
+  fill: #EDEDED;
 }
 
 .c0.kirk-icon-wrapper {
@@ -113,7 +113,7 @@ exports[`Should highlight FAR and have a title 1`] = `
 }
 
 .c1 {
-  stroke: #F78B00;
+  fill: #F78B00;
 }
 
 .c1.kirk-icon-wrapper {
@@ -184,7 +184,7 @@ exports[`Should highlight FAR and have a title 1`] = `
 
 exports[`Should highlight MIDDLE without a title 1`] = `
 .c0 {
-  stroke: #EDEDED;
+  fill: #EDEDED;
 }
 
 .c0.kirk-icon-wrapper {
@@ -204,7 +204,7 @@ exports[`Should highlight MIDDLE without a title 1`] = `
 }
 
 .c1 {
-  stroke: #FFCA0C;
+  fill: #FFCA0C;
 }
 
 .c1.kirk-icon-wrapper {

--- a/src/pushInfo/__snapshots__/PushInfo.unit.tsx.snap
+++ b/src/pushInfo/__snapshots__/PushInfo.unit.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Should also have the correct icon. 1`] = `
 .c1 {
-  stroke: #5DD167;
+  fill: #5DD167;
 }
 
 .c1.kirk-icon-wrapper {

--- a/src/searchRecap/__snapshots__/SearchRecap.unit.tsx.snap
+++ b/src/searchRecap/__snapshots__/SearchRecap.unit.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`searchRecap Should display searchRecap component 1`] = `
 .c1 {
-  stroke: #708C91;
+  fill: #708C91;
 }
 
 .c1.kirk-icon-wrapper {

--- a/src/selectField/__snapshots__/SelectField.unit.tsx.snap
+++ b/src/selectField/__snapshots__/SelectField.unit.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`SelectField should have the expected markup in the DOM 1`] = `
 .c1 {
-  stroke: #708C91;
+  fill: #708C91;
 }
 
 .c1.kirk-icon-wrapper {

--- a/src/snackbar/__snapshots__/Snackbar.unit.tsx.snap
+++ b/src/snackbar/__snapshots__/Snackbar.unit.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Snackbar should not have changed 1`] = `
 .c4 {
-  stroke: #FFF;
+  fill: #FFF;
 }
 
 .c4.kirk-icon-wrapper {

--- a/src/tabs/__snapshots__/Tabs.unit.tsx.snap
+++ b/src/tabs/__snapshots__/Tabs.unit.tsx.snap
@@ -130,7 +130,7 @@ exports[`Rendering testing should render properly 1`] = `
 
 exports[`Rendering testing should render properly with icons 1`] = `
 .c0 {
-  stroke: #708C91;
+  fill: #708C91;
 }
 
 .c0.kirk-icon-wrapper {


### PR DESCRIPTION
## Description

<!-- Give some context of this PR. Illustrate with screenshots or a video (gif, loom, etc.) -->
BBC Icons have a irregular stroke, to try to reduce this difference I've used `stroke` attributes to set colors` but it makes the icon look stronger than they really are.

**STROKE**
![Screenshot 2020-06-25 at 16 57 10](https://user-images.githubusercontent.com/2952998/85745418-f9176180-b705-11ea-91e1-756b3b4300c3.png)


Back to the old fill version, still irregular, but _we don't see them_

**FILL**
![Screenshot 2020-06-25 at 16 57 55](https://user-images.githubusercontent.com/2952998/85745428-fb79bb80-b705-11ea-8bac-45dd0569d361.png)


## How it was tested

<!-- Local environment with ui-library only, integrated within the main project, on which browsers, etc. -->
👀  eyes
