### PR TITLE
add missing props exports in several Item components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [...]
 
+- **[FIX]** Missing props exports in index file for `ItemAction`, `ItemBigData`, `ItemData`, `ItemEditableInfo`
+
 # v37.1.0 (22/07/2020)
 
 - **[UPDATE]** Add `initialFrom`, `initialTo`, `disabledFrom`, `disabledTo` props in `SearchForm` component

--- a/src/itemAction/index.tsx
+++ b/src/itemAction/index.tsx
@@ -1,2 +1,2 @@
-export { ItemAction } from './ItemAction'
+export { ItemAction, ItemActionProps } from './ItemAction'
 export { ItemAction as default } from './ItemAction'

--- a/src/itemBigData/index.tsx
+++ b/src/itemBigData/index.tsx
@@ -1,2 +1,2 @@
-export { ItemBigData } from './ItemBigData'
+export { ItemBigData, ItemBigDataProps } from './ItemBigData'
 export { ItemBigData as default } from './ItemBigData'

--- a/src/itemData/index.tsx
+++ b/src/itemData/index.tsx
@@ -1,2 +1,2 @@
-export { ItemData } from './ItemData'
+export { ItemData, ItemDataProps } from './ItemData'
 export { ItemData as default } from './ItemData'

--- a/src/itemEditableInfo/index.tsx
+++ b/src/itemEditableInfo/index.tsx
@@ -1,2 +1,2 @@
-export { ItemEditableInfo } from './itemEditableInfo'
+export { ItemEditableInfo, ItemEditableInfoProps } from './itemEditableInfo'
 export { ItemEditableInfo as default } from './itemEditableInfo'


### PR DESCRIPTION
The last update to the Item components broke the linter on the SPA project, as props are missing.
They were not exported in the new index files.
