### PR TITLE
Implement Loader basic a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[UPDATE]** Add basic a11y to `Loader` component
 [...]
 
 # v38.2.0 (31/07/2020)

--- a/src/_internals/checkboxIcon/__snapshots__/index.unit.tsx.snap
+++ b/src/_internals/checkboxIcon/__snapshots__/index.unit.tsx.snap
@@ -125,6 +125,16 @@ exports[`CheckboxIcon Should render a loader if isLoading and isChecked are set 
   position: absolute;
 }
 
+.c0 .visually-hidden {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  white-space: nowrap;
+}
+
 .c0.kirk-loader--inline {
   display: inline-block;
 }
@@ -186,31 +196,42 @@ exports[`CheckboxIcon Should render a loader if isLoading and isChecked are set 
   className="kirk-loader--inline c0"
 >
   <div
-    className=""
-    style={
-      Object {
-        "height": "24px",
-        "width": "24px",
-      }
-    }
+    aria-valuetext="Loading"
+    role="progressbar"
   >
-    <svg
-      aria-hidden={true}
-      className="kirk-icon kirk-icon-circle spinning c1 c2"
-      height={24}
-      viewBox="0 0 66 66"
-      width={24}
-      xmlns="http://www.w3.org/2000/svg"
+    <div
+      className=""
+      style={
+        Object {
+          "height": "24px",
+          "width": "24px",
+        }
+      }
     >
-      
-      <circle
-        className="outer"
-        cx="33"
-        cy="33"
-        fill="none"
-        r="30"
-      />
-    </svg>
+      <svg
+        aria-hidden={true}
+        className="kirk-icon kirk-icon-circle spinning c1 c2"
+        height={24}
+        viewBox="0 0 66 66"
+        width={24}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        
+        <circle
+          className="outer"
+          cx="33"
+          cy="33"
+          fill="none"
+          r="30"
+        />
+      </svg>
+    </div>
+  </div>
+  <div
+    className="visually-hidden"
+    role="status"
+  >
+    Loading
   </div>
 </div>
 `;
@@ -273,6 +294,16 @@ exports[`CheckboxIcon Should render a loader if isLoading is set to true 1`] = `
   position: absolute;
 }
 
+.c0 .visually-hidden {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  white-space: nowrap;
+}
+
 .c0.kirk-loader--inline {
   display: inline-block;
 }
@@ -334,31 +365,42 @@ exports[`CheckboxIcon Should render a loader if isLoading is set to true 1`] = `
   className="kirk-loader--inline c0"
 >
   <div
-    className=""
-    style={
-      Object {
-        "height": "24px",
-        "width": "24px",
-      }
-    }
+    aria-valuetext="Loading"
+    role="progressbar"
   >
-    <svg
-      aria-hidden={true}
-      className="kirk-icon kirk-icon-circle spinning c1 c2"
-      height={24}
-      viewBox="0 0 66 66"
-      width={24}
-      xmlns="http://www.w3.org/2000/svg"
+    <div
+      className=""
+      style={
+        Object {
+          "height": "24px",
+          "width": "24px",
+        }
+      }
     >
-      
-      <circle
-        className="outer"
-        cx="33"
-        cy="33"
-        fill="none"
-        r="30"
-      />
-    </svg>
+      <svg
+        aria-hidden={true}
+        className="kirk-icon kirk-icon-circle spinning c1 c2"
+        height={24}
+        viewBox="0 0 66 66"
+        width={24}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        
+        <circle
+          className="outer"
+          cx="33"
+          cy="33"
+          fill="none"
+          r="30"
+        />
+      </svg>
+    </div>
+  </div>
+  <div
+    className="visually-hidden"
+    role="status"
+  >
+    Loading
   </div>
 </div>
 `;

--- a/src/_internals/radioIcon/__snapshots__/index.unit.tsx.snap
+++ b/src/_internals/radioIcon/__snapshots__/index.unit.tsx.snap
@@ -141,6 +141,16 @@ exports[`RadioIcon Should render a loader if isLoading and isChecked are set to 
   position: absolute;
 }
 
+.c0 .visually-hidden {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  white-space: nowrap;
+}
+
 .c0.kirk-loader--inline {
   display: inline-block;
 }
@@ -202,31 +212,42 @@ exports[`RadioIcon Should render a loader if isLoading and isChecked are set to 
   className="kirk-loader--inline c0"
 >
   <div
-    className=""
-    style={
-      Object {
-        "height": "24px",
-        "width": "24px",
-      }
-    }
+    aria-valuetext="Loading"
+    role="progressbar"
   >
-    <svg
-      aria-hidden={true}
-      className="kirk-icon kirk-icon-circle spinning c1 c2"
-      height={24}
-      viewBox="0 0 66 66"
-      width={24}
-      xmlns="http://www.w3.org/2000/svg"
+    <div
+      className=""
+      style={
+        Object {
+          "height": "24px",
+          "width": "24px",
+        }
+      }
     >
-      
-      <circle
-        className="outer"
-        cx="33"
-        cy="33"
-        fill="none"
-        r="30"
-      />
-    </svg>
+      <svg
+        aria-hidden={true}
+        className="kirk-icon kirk-icon-circle spinning c1 c2"
+        height={24}
+        viewBox="0 0 66 66"
+        width={24}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        
+        <circle
+          className="outer"
+          cx="33"
+          cy="33"
+          fill="none"
+          r="30"
+        />
+      </svg>
+    </div>
+  </div>
+  <div
+    className="visually-hidden"
+    role="status"
+  >
+    Loading
   </div>
 </div>
 `;
@@ -289,6 +310,16 @@ exports[`RadioIcon Should render a loader if isLoading is set to true 1`] = `
   position: absolute;
 }
 
+.c0 .visually-hidden {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  white-space: nowrap;
+}
+
 .c0.kirk-loader--inline {
   display: inline-block;
 }
@@ -350,31 +381,42 @@ exports[`RadioIcon Should render a loader if isLoading is set to true 1`] = `
   className="kirk-loader--inline c0"
 >
   <div
-    className=""
-    style={
-      Object {
-        "height": "24px",
-        "width": "24px",
-      }
-    }
+    aria-valuetext="Loading"
+    role="progressbar"
   >
-    <svg
-      aria-hidden={true}
-      className="kirk-icon kirk-icon-circle spinning c1 c2"
-      height={24}
-      viewBox="0 0 66 66"
-      width={24}
-      xmlns="http://www.w3.org/2000/svg"
+    <div
+      className=""
+      style={
+        Object {
+          "height": "24px",
+          "width": "24px",
+        }
+      }
     >
-      
-      <circle
-        className="outer"
-        cx="33"
-        cy="33"
-        fill="none"
-        r="30"
-      />
-    </svg>
+      <svg
+        aria-hidden={true}
+        className="kirk-icon kirk-icon-circle spinning c1 c2"
+        height={24}
+        viewBox="0 0 66 66"
+        width={24}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        
+        <circle
+          className="outer"
+          cx="33"
+          cy="33"
+          fill="none"
+          r="30"
+        />
+      </svg>
+    </div>
+  </div>
+  <div
+    className="visually-hidden"
+    role="status"
+  >
+    Loading
   </div>
 </div>
 `;

--- a/src/button/Button.unit.tsx
+++ b/src/button/Button.unit.tsx
@@ -60,7 +60,7 @@ describe('Button', () => {
       </Button>,
     )
     expect(button.contains(<CrossIcon />)).toBe(false)
-    expect(button.text()).toEqual('')
+    expect(button.text().includes('blabla')).toBe(false)
   })
 
   it('Simulates a click action.', () => {
@@ -120,7 +120,7 @@ describe('Button', () => {
       </Button>,
     )
     expect(button.contains(<CrossIcon />)).toBe(false)
-    expect(button.text()).toEqual('')
+    expect(button.text().includes('blabla')).toBe(false)
   })
 
   describe('href', () => {

--- a/src/itemCheckbox/__snapshots__/ItemCheckbox.unit.tsx.snap
+++ b/src/itemCheckbox/__snapshots__/ItemCheckbox.unit.tsx.snap
@@ -369,6 +369,16 @@ exports[`ItemCheckbox Should display a Loader when the component is in loading s
   position: absolute;
 }
 
+.c2 .visually-hidden {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  white-space: nowrap;
+}
+
 .c2.kirk-loader--inline {
   display: inline-block;
 }
@@ -672,31 +682,42 @@ button:focus:not(.focus-visible).c0 {
       className="kirk-loader--inline c2"
     >
       <div
-        className=""
-        style={
-          Object {
-            "height": "24px",
-            "width": "24px",
-          }
-        }
+        aria-valuetext="Loading"
+        role="progressbar"
       >
-        <svg
-          aria-hidden={true}
-          className="kirk-icon kirk-icon-circle spinning c3 c4"
-          height={24}
-          viewBox="0 0 66 66"
-          width={24}
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          className=""
+          style={
+            Object {
+              "height": "24px",
+              "width": "24px",
+            }
+          }
         >
-          
-          <circle
-            className="outer"
-            cx="33"
-            cy="33"
-            fill="none"
-            r="30"
-          />
-        </svg>
+          <svg
+            aria-hidden={true}
+            className="kirk-icon kirk-icon-circle spinning c3 c4"
+            height={24}
+            viewBox="0 0 66 66"
+            width={24}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            
+            <circle
+              className="outer"
+              cx="33"
+              cy="33"
+              fill="none"
+              r="30"
+            />
+          </svg>
+        </div>
+      </div>
+      <div
+        className="visually-hidden"
+        role="status"
+      >
+        Loading
       </div>
     </div>
   </span>

--- a/src/itemChoice/__snapshots__/index.unit.tsx.snap
+++ b/src/itemChoice/__snapshots__/index.unit.tsx.snap
@@ -269,6 +269,16 @@ button:focus:not(.focus-visible).c0 {
   position: absolute;
 }
 
+.c3 .visually-hidden {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  white-space: nowrap;
+}
+
 .c3.kirk-loader--inline {
   display: inline-block;
 }
@@ -421,31 +431,42 @@ button:focus:not(.focus-visible).c0 {
       className="kirk-loader--inline c3"
     >
       <div
-        className=""
-        style={
-          Object {
-            "height": "24px",
-            "width": "24px",
-          }
-        }
+        aria-valuetext="Loading"
+        role="progressbar"
       >
-        <svg
-          aria-hidden={true}
-          className="kirk-icon kirk-icon-circle spinning c4 c5"
-          height={24}
-          viewBox="0 0 66 66"
-          width={24}
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          className=""
+          style={
+            Object {
+              "height": "24px",
+              "width": "24px",
+            }
+          }
         >
-          
-          <circle
-            className="outer"
-            cx="33"
-            cy="33"
-            fill="none"
-            r="30"
-          />
-        </svg>
+          <svg
+            aria-hidden={true}
+            className="kirk-icon kirk-icon-circle spinning c4 c5"
+            height={24}
+            viewBox="0 0 66 66"
+            width={24}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            
+            <circle
+              className="outer"
+              cx="33"
+              cy="33"
+              fill="none"
+              r="30"
+            />
+          </svg>
+        </div>
+      </div>
+      <div
+        className="visually-hidden"
+        role="status"
+      >
+        Loading
       </div>
     </div>
   </span>
@@ -710,6 +731,16 @@ button:focus:not(.focus-visible).c0 {
   animation: dash 0.5s cubic-bezier(0.65,0,0.45,1) forwards;
 }
 
+.c3 .visually-hidden {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  white-space: nowrap;
+}
+
 .c3.kirk-loader--inline {
   display: inline-block;
 }
@@ -862,32 +893,43 @@ button:focus:not(.focus-visible).c0 {
       className="kirk-loader--inline c3"
     >
       <div
-        className="kirk-loader--done"
-        style={
-          Object {
-            "height": "24px",
-            "width": "24px",
-          }
-        }
+        aria-valuetext="Loaded"
+        role="progressbar"
       >
-        <svg
-          aria-hidden={true}
-          className="kirk-icon kirk-icon-check validate c4 c5"
-          height={12}
-          viewBox="0 0 24 24"
-          width={12}
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          className="kirk-loader--done"
+          style={
+            Object {
+              "height": "24px",
+              "width": "24px",
+            }
+          }
         >
-          
-          <path
-            d="M6.5 12.5l4 4 8-8"
-            fill="none"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeMiterlimit="10"
-            strokeWidth="2"
-          />
-        </svg>
+          <svg
+            aria-hidden={true}
+            className="kirk-icon kirk-icon-check validate c4 c5"
+            height={12}
+            viewBox="0 0 24 24"
+            width={12}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            
+            <path
+              d="M6.5 12.5l4 4 8-8"
+              fill="none"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeMiterlimit="10"
+              strokeWidth="2"
+            />
+          </svg>
+        </div>
+      </div>
+      <div
+        className="visually-hidden"
+        role="status"
+      >
+        Loaded
       </div>
     </div>
   </span>

--- a/src/itemRadio/__snapshots__/ItemRadio.unit.tsx.snap
+++ b/src/itemRadio/__snapshots__/ItemRadio.unit.tsx.snap
@@ -570,6 +570,16 @@ button:focus:not(.focus-visible).c0 {
   position: absolute;
 }
 
+.c2 .visually-hidden {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  -webkit-clip: rect(1px,1px,1px,1px);
+  clip: rect(1px,1px,1px,1px);
+  white-space: nowrap;
+}
+
 .c2.kirk-loader--inline {
   display: inline-block;
 }
@@ -676,31 +686,42 @@ button:focus:not(.focus-visible).c0 {
       className="kirk-loader--inline c2"
     >
       <div
-        className=""
-        style={
-          Object {
-            "height": "24px",
-            "width": "24px",
-          }
-        }
+        aria-valuetext="Loading"
+        role="progressbar"
       >
-        <svg
-          aria-hidden={true}
-          className="kirk-icon kirk-icon-circle spinning c3 c4"
-          height={24}
-          viewBox="0 0 66 66"
-          width={24}
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          className=""
+          style={
+            Object {
+              "height": "24px",
+              "width": "24px",
+            }
+          }
         >
-          
-          <circle
-            className="outer"
-            cx="33"
-            cy="33"
-            fill="none"
-            r="30"
-          />
-        </svg>
+          <svg
+            aria-hidden={true}
+            className="kirk-icon kirk-icon-circle spinning c3 c4"
+            height={24}
+            viewBox="0 0 66 66"
+            width={24}
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            
+            <circle
+              className="outer"
+              cx="33"
+              cy="33"
+              fill="none"
+              r="30"
+            />
+          </svg>
+        </div>
+      </div>
+      <div
+        className="visually-hidden"
+        role="status"
+      >
+        Loading
       </div>
     </div>
   </span>

--- a/src/loader/Loader.style.tsx
+++ b/src/loader/Loader.style.tsx
@@ -3,6 +3,15 @@ import styled from 'styled-components'
 import { color } from '../_utils/branding'
 
 export const StyledLoader = styled.div`
+  & .visually-hidden {
+    position: absolute;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    clip: rect(1px, 1px, 1px, 1px);
+    white-space: nowrap;
+  }
+
   &.kirk-loader--inline {
     display: inline-block;
   }

--- a/src/loader/Loader.tsx
+++ b/src/loader/Loader.tsx
@@ -28,6 +28,8 @@ export interface LoaderProps {
   done?: boolean
   layoutMode?: LoaderLayoutMode
   onDoneAnimationEnd?: () => void
+  loadingAriaLabel?: string
+  loadedAriaLabel?: string
 }
 
 export class Loader extends PureComponent<LoaderProps> {
@@ -37,6 +39,8 @@ export class Loader extends PureComponent<LoaderProps> {
     size: 48,
     done: false,
     onDoneAnimationEnd() {},
+    loadingAriaLabel: 'Loading',
+    loadedAriaLabel: 'Loaded',
   }
 
   validate = () => {
@@ -80,17 +84,26 @@ export class Loader extends PureComponent<LoaderProps> {
   }
 
   render() {
-    const { className, size, done } = this.props
+    const { className, size, done, loadingAriaLabel, loadedAriaLabel } = this.props
     const iconSize = {
       width: `${size}px`,
       height: `${size}px`,
     }
-
+    const loaderStatusLabel = done ? loadedAriaLabel : loadingAriaLabel
     return (
       <StyledLoader className={cc([className, this.computeLayoutClass()])}>
-        <div className={cc([{ 'kirk-loader--done': done }])} style={iconSize}>
-          {!done && <CircleIcon iconColor={color.green} size={size} spinning />}
-          {done && <CheckIcon iconColor={color.white} size={size / 2} validate />}
+        <div role="progressbar" aria-valuetext={loaderStatusLabel}>
+          <div className={cc([{ 'kirk-loader--done': done }])} style={iconSize}>
+            {!done && <CircleIcon iconColor={color.green} size={size} spinning />}
+            {done && <CheckIcon iconColor={color.white} size={size / 2} validate />}
+          </div>
+        </div>
+        {/*
+          The progressbar role does not announce anything when changing state. We associate the
+          role='progressbar' with a role='status' to get loading state's announcements.
+        */}
+        <div className="visually-hidden" role="status">
+          {loaderStatusLabel}
         </div>
       </StyledLoader>
     )

--- a/src/loader/Loader.unit.tsx
+++ b/src/loader/Loader.unit.tsx
@@ -30,6 +30,16 @@ describe('Loader', () => {
     expect(wrapper.find('.kirk-loader--inline').exists()).toBe(true)
   })
 
+  it('Should use custom loading announcements', () => {
+    const wrapper = mount(<Loader loadingAriaLabel="localized custom loading" />)
+    expect(wrapper.text()).toBe('localized custom loading')
+  })
+
+  it('Should use custom loaded announcements', () => {
+    const wrapper = mount(<Loader done loadedAriaLabel="localized custom loaded" />)
+    expect(wrapper.text()).toBe('localized custom loaded')
+  })
+
   it('Should override layoutMode when inline prop is set', () => {
     const wrapper = mount(<Loader inline layoutMode={LoaderLayoutMode.BLOCK} />)
     expect(wrapper.find('.kirk-loader--inline').exists()).toBe(true)


### PR DESCRIPTION
Implement basic Loader a11y:
- add role progressbar on loader itself (it had no role before)
- use aria-valuetext for the progressbar with the default non-localized value: loading and loaded
- allow customization of these loading and loaded strings with 2 new optional props loadingAriaLabel and loadedAriaLabel
- Add a new non-visual role=status element to get announcements when the state changes (the progressbar does not do that).

It's only basic a11y since that will solve discoverability for screenreaders and tests (selection with a11y-based react testing lib queries).
Still needs to be done to be considered complete a11y-wise:
 - the state announcement should be done using some programmatic announcer instead of this role=status. That will allow us to get rid/factorize properly the 'visually-hidden' CSS class for instance and encourage people to announce their state if they have an easy to use tool.
 - a loader should mark some area in the page as aria-busy (probably using some callback mechanism, TBD)
 - when the loading resume, we should probably manage the focus in some cases (when the loader is fullscreen but maybe not when it's inline or block. Again we should probably use some callbacks to delegate this to the application, not the Loader itself).

TESTED=Unit tests
