### PR TITLE
Release/37.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [...]
 
+# v37.1.1 (22/07/2020)
+
 - **[FIX]** Missing props exports in index file for `ItemAction`, `ItemBigData`, `ItemData`, `ItemEditableInfo`
 
 # v37.1.0 (22/07/2020)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "37.1.0",
+  "version": "37.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "37.1.0",
+  "version": "37.1.1",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION

# v37.1.1 (22/07/2020)

- **[FIX]** Missing props exports in index file for `ItemAction`, `ItemBigData`, `ItemData`, `ItemEditableInfo`