### PR TITLE
add SearchForm props initialFrom initialTo disabledFrom disabledTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[UPDATE]** Add `initialFrom`, `initialTo`, `disabledFrom`, `disabledTo` props in `SearchForm` component
 - **[UPDATE]** Added `secondLine` prop on Tabs config
 
 # v37.0.0 (10/07/2020)

--- a/src/searchForm/SearchForm.tsx
+++ b/src/searchForm/SearchForm.tsx
@@ -29,6 +29,10 @@ import { TRANSITION_SECTION_CLASS_NAME, transitionSectionTimeout } from './trans
 export interface SearchFormProps {
   className?: string
   onSubmit: (formValues: SearchFormValues) => void
+  disabledFrom?: boolean
+  disabledTo?: boolean
+  initialFrom?: string
+  initialTo?: string
   autocompleteFromPlaceholder: AutoCompleteProps['placeholder']
   autocompleteToPlaceholder: AutoCompleteProps['placeholder']
   renderAutocompleteFrom: AutoCompleteOverlayProps['renderAutocompleteComponent']
@@ -68,9 +72,28 @@ export type SearchFormValues = {
   AUTOCOMPLETE_TO?: AutocompleteOnChange
 }
 
+const getPlaceholderText = (
+  initial: string,
+  autocompleted: string,
+  placeholder: string,
+): string => {
+  if (autocompleted) {
+    return autocompleted
+  }
+  if (initial) {
+    return initial
+  }
+
+  return placeholder
+}
+
 export const SearchForm = ({
   className,
   onSubmit,
+  initialFrom,
+  initialTo,
+  disabledFrom,
+  disabledTo,
   autocompleteFromPlaceholder,
   autocompleteToPlaceholder,
   renderAutocompleteFrom,
@@ -238,6 +261,7 @@ export const SearchForm = ({
               type="button"
               className="kirk-search-button"
               onClick={() => setElementOpened(SearchFormElements.AUTOCOMPLETE_FROM)}
+              disabled={disabledFrom}
             >
               <span className="kirk-bullet--searchForm">
                 <Bullet type={BulletTypes.SEARCH} />
@@ -245,10 +269,14 @@ export const SearchForm = ({
               <TextTitle
                 className={cc([
                   'kirk-search-ellipsis',
-                  { 'kirk-search-placeholder': !autocompleteFromValue },
+                  { 'kirk-search-placeholder': !autocompleteFromValue && !initialFrom },
                 ])}
               >
-                {autocompleteFromValue?.item.label || autocompleteFromPlaceholder}
+                {getPlaceholderText(
+                  initialFrom,
+                  autocompleteFromValue?.item.label,
+                  autocompleteFromPlaceholder,
+                )}
               </TextTitle>
             </button>
           </SlideSwitchTransition>
@@ -304,6 +332,7 @@ export const SearchForm = ({
             type="button"
             className="kirk-search-button"
             onClick={() => setElementOpened(SearchFormElements.AUTOCOMPLETE_TO)}
+            disabled={disabledTo}
           >
             <span className="kirk-bullet--searchForm">
               <Bullet type={BulletTypes.SEARCH} />
@@ -311,10 +340,14 @@ export const SearchForm = ({
             <TextTitle
               className={cc([
                 'kirk-search-ellipsis',
-                { 'kirk-search-placeholder': !autocompleteToValue },
+                { 'kirk-search-placeholder': !autocompleteToValue && !initialTo },
               ])}
             >
-              {autocompleteToValue?.item.label || autocompleteToPlaceholder}
+              {getPlaceholderText(
+                initialTo,
+                autocompleteToValue?.item.label,
+                autocompleteToPlaceholder,
+              )}
             </TextTitle>
           </button>
         </SlideSwitchTransition>

--- a/src/searchForm/SearchForm.unit.tsx
+++ b/src/searchForm/SearchForm.unit.tsx
@@ -37,6 +37,18 @@ const defaultProps: SearchFormProps = {
   },
 }
 
+const withInitialFromTo: SearchFormProps = {
+  ...defaultProps,
+  initialFrom: 'Avignon',
+  initialTo: 'Marseille',
+}
+
+const withDisabledFromTo: SearchFormProps = {
+  ...defaultProps,
+  disabledFrom: true,
+  disabledTo: true,
+}
+
 describe('searchForm', () => {
   let wrapper
   const fakeEvent = { e: { relatedTarget: null } }
@@ -97,6 +109,26 @@ describe('searchForm', () => {
         expect(wrapper.find(StepperOverlay).exists()).toBe(false)
         wrapper.find('.kirk-searchForm-seats > .kirk-search-button').simulate('click')
         expect(wrapper.find(StepperOverlay).exists()).toBe(true)
+      })
+
+      it('should have initial values for From & To', () => {
+        const wrapperWithInitialValues = mount(<SearchForm {...withInitialFromTo} />)
+        expect(wrapperWithInitialValues.find('.kirk-searchForm-from').text()).toBe('Avignon')
+        expect(wrapperWithInitialValues.find('.kirk-searchForm-to').text()).toBe('Marseille')
+      })
+
+      it('should have disabled fields From & To', () => {
+        const wrapperWithDisabledValues = mount(<SearchForm {...withDisabledFromTo} />)
+        expect(
+          wrapperWithDisabledValues
+            .find('.kirk-searchForm-from .kirk-search-button')
+            .prop('disabled'),
+        ).toBe(true)
+        expect(
+          wrapperWithDisabledValues
+            .find('.kirk-searchForm-to .kirk-search-button')
+            .prop('disabled'),
+        ).toBe(true)
       })
     })
 
@@ -167,6 +199,26 @@ describe('searchForm', () => {
             .find(CSSTransition)
             .at(3)
             .prop('in'),
+        ).toBe(true)
+      })
+
+      it('should have initial values for From & To', () => {
+        const wrapperWithInitialValues = mount(<SearchForm {...withInitialFromTo} />)
+        expect(wrapperWithInitialValues.find('.kirk-searchForm-from').text()).toBe('Avignon')
+        expect(wrapperWithInitialValues.find('.kirk-searchForm-to').text()).toBe('Marseille')
+      })
+
+      it('should have disabled fields From & To', () => {
+        const wrapperWithDisabledValues = mount(<SearchForm {...withDisabledFromTo} />)
+        expect(
+          wrapperWithDisabledValues
+            .find('.kirk-searchForm-from .kirk-search-button')
+            .prop('disabled'),
+        ).toBe(true)
+        expect(
+          wrapperWithDisabledValues
+            .find('.kirk-searchForm-to .kirk-search-button')
+            .prop('disabled'),
         ).toBe(true)
       })
     })

--- a/src/searchForm/index.tsx
+++ b/src/searchForm/index.tsx
@@ -96,6 +96,10 @@ const StyledSearchForm = styled(SearchForm)`
     & > *:not(:first-child) {
       margin-left: ${space.m};
     }
+
+    &:disabled {
+      cursor: default;
+    }
   }
 
   & .kirk-searchForm-from .kirk-search-button,

--- a/src/searchForm/story.tsx
+++ b/src/searchForm/story.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { text, withKnobs } from '@storybook/addon-knobs'
+import { boolean, text, withKnobs } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 
 import { TransitionDuration } from '../_utils/branding'
@@ -86,6 +86,10 @@ stories.add(
       <BaseSection contentSize={SectionContentSize.LARGE}>
         <SearchForm
           onSubmit={() => {}}
+          initialFrom={text('initialFrom')}
+          initialTo={text('initialTo')}
+          disabledFrom={boolean('disabledFrom', false)}
+          disabledTo={boolean('disabledTo', false)}
           autocompleteFromPlaceholder={text('autocompleteFromPlaceholder', 'Leaving From')}
           autocompleteToPlaceholder={text('autocompleteToPlaceholder', 'Going to')}
           renderAutocompleteFrom={props => (


### PR DESCRIPTION
## Description

Add `initialFrom` and `initialTo` to prefill the form. The values are placed instead of the placeholder.
Add `disabledFrom` and `disabledTo` to disable From and To inputs. It is not clear if we'll use it but it's a safe move in case we want to protect the initial values.

With `initialFrom` = "Grenoble" (and `disabledTo` set to true but it doesn't show)
![Screen Shot 2020-07-20 at 17 39 10](https://user-images.githubusercontent.com/373381/87957743-f1eb3580-cab0-11ea-94d8-b63b516222c8.png)

## Things to consider

I didn't change the story to MDX yet. The original story has a case for each component of the Search Form so I'd rather separate the update in another PR.

## How it was tested

Tested locally on Firefox within the main project.
