### PR TITLE
Release/v35.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 
 - [...]
+
+# v35.0.0 (01/07/2020)
+
 - **[BREAKING CHANGE]** `Item`: `leftTitle` attribute can receive `string` or `node`
 - **[NEW]** Introducing `ItemBigData` component
 - **[FIX]** Use `stroke` for disabled icons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - **[BREAKING CHANGE]** `Item`: `leftTitle` attribute can receive `string` or `node`
 - **[NEW]** Introducing `ItemBigData` component
-- **[FIX]** Use `stroke` for disabled icons
+- **[FIX]** Use `stroke` for `disabled` icons
 - **[UPDATE]** `RideAxis` alignment polish: when text goes from 1 to 2 lines.
 - **[UPDATE]** `MessagingItemSummary` with `RideAxis`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "0.0.0-9b038c51",
+  "version": "0.0.0-517fafe7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "34.5.1",
+  "version": "0.0.0-517fafe7",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/_utils/rideAxis/index.tsx
+++ b/src/_utils/rideAxis/index.tsx
@@ -4,21 +4,16 @@ import styled from 'styled-components'
 import { ArrowIcon } from '../../icon'
 import { space } from '../branding'
 
-const StyledRideAxis = styled.span`
-  display: inline-flex;
-  align-items: self-start;
-
-  > span {
-    flex: 1;
-  }
-`
+const StyledRideAxis = styled.span``
 
 const StyledArrowIcon = styled(ArrowIcon)`
   & {
     display: inline-block;
+    /* hack: optical alignment since the icon isn't centered on the viewport */
+    padding: 0.1em 0 0;
     margin: 0 ${space.m};
-    height: 1em;
-    width: 1em;
+    height: 0.9em;
+    width: 0.9em;
     flex-shrink: 0;
     flex-grow: 0;
   }

--- a/src/messagingSummaryItem/index.tsx
+++ b/src/messagingSummaryItem/index.tsx
@@ -5,6 +5,8 @@ import { MessagingSummaryItem } from './MessagingSummaryItem'
 const StyledMessagingSummaryItem = styled(MessagingSummaryItem)`
   & .kirk-messaging-summary-item-sub-label {
     display: flex;
+    word-break: break-word;
+
     /* Truncate sublabel to max 2 lines. */
     max-height: 2.5em;
     overflow: hidden;

--- a/src/searchRecap/__snapshots__/SearchRecap.unit.tsx.snap
+++ b/src/searchRecap/__snapshots__/SearchRecap.unit.tsx.snap
@@ -22,27 +22,11 @@ exports[`searchRecap Should display searchRecap component 1`] = `
 }
 
 .c3 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-align-items: self-start;
-  -webkit-box-align: self-start;
-  -ms-flex-align: self-start;
-  align-items: self-start;
-}
-
-.c3 > span {
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-}
-
-.c4 {
   display: inline-block;
+  padding: 0.1em 0 0;
   margin: 0 8px;
-  height: 1em;
-  width: 1em;
+  height: 0.9em;
+  width: 0.9em;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
@@ -195,14 +179,14 @@ exports[`searchRecap Should display searchRecap component 1`] = `
         }
       >
         <span
-          className="c3"
+          className=""
         >
           <span>
             Middlesbrough
           </span>
           <svg
             aria-hidden={true}
-            className="kirk-icon c4 c1"
+            className="kirk-icon c3 c1"
             height={24}
             viewBox="0 0 24 24"
             width={24}


### PR DESCRIPTION
## Description

<!-- Give some context of this PR. Illustrate with screenshots or a video (gif, loom, etc.) -->

- **[BREAKING CHANGE]** `Item`: `leftTitle` attribute can receive `string` or `node`
- **[NEW]** Introducing `ItemBigData` component
- **[FIX]** Use `stroke` for disabled icons
- **[UPDATE]** `RideAxis` alignment polish: when text goes from 1 to 2 lines.
- **[UPDATE]** `MessagingItemSummary` with `RideAxis`
