### PR TITLE
Normalizing Item, TheVoice, Divider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- [...]
+- **[BREAKING CHANGE]** Added normalized horizontal padding/margin on `TheVoice`, `Divider`, all kind of `Item`
 
 # v36.0.0 (03/07/2020)
 

--- a/src/_internals/item/Item.tsx
+++ b/src/_internals/item/Item.tsx
@@ -5,6 +5,7 @@ import { color } from '../../_utils/branding'
 import { A11yProps, pickA11yProps } from '../../_utils/interfaces'
 import { Button } from '../../button/Button'
 import { ChevronIcon } from '../../icon/chevronIcon'
+import { NormalizeProps } from '../../layout/layoutNormalizer'
 import { Text, TextDisplayType, TextTagType } from '../../text'
 
 export enum ItemStatus {
@@ -13,7 +14,7 @@ export enum ItemStatus {
   CHECKED = 'checked',
 }
 
-export interface ItemProps extends A11yProps {
+export interface ItemProps extends A11yProps, NormalizeProps {
   readonly chevron?: boolean
   readonly className?: string
   readonly href?: string | JSX.Element

--- a/src/_internals/item/__snapshots__/Item.unit.tsx.snap
+++ b/src/_internals/item/__snapshots__/Item.unit.tsx.snap
@@ -87,12 +87,18 @@ exports[`Item Should not have changed 1`] = `
 }
 
 .c0 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.c0 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0;
   padding-top: 16px;
   padding-bottom: 16px;
   -webkit-align-items: center;

--- a/src/_internals/item/index.tsx
+++ b/src/_internals/item/index.tsx
@@ -1,13 +1,18 @@
 import styled from 'styled-components'
 
 import { color, space } from '../../_utils/branding'
+import { normalizeHorizontally } from '../../layout/layoutNormalizer'
 import { Item } from './Item'
 
 const StyledItem = styled(Item)`
+  /* HorizontalNormalization */
+  & {
+    ${normalizeHorizontally}
+  }
+
   & {
     position: relative;
     display: flex;
-    padding: 0;
     padding-top: ${space.l};
     padding-bottom: ${space.l};
     align-items: center;

--- a/src/_utils/branding.ts
+++ b/src/_utils/branding.ts
@@ -73,6 +73,12 @@ export const space: defaultBranding = {
   xxl: '48px',
 }
 
+export const horizontalSpace: defaultBranding = {
+  inner: '8px',
+  outer: '16px',
+  global: '24px',
+}
+
 export const radius: defaultBranding = {
   none: '0',
   s: '4px',

--- a/src/divider/Divider.tsx
+++ b/src/divider/Divider.tsx
@@ -3,28 +3,34 @@ import cc from 'classcat'
 import styled from 'styled-components'
 
 import { color, space } from '../_utils/branding'
+import { normalizeHorizontally, NormalizeProps } from '../layout/layoutNormalizer'
 
-export interface DividerProps {
+export interface DividerProps extends NormalizeProps {
   readonly className?: string
 }
 
 const StyledDivider = styled.div`
+  /* HorizontalNormalization */
   & {
-    // Height is used instead of margins to prevent collapsing margin issues with other
-    // margin-based components.
-    height: calc(2 * ${space.m});
-    position: relative;
+    ${normalizeHorizontally}
   }
 
-  &:after {
-    position: absolute;
-    top: ${space.m};
-    content: ' ';
-    border-top: solid ${color.lightGray} 1px;
-    width: 100%;
+  & {
+    /* Using padding to avoid collapsing margins with above and below components */
+    padding-top: ${space.m};
+    padding-bottom: ${space.m};
+  }
+
+  & > hr {
+    border: none;
+    background-color: ${color.lightGray};
+    height: 1px;
+    margin: 0;
   }
 `
 
 export const Divider = ({ className }: DividerProps) => (
-  <StyledDivider className={cc(className)} aria-hidden="true" />
+  <StyledDivider className={cc(className)} aria-hidden="true">
+    <hr />
+  </StyledDivider>
 )

--- a/src/itemAction/index.tsx
+++ b/src/itemAction/index.tsx
@@ -4,9 +4,10 @@ import cc from 'classcat'
 import { Item, ItemStatus } from '../_internals/item'
 import { prefix } from '../_utils'
 import { A11yProps, pickA11yProps } from '../_utils/interfaces'
+import { NormalizeProps } from '../layout/layoutNormalizer'
 import { Loader } from '../loader/Loader'
 
-export interface ItemActionProps extends A11yProps {
+export interface ItemActionProps extends A11yProps, NormalizeProps {
   readonly highlighted?: boolean
   readonly tag?: JSX.Element
   readonly className?: string
@@ -48,6 +49,7 @@ export class ItemAction extends PureComponent<ItemActionProps> {
       onMouseDown,
       onDoneAnimationEnd,
       hideHoverBackground = false,
+      hasHorizontalSpacing = false,
     } = this.props
     const a11yAttrs = pickA11yProps<ItemActionProps>(this.props)
 
@@ -91,6 +93,7 @@ export class ItemAction extends PureComponent<ItemActionProps> {
         tag={tag}
         isClickable
         hideHoverBackground={hideHoverBackground}
+        hasHorizontalSpacing={hasHorizontalSpacing}
         {...a11yAttrs}
       />
     )

--- a/src/itemBigData/index.tsx
+++ b/src/itemBigData/index.tsx
@@ -3,9 +3,10 @@ import styled from 'styled-components'
 
 import Item from '../_internals/item'
 import { A11yProps, pickA11yProps } from '../_utils/interfaces'
+import { NormalizeProps } from '../layout/layoutNormalizer'
 import { TextDisplay2 } from '../typography/display2'
 
-export interface ItemBigDataProps extends A11yProps {
+export interface ItemBigDataProps extends A11yProps, NormalizeProps {
   readonly mainInfo?: string
   readonly className?: string
   readonly mainTitle?: string
@@ -27,7 +28,7 @@ const StyledItemBigData = styled(Item)`
 `
 
 export const ItemBigData = (props: ItemBigDataProps) => {
-  const { mainInfo, className, mainTitle, tag, ariaLabel } = props
+  const { mainInfo, className, mainTitle, tag, ariaLabel, hasHorizontalSpacing = false } = props
   const a11yAttrs = pickA11yProps<ItemBigDataProps>(props)
 
   return (
@@ -37,6 +38,7 @@ export const ItemBigData = (props: ItemBigDataProps) => {
       leftBody={mainInfo}
       tag={tag}
       ariaLabel={ariaLabel}
+      hasHorizontalSpacing={hasHorizontalSpacing}
       {...a11yAttrs}
     />
   )

--- a/src/itemCheckbox/ItemCheckbox.tsx
+++ b/src/itemCheckbox/ItemCheckbox.tsx
@@ -5,6 +5,7 @@ import { CheckboxIcon } from '../_internals/checkboxIcon'
 import { Item } from '../_internals/item'
 import { OnChangeParameters } from '../_internals/onChange'
 import { A11yProps, pickA11yProps } from '../_utils/interfaces'
+import { NormalizeProps } from '../layout/layoutNormalizer'
 import { TextDisplayType } from '../text'
 
 export enum ItemCheckboxStatus {
@@ -12,7 +13,7 @@ export enum ItemCheckboxStatus {
   LOADING = 'loading',
 }
 
-export interface ItemCheckboxProps extends A11yProps {
+export interface ItemCheckboxProps extends A11yProps, NormalizeProps {
   readonly className?: string
   readonly name: string
   readonly leftAddon?: React.ReactNode
@@ -50,6 +51,7 @@ export class ItemCheckbox extends Component<ItemCheckboxProps> {
       checked,
       disabled,
       status,
+      hasHorizontalSpacing = false,
     } = this.props
     const a11yAttrs = pickA11yProps<ItemCheckboxProps>(this.props)
     const isLoading = status === ItemCheckboxStatus.LOADING
@@ -84,6 +86,7 @@ export class ItemCheckbox extends Component<ItemCheckboxProps> {
         rightAddon={checkbox}
         isClickable={!disabled}
         disabled={disabled}
+        hasHorizontalSpacing={hasHorizontalSpacing}
         {...a11yAttrs}
       />
     )

--- a/src/itemCheckbox/__snapshots__/ItemCheckbox.unit.tsx.snap
+++ b/src/itemCheckbox/__snapshots__/ItemCheckbox.unit.tsx.snap
@@ -87,12 +87,18 @@ exports[`ItemCheckbox Should display a CheckIcon when the input is checked 1`] =
 }
 
 .c0 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.c0 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0;
   padding-top: 16px;
   padding-bottom: 16px;
   -webkit-align-items: center;
@@ -382,12 +388,18 @@ exports[`ItemCheckbox Should display a Loader when the component is in loading s
 }
 
 .c0 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.c0 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0;
   padding-top: 16px;
   padding-bottom: 16px;
   -webkit-align-items: center;
@@ -758,12 +770,18 @@ exports[`ItemCheckbox Should forward its props to the Item component 1`] = `
 }
 
 .c0 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.c0 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0;
   padding-top: 16px;
   padding-bottom: 16px;
   -webkit-align-items: center;

--- a/src/itemChoice/__snapshots__/index.unit.tsx.snap
+++ b/src/itemChoice/__snapshots__/index.unit.tsx.snap
@@ -107,12 +107,18 @@ exports[`ItemChoice Should display a Loader when the component is in loading sta
 }
 
 .c0 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.c0 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0;
   padding-top: 16px;
   padding-bottom: 16px;
   -webkit-align-items: center;
@@ -553,12 +559,18 @@ exports[`ItemChoice Should display a done Loader when the component is in checke
 }
 
 .c0 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.c0 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0;
   padding-top: 16px;
   padding-bottom: 16px;
   -webkit-align-items: center;
@@ -969,12 +981,18 @@ exports[`ItemChoice Should forward its props to the Item component 1`] = `
 }
 
 .c0 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.c0 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0;
   padding-top: 16px;
   padding-bottom: 16px;
   -webkit-align-items: center;
@@ -1342,12 +1360,18 @@ exports[`ItemChoice Should support a disabled state 1`] = `
 }
 
 .c0 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.c0 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0;
   padding-top: 16px;
   padding-bottom: 16px;
   -webkit-align-items: center;
@@ -1697,12 +1721,18 @@ exports[`ItemChoice Should use a button tag if no href is given 1`] = `
 }
 
 .c0 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.c0 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0;
   padding-top: 16px;
   padding-bottom: 16px;
   -webkit-align-items: center;

--- a/src/itemChoice/index.tsx
+++ b/src/itemChoice/index.tsx
@@ -5,6 +5,7 @@ import { Item, ItemStatus } from '../_internals/item'
 import { color } from '../_utils/branding'
 import { FocusVisibleContext } from '../_utils/focusVisibleProvider'
 import { A11yProps, pickA11yProps } from '../_utils/interfaces'
+import { NormalizeProps } from '../layout/layoutNormalizer'
 import { Loader } from '../loader'
 import { TextDisplayType } from '../text'
 
@@ -16,7 +17,7 @@ export enum ItemChoiceStyle {
 
 export const ItemChoiceStatus = ItemStatus
 
-export interface ItemChoiceProps extends A11yProps {
+export interface ItemChoiceProps extends A11yProps, NormalizeProps {
   readonly label?: string
   readonly labelInfo?: React.ReactNode
   readonly data?: string
@@ -91,6 +92,7 @@ export class ItemChoice extends PureComponent<ItemChoiceProps> {
       disabled,
       ariaLabel,
       className,
+      hasHorizontalSpacing = false,
     } = this.props
     const a11yAttrs = pickA11yProps<ItemChoiceProps>(this.props)
     const isRecommended = style === ItemChoiceStyle.RECOMMENDED
@@ -128,6 +130,7 @@ export class ItemChoice extends PureComponent<ItemChoiceProps> {
             chevron={status === ItemStatus.DEFAULT}
             isClickable={!disabled}
             ariaLabel={ariaLabel}
+            hasHorizontalSpacing={hasHorizontalSpacing}
             {...a11yAttrs}
           />
         )}

--- a/src/itemData/index.tsx
+++ b/src/itemData/index.tsx
@@ -3,9 +3,10 @@ import React from 'react'
 import { Item } from '../_internals/item'
 import { A11yProps, pickA11yProps } from '../_utils/interfaces'
 import { Button } from '../button/Button'
+import { NormalizeProps } from '../layout/layoutNormalizer'
 import { TextDisplayType } from '../text'
 
-export interface ItemDataProps extends A11yProps {
+export interface ItemDataProps extends A11yProps, NormalizeProps {
   readonly data: string | JSX.Element
   readonly dataStrikeThrough?: boolean
   readonly dataAriaLabel?: string
@@ -32,6 +33,7 @@ export const ItemData = (props: ItemDataProps) => {
     tag,
     ariaLabel,
     disabled,
+    hasHorizontalSpacing = false,
   } = props
   const a11yAttrs = pickA11yProps<ItemDataProps>(props)
   return (
@@ -48,6 +50,7 @@ export const ItemData = (props: ItemDataProps) => {
       tag={tag}
       ariaLabel={ariaLabel}
       disabled={disabled}
+      hasHorizontalSpacing={hasHorizontalSpacing}
       {...a11yAttrs}
     />
   )

--- a/src/itemInfo/index.tsx
+++ b/src/itemInfo/index.tsx
@@ -2,8 +2,9 @@ import React from 'react'
 
 import { Item } from '../_internals/item'
 import { A11yProps, pickA11yProps } from '../_utils/interfaces'
+import { NormalizeProps } from '../layout/layoutNormalizer'
 
-export interface ItemInfoProps extends A11yProps {
+export interface ItemInfoProps extends A11yProps, NormalizeProps {
   readonly mainInfo?: string
   readonly className?: string
   readonly icon?: React.ReactNode
@@ -13,7 +14,15 @@ export interface ItemInfoProps extends A11yProps {
 }
 
 export const ItemInfo = (props: ItemInfoProps) => {
-  const { mainInfo, className, mainTitle, icon, tag, ariaLabel } = props
+  const {
+    mainInfo,
+    className,
+    mainTitle,
+    icon,
+    tag,
+    ariaLabel,
+    hasHorizontalSpacing = false,
+  } = props
   const a11yAttrs = pickA11yProps<ItemInfoProps>(props)
 
   return (
@@ -24,6 +33,7 @@ export const ItemInfo = (props: ItemInfoProps) => {
       leftAddon={icon}
       tag={tag}
       ariaLabel={ariaLabel}
+      hasHorizontalSpacing={hasHorizontalSpacing}
       {...a11yAttrs}
     />
   )

--- a/src/itemRadio/ItemRadio.tsx
+++ b/src/itemRadio/ItemRadio.tsx
@@ -5,6 +5,7 @@ import { Item } from '../_internals/item'
 import { OnChangeParameters } from '../_internals/onChange'
 import { RadioIcon } from '../_internals/radioIcon'
 import { A11yProps, pickA11yProps } from '../_utils/interfaces'
+import { NormalizeProps } from '../layout/layoutNormalizer'
 import { TextDisplayType } from '../text'
 
 export enum ItemRadioStatus {
@@ -12,7 +13,7 @@ export enum ItemRadioStatus {
   LOADING = 'loading',
 }
 
-export interface ItemRadioProps extends A11yProps {
+export interface ItemRadioProps extends A11yProps, NormalizeProps {
   readonly className?: string
   readonly name: string
   readonly value: string | number
@@ -79,6 +80,7 @@ export class ItemRadio extends Component<ItemRadioProps> {
       chevron,
       highlighted,
       leftAddon,
+      hasHorizontalSpacing = false,
     } = this.props
     const a11yAttrs = pickA11yProps<ItemRadioProps>(this.props)
     const isLoading = status === ItemRadioStatus.LOADING
@@ -122,6 +124,7 @@ export class ItemRadio extends Component<ItemRadioProps> {
           highlighted={highlighted}
           isClickable={!disabled}
           disabled={disabled}
+          hasHorizontalSpacing={hasHorizontalSpacing}
           {...a11yAttrs}
         />
       </Fragment>

--- a/src/itemRadio/__snapshots__/ItemRadio.unit.tsx.snap
+++ b/src/itemRadio/__snapshots__/ItemRadio.unit.tsx.snap
@@ -87,12 +87,18 @@ exports[`ItemRadio Should display a CircleIcon with an innerDisc when the input 
 }
 
 .c0 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.c0 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0;
   padding-top: 16px;
   padding-bottom: 16px;
   -webkit-align-items: center;
@@ -402,12 +408,18 @@ exports[`ItemRadio Should display a Loader when the component is in loading stat
 }
 
 .c0 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.c0 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0;
   padding-top: 16px;
   padding-bottom: 16px;
   -webkit-align-items: center;
@@ -782,12 +794,18 @@ exports[`ItemRadio Should forward its props to the Item component 1`] = `
 }
 
 .c0 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.c0 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0;
   padding-top: 16px;
   padding-bottom: 16px;
   -webkit-align-items: center;

--- a/src/itemRadio/index.tsx
+++ b/src/itemRadio/index.tsx
@@ -11,7 +11,7 @@ const StyledItemRadio = styled(ItemRadio)`
   & {
     cursor: ${props => (props.disabled ? 'default' : 'pointer')};
     border: ${inputBorderSize.focus} solid transparent;
-    padding: calc(${space.l} - ${inputBorderSize.focus}) 0;
+    padding: calc(${space.l} - ${inputBorderSize.focus}) auto;
   }
   &.focus {
     border: ${inputBorderSize.focus} solid ${color.blue};

--- a/src/itemRadioGroup/__snapshots__/index.unit.tsx.snap
+++ b/src/itemRadioGroup/__snapshots__/index.unit.tsx.snap
@@ -87,12 +87,18 @@ exports[`ItemRadioGroup Should map its children and render them with specific pr
 }
 
 .c2 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.c2 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0;
   padding-top: 16px;
   padding-bottom: 16px;
   -webkit-align-items: center;
@@ -252,7 +258,7 @@ button:focus:not(.focus-visible).c2 {
 .c1 {
   cursor: pointer;
   border: 3px solid transparent;
-  padding: calc(16px - 3px) 0;
+  padding: calc(16px - 3px) auto;
 }
 
 .c1.focus {

--- a/src/itemsList/__snapshots__/ItemsList.unit.tsx.snap
+++ b/src/itemsList/__snapshots__/ItemsList.unit.tsx.snap
@@ -87,12 +87,18 @@ exports[`ItemsList Should render an unordered list 1`] = `
 }
 
 .c1 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.c1 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0;
   padding-top: 16px;
   padding-bottom: 16px;
   -webkit-align-items: center;
@@ -455,12 +461,18 @@ exports[`ItemsList Should render an unordered list with some separators 1`] = `
 }
 
 .c1 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.c1 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0;
   padding-top: 16px;
   padding-bottom: 16px;
   -webkit-align-items: center;
@@ -575,16 +587,22 @@ button:focus:not(.focus-visible).c1 {
 }
 
 .c4 {
-  height: calc(2 * 8px);
-  position: relative;
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
 }
 
-.c4:after {
-  position: absolute;
-  top: 8px;
-  content: ' ';
-  border-top: solid #EDEDED 1px;
-  width: 100%;
+.c4 {
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.c4 > hr {
+  border: none;
+  background-color: #EDEDED;
+  height: 1px;
+  margin: 0;
 }
 
 .c0 {
@@ -700,7 +718,9 @@ button:focus:not(.focus-visible).c1 {
     <div
       aria-hidden="true"
       className="c4"
-    />
+    >
+      <hr />
+    </div>
   </li>
   <li
     className="kirk-items-list-item"
@@ -840,12 +860,18 @@ exports[`ItemsList Should render an unordered list with the separators classname
 }
 
 .c1 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.c1 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0;
   padding-top: 16px;
   padding-bottom: 16px;
   -webkit-align-items: center;
@@ -960,16 +986,22 @@ button:focus:not(.focus-visible).c1 {
 }
 
 .c4 {
-  height: calc(2 * 8px);
-  position: relative;
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
 }
 
-.c4:after {
-  position: absolute;
-  top: 8px;
-  content: ' ';
-  border-top: solid #EDEDED 1px;
-  width: 100%;
+.c4 {
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.c4 > hr {
+  border: none;
+  background-color: #EDEDED;
+  height: 1px;
+  margin: 0;
 }
 
 .c0 {
@@ -1037,7 +1069,9 @@ button:focus:not(.focus-visible).c1 {
     <div
       aria-hidden="true"
       className="c4"
-    />
+    >
+      <hr />
+    </div>
   </li>
   <li
     className="kirk-items-list-item"
@@ -1089,7 +1123,9 @@ button:focus:not(.focus-visible).c1 {
     <div
       aria-hidden="true"
       className="c4"
-    />
+    >
+      <hr />
+    </div>
   </li>
   <li
     className="kirk-items-list-item"

--- a/src/layout/layoutNormalizer.tsx
+++ b/src/layout/layoutNormalizer.tsx
@@ -1,20 +1,30 @@
 import React from 'react'
 import { createGlobalStyle } from 'styled-components'
 
+import { horizontalSpace } from '../_utils/branding'
+
+const horizontalPadding = (props: any): string =>
+  props.hasHorizontalSpacing ? horizontalSpace.inner : horizontalSpace.global
+
+const horizontalMargin = (props: any): string | number =>
+  props.hasHorizontalSpacing ? horizontalSpace.outer : 0
+
+export interface NormalizeProps {
+  readonly hasHorizontalSpacing?: boolean
+}
+/**
+ * Util method to normalize horizontal spacing
+ * using !important because this should never be overridden
+ */
+export const normalizeHorizontally = (props: NormalizeProps): string => `
+  padding-left: ${horizontalPadding(props)} !important;
+  padding-right: ${horizontalPadding(props)} !important;
+  margin-left: ${horizontalMargin(props)} !important;
+  margin-right: ${horizontalMargin(props)} !important;
+  `
+
 // Legacy layout rules from production BBC.
 const LegacyLayoutNormalizationGlobalStyles = createGlobalStyle`
-    /* Items negative margins from legacy layouts. */
-    .kirk-item.kirk-item--clickable {
-        margin-left: -24px;
-        margin-right: -24px;
-        padding-left: 24px;
-        padding-right: 24px;
-    }
-
-    button.kirk-item.kirk-item--clickable {
-        width: calc(100% + 48px); /* fixes button width not scaling with negative margins */
-    }
-
     .home-column .kirk-item.kirk-item--clickable,
     .user-menu-item.kirk-item.kirk-item--clickable {
         margin-left: 0;

--- a/src/layout/section/baseSection/baseSection.tsx
+++ b/src/layout/section/baseSection/baseSection.tsx
@@ -14,6 +14,7 @@ export interface BaseSectionProps {
   readonly role?: string
   readonly children: JSX.Element | string | React.ReactNode
   readonly contentSize?: SectionContentSize
+  readonly noHorizontalSpacing?: boolean
 }
 
 /**

--- a/src/layout/section/baseSection/index.tsx
+++ b/src/layout/section/baseSection/index.tsx
@@ -1,12 +1,12 @@
 import styled from 'styled-components'
 
-import { componentSizes, responsiveBreakpoints, space } from '../../../_utils/branding'
+import { componentSizes, horizontalSpace, responsiveBreakpoints } from '../../../_utils/branding'
 import { BaseSection } from './baseSection'
 
 const StyledBaseSection = styled(BaseSection)`
   & .section-content {
-    padding-left: ${space.xl};
-    padding-right: ${space.xl};
+    padding-left: ${props => (props.noHorizontalSpacing ? 0 : horizontalSpace.global)};
+    padding-right: ${props => (props.noHorizontalSpacing ? 0 : horizontalSpace.global)};
   }
 
   @media (${responsiveBreakpoints.isMediaLarge}) {

--- a/src/layout/section/illustratedSection/__snapshots__/index.unit.tsx.snap
+++ b/src/layout/section/illustratedSection/__snapshots__/index.unit.tsx.snap
@@ -88,8 +88,8 @@ exports[`IllustratedSection should render an IllustratedSection section with an 
 }
 
 .c1 .section-content {
-  padding-left: 24px;
-  padding-right: 24px;
+  padding-left: 0;
+  padding-right: 0;
 }
 
 .c0 .section-content {
@@ -103,8 +103,6 @@ exports[`IllustratedSection should render an IllustratedSection section with an 
 }
 
 .c0 .kirk-illustratedSection-illustration {
-  margin-left: -24px;
-  margin-right: -24px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -188,8 +186,8 @@ exports[`IllustratedSection should render an IllustratedSection section with an 
 
 exports[`IllustratedSection should render default IllustratedSection section 1`] = `
 .c1 .section-content {
-  padding-left: 24px;
-  padding-right: 24px;
+  padding-left: 0;
+  padding-right: 0;
 }
 
 .c0 .section-content {
@@ -203,8 +201,6 @@ exports[`IllustratedSection should render default IllustratedSection section 1`]
 }
 
 .c0 .kirk-illustratedSection-illustration {
-  margin-left: -24px;
-  margin-right: -24px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/src/layout/section/illustratedSection/illustratedSection.tsx
+++ b/src/layout/section/illustratedSection/illustratedSection.tsx
@@ -24,7 +24,12 @@ export const IllustratedSection: React.SFC<IllustratedSectionProps> = (
     <Avatar image={illustrationUrl} alt={illustrationAlt} isLarge />
   )
   return (
-    <BaseSection tagName="article" className={className} contentSize={SectionContentSize.LARGE}>
+    <BaseSection
+      tagName="article"
+      className={className}
+      contentSize={SectionContentSize.LARGE}
+      noHorizontalSpacing
+    >
       <div className="kirk-illustratedSection-illustration">{illu}</div>
       <div className="kirk-illustratedSection-content">{props.children}</div>
     </BaseSection>

--- a/src/layout/section/illustratedSection/index.tsx
+++ b/src/layout/section/illustratedSection/index.tsx
@@ -10,8 +10,6 @@ const StyledIllustratedSection = styled(IllustratedSection)`
   }
 
   & .kirk-illustratedSection-illustration {
-    margin-left: -${space.xl};
-    margin-right: -${space.xl};
     display: flex;
     flex-direction: row;
     justify-content: center;

--- a/src/layout/section/itemsSection/__snapshots__/index.unit.tsx.snap
+++ b/src/layout/section/itemsSection/__snapshots__/index.unit.tsx.snap
@@ -67,12 +67,18 @@ exports[`ItemsSection should render default items section 1`] = `
 }
 
 .c2 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.c2 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0;
   padding-top: 16px;
   padding-bottom: 16px;
   -webkit-align-items: center;
@@ -324,12 +330,18 @@ exports[`ItemsSection should render non-default items section 1`] = `
 }
 
 .c2 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.c2 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0;
   padding-top: 16px;
   padding-bottom: 16px;
   -webkit-align-items: center;

--- a/src/layout/section/tabsSection/__snapshots__/index.unit.tsx.snap
+++ b/src/layout/section/tabsSection/__snapshots__/index.unit.tsx.snap
@@ -138,15 +138,7 @@ exports[`TabsSection should render default TabsSection 1`] = `
   transition-timing-function: ease-in-out;
 }
 
-@media (max-width:799px) {
-  .c0 .kirk-panels-section {
-    padding-left: 24px;
-    padding-right: 24px;
-  }
-}
-
 @media (min-width:800px) {
-  .c0 .kirk-panels-section,
   .c0 .kirk-tablist-wrapper {
     width: calc(662px - 2 * 24px);
     margin: 0 auto;

--- a/src/layout/section/tabsSection/index.tsx
+++ b/src/layout/section/tabsSection/index.tsx
@@ -4,15 +4,7 @@ import { componentSizes, responsiveBreakpoints, space } from '../../../_utils/br
 import { TabsSection } from './tabsSection'
 
 const StyledTabsSection = styled(TabsSection)`
-  @media (${responsiveBreakpoints.isMediaSmall}) {
-    & .kirk-panels-section {
-      padding-left: ${space.xl};
-      padding-right: ${space.xl};
-    }
-  }
-
   @media (${responsiveBreakpoints.isMediaLarge}) {
-    & .kirk-panels-section,
     & .kirk-tablist-wrapper {
       width: calc(${componentSizes.smallSectionWidth} - 2 * ${space.xl});
       margin: 0 auto;

--- a/src/layout/section/tabsSection/story.tsx
+++ b/src/layout/section/tabsSection/story.tsx
@@ -1,18 +1,20 @@
 import React from 'react'
 import { action } from '@storybook/addon-actions'
-import { boolean, select, text, withKnobs } from '@storybook/addon-knobs'
+import { select, text, withKnobs } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 
 import { Button } from '../../../button'
+import ItemAction from '../../../itemAction'
 import { TabStatus } from '../../../tabs'
+import { BaseSection } from '../baseSection'
 import { TabsSection } from './index'
 
 const stories = storiesOf('Sections|TabsSection', module)
 stories.addDecorator(withKnobs)
 
 const panels = [
-  <div>Content for first tab</div>,
-  <div>
+  <BaseSection>Content for first tab</BaseSection>,
+  <BaseSection>
     <Button
       onClick={() => {
         action('onClickButton')
@@ -20,14 +22,15 @@ const panels = [
     >
       Button inside panel 2.
     </Button>
-  </div>,
-  <div>Content for tab3</div>,
+  </BaseSection>,
+  <BaseSection noHorizontalSpacing>
+    <ItemAction subLabel="Hello" />
+  </BaseSection>,
 ]
 
 const tabs = {
   activeTabId: 'tab1',
   status: select('status', TabStatus, TabStatus.FIXED),
-  isWrapped: boolean('isWrapped', false),
   tabs: [
     {
       id: 'tab1',

--- a/src/messagingSummaryItem/MessagingSummaryItem.tsx
+++ b/src/messagingSummaryItem/MessagingSummaryItem.tsx
@@ -4,9 +4,10 @@ import cc from 'classcat'
 import { Item } from '../_internals/item'
 import { color } from '../_utils/branding'
 import { Avatar } from '../avatar'
+import { NormalizeProps } from '../layout/layoutNormalizer'
 import { TextDisplayType } from '../text'
 
-export interface MessagingSummaryItemProps {
+export interface MessagingSummaryItemProps extends NormalizeProps {
   readonly className?: string
   readonly url: string
   readonly pictureUrl: string
@@ -31,6 +32,7 @@ export const MessagingSummaryItem = ({
   subLabel,
   timeLabel,
   hasUnreadMessages,
+  hasHorizontalSpacing = false,
 }: MessagingSummaryItemProps) => (
   <Fragment>
     <Item
@@ -47,6 +49,7 @@ export const MessagingSummaryItem = ({
       chevron
       href={url}
       isClickable
+      hasHorizontalSpacing={hasHorizontalSpacing}
     />
   </Fragment>
 )

--- a/src/messagingSummaryItem/__snapshots__/MessagingSummaryItem.unit.tsx.snap
+++ b/src/messagingSummaryItem/__snapshots__/MessagingSummaryItem.unit.tsx.snap
@@ -87,12 +87,18 @@ exports[`Should render properly with read messages 1`] = `
 }
 
 .c0 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.c0 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0;
   padding-top: 16px;
   padding-bottom: 16px;
   -webkit-align-items: center;
@@ -454,12 +460,18 @@ exports[`Should render properly with unread messages 1`] = `
 }
 
 .c0 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.c0 {
   position: relative;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0;
   padding-top: 16px;
   padding-bottom: 16px;
   -webkit-align-items: center;

--- a/src/pages/messaging/inbox.story.tsx
+++ b/src/pages/messaging/inbox.story.tsx
@@ -29,14 +29,16 @@ const notificationConfig = {
 }
 
 const panel1 = (
-  <ul>
-    <MessagingSummaryItem {...messagingSummaryItemConfig} />
-    <MessagingSummaryItem {...messagingSummaryItemConfig} />
-    <MessagingSummaryItem {...messagingSummaryItemConfig} />
-    <MessagingSummaryItem {...messagingSummaryItemConfig} />
-    <MessagingSummaryItem {...messagingSummaryItemConfig} />
-    <MessagingSummaryItem {...messagingSummaryItemConfig} />
-  </ul>
+  <Section noHorizontalSpacing>
+    <ul>
+      <MessagingSummaryItem {...messagingSummaryItemConfig} />
+      <MessagingSummaryItem {...messagingSummaryItemConfig} />
+      <MessagingSummaryItem {...messagingSummaryItemConfig} />
+      <MessagingSummaryItem {...messagingSummaryItemConfig} />
+      <MessagingSummaryItem {...messagingSummaryItemConfig} />
+      <MessagingSummaryItem {...messagingSummaryItemConfig} />
+    </ul>
+  </Section>
 )
 
 const panel2 = (

--- a/src/pages/ridedetails/carpool.story.tsx
+++ b/src/pages/ridedetails/carpool.story.tsx
@@ -47,6 +47,8 @@ stories.add('Default', () => (
         ]}
         small={false}
       />
+    </Section>
+    <Section noHorizontalSpacing>
       <ItemData data="17,50 €" mainInfo="Prix total pour 1 passager" />
       <Divider />
       <ItemChoice label="Vince" rightAddon={<Avatar />} href="#" />
@@ -61,7 +63,11 @@ stories.add('Default', () => (
         <ItemInfo mainInfo="Pas d'animaux dans la voiture." icon={<PetIcon />} />
       </ul>
       <Divider />
+    </Section>
+    <Section>
       <SubHeader>Passagers</SubHeader>
+    </Section>
+    <Section noHorizontalSpacing>
       <ul>
         <ItemChoice
           label="Jessica"

--- a/src/theVoice/index.tsx
+++ b/src/theVoice/index.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
 
 import { color, responsiveBreakpoints, space } from '../_utils/branding'
+import { normalizeHorizontally } from '../layout/layoutNormalizer'
 import { TheVoice } from './TheVoice'
 
 const StyledTheVoice = styled(TheVoice)`
@@ -14,6 +15,8 @@ const StyledTheVoice = styled(TheVoice)`
   padding: ${space.xl} 0 var(--space-bottom);
   color: ${props => (props.isInverted ? color.white : '')};
   white-space: pre-line;
+
+  ${normalizeHorizontally};
 
   @media (${responsiveBreakpoints.isMediaLarge}) {
     text-align: center;


### PR DESCRIPTION
## Description
Normalized horizontally `Item`, `Divider`, and `TheVoice` component.

## What has been done
- Adding 24px horizontally differently when Item is in the page or Item is in a Section or Card
- Simplified the Divider and use semantic tag `hr`, the use of absolute positioning was breaking the spacing.
- Adding `noHorizontalSpacing` optional on `Section`
- Updated `Item*` with the new `hasHorizontalSpacing` prop

## Things to consider

Trying to break the less possible things by using explicit rules padding-left/right and margin-left/right so that the changes don't apply to the vertical spacing.

On ride details view: 
- Keep existing `Section` for children that have not been normalized.
- Update `Section` with a new `noHorizontalSpacing` prop so that the section padding does not apply.

This is the approach I found the less risky, we can work iteratively component by component. That way having normalized components and not-normalized components in the same page is not an issue.
See https://github.com/blablacar/ui-library/pull/777/files#diff-4db8d39277f2b246fb53549b429444de
 
## How it was tested

Storybook 

![image](https://user-images.githubusercontent.com/1606624/86257195-8a308180-bbb9-11ea-9da4-97dcd9cd7ea9.png)
