### PR TITLE
Fixed stepper icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [...]
 - **[BREAKING CHANGE]** `Item`: `leftTitle` attribute can receive `string` or `node`
 - **[NEW]** Introducing `ItemBigData` component
+- **[FIX]** Use `stroke` for disabled icons
 - **[UPDATE]** `RideAxis` alignment polish: when text goes from 1 to 2 lines.
 - **[UPDATE]** `MessagingItemSummary` with `RideAxis`
 

--- a/src/_utils/icon/index.tsx
+++ b/src/_utils/icon/index.tsx
@@ -13,7 +13,7 @@ const StyledBaseIcon = styled(BaseIcon)`
   & polyline,
   & path,
   & g {
-    fill: ${props => (props.isDisabled ? color.gray : '')};
+    stroke: ${props => (props.isDisabled ? color.gray : '')};
   }
 
   &.kirk-icon-wrapper {


### PR DESCRIPTION
## Description

Reverting fill to stroke on disabled icons

## What has been done

Used stroke instead of fill

## Things to consider

Don't mind the spacing in screenshots, it's due to the screenshots themselves

## How it was tested

Storybook

Before:
![image](https://user-images.githubusercontent.com/1606624/86146302-580b1b00-baf8-11ea-952f-8d460dab258f.png)

After:
![image](https://user-images.githubusercontent.com/1606624/86146365-69542780-baf8-11ea-80fb-ce95e4ce58bf.png)

