### PR TITLE
FIX exports to avoid breaking change

### DIFF
--- a/src/buttonGroup/ButtonGroup.style.tsx
+++ b/src/buttonGroup/ButtonGroup.style.tsx
@@ -1,0 +1,52 @@
+import styled from 'styled-components'
+
+import { space } from '../_utils/branding'
+
+export const StyledButtonGroup = styled.div`
+  & {
+    display: flex;
+  }
+
+  &.kirk-button-group-column {
+    flex-direction: column;
+  }
+  &.kirk-button-group-column .kirk-button {
+    justify-content: center;
+  }
+  &.kirk-button-group-column > .kirk-button + .kirk-button {
+    margin-top: ${space.m};
+  }
+  &.kirk-button-group-column > .kirk-button.kirk-button-loading,
+  &.kirk-button-group-column > .kirk-button.kirk-button-checked {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  &.kirk-button-group-column.kirk-button-group-reverse {
+    flex-direction: column-reverse;
+  }
+  &.kirk-button-group-column.kirk-button-group-reverse > .kirk-button + .kirk-button {
+    margin-bottom: ${space.m};
+    margin-top: 0;
+  }
+
+  &.kirk-button-group-row {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+  &.kirk-button-group-row > .kirk-button {
+    flex-grow: 1;
+    justify-content: center;
+  }
+  &.kirk-button-group-row > .kirk-button + .kirk-button {
+    margin-left: ${space.l};
+  }
+
+  &.kirk-button-group-row.kirk-button-group-reverse {
+    flex-direction: row-reverse;
+  }
+  &.kirk-button-group-row.kirk-button-group-reverse > .kirk-button + .kirk-button {
+    margin-right: ${space.l};
+    margin-left: 0;
+  }
+`

--- a/src/buttonGroup/ButtonGroup.tsx
+++ b/src/buttonGroup/ButtonGroup.tsx
@@ -1,10 +1,9 @@
 import React, { cloneElement } from 'react'
 import cc from 'classcat'
-import styled from 'styled-components'
 
 import { prefix } from '../_utils'
-import { space } from '../_utils/branding'
 import { ButtonProps, ButtonStatus } from '../button'
+import { StyledButtonGroup } from './ButtonGroup.style'
 
 export interface ButtonGroupProps {
   readonly children: React.ReactElement<ButtonProps>[]
@@ -13,55 +12,6 @@ export interface ButtonGroupProps {
   readonly isReverse?: boolean
   readonly loadingIndex?: string
 }
-
-const StyledButtonGroup = styled.div`
-  & {
-    display: flex;
-  }
-
-  &.kirk-button-group-column {
-    flex-direction: column;
-  }
-  &.kirk-button-group-column .kirk-button {
-    justify-content: center;
-  }
-  &.kirk-button-group-column > .kirk-button + .kirk-button {
-    margin-top: ${space.m};
-  }
-  &.kirk-button-group-column > .kirk-button.kirk-button-loading,
-  &.kirk-button-group-column > .kirk-button.kirk-button-checked {
-    margin-left: auto;
-    margin-right: auto;
-  }
-
-  &.kirk-button-group-column.kirk-button-group-reverse {
-    flex-direction: column-reverse;
-  }
-  &.kirk-button-group-column.kirk-button-group-reverse > .kirk-button + .kirk-button {
-    margin-bottom: ${space.m};
-    margin-top: 0;
-  }
-
-  &.kirk-button-group-row {
-    flex-direction: row;
-    justify-content: space-between;
-  }
-  &.kirk-button-group-row > .kirk-button {
-    flex-grow: 1;
-    justify-content: center;
-  }
-  &.kirk-button-group-row > .kirk-button + .kirk-button {
-    margin-left: ${space.l};
-  }
-
-  &.kirk-button-group-row.kirk-button-group-reverse {
-    flex-direction: row-reverse;
-  }
-  &.kirk-button-group-row.kirk-button-group-reverse > .kirk-button + .kirk-button {
-    margin-right: ${space.l};
-    margin-left: 0;
-  }
-`
 
 const BASE_CLASSNAME = 'button-group'
 

--- a/src/buttonGroup/index.tsx
+++ b/src/buttonGroup/index.tsx
@@ -1,1 +1,2 @@
 export { ButtonGroup, ButtonGroupProps } from './ButtonGroup'
+export { ButtonGroup as default } from './ButtonGroup'

--- a/src/disclaimer/index.tsx
+++ b/src/disclaimer/index.tsx
@@ -1,1 +1,2 @@
 export { Disclaimer, DisclaimerProps } from './Disclaimer'
+export { Disclaimer as default } from './Disclaimer'

--- a/src/divider/index.tsx
+++ b/src/divider/index.tsx
@@ -1,1 +1,2 @@
 export { Divider, DividerProps } from './Divider'
+export { Divider as default } from './Divider'

--- a/src/emptyState/index.tsx
+++ b/src/emptyState/index.tsx
@@ -1,1 +1,2 @@
 export { EmptyState, EmptyStateProps } from './EmptyState'
+export { EmptyState as default } from './EmptyState'


### PR DESCRIPTION
## Description

<!-- Give some context of this PR. Illustrate with screenshots or a video (gif, loom, etc.) -->

- Export components as **Default** to  avoid breaking changes on BBC App

 

## What has been done

<!-- How do you solve the problem? -->

- [Boyscout] Move ButtonGroup style to another file

## Things to consider

<!-- Explain your changes. What are you expecting for the reviewers? -->

## How it was tested

<!-- Local environment with ui-library only, integrated within the main project, on which browsers, etc. -->
- canary
