### PR TITLE
Release/v36.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Unreleased
 
-- **[BREAKING CHANGE]** Move non API components in an `_internal` folder
 - [...]
+
+# v36.0.0 (03/07/2020)
+
+- **[BREAKING CHANGE]** Move non API components from `_utils` to `_internal` folder
 
 # v35.0.0 (01/07/2020)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "35.0.0",
+  "version": "36.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "35.0.0",
+  "version": "36.0.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# v36.0.0 (03/07/2020)

- **[BREAKING CHANGE]** Move non API components from `_utils` to `_internal` folder
