### PR TITLE
Add prop noHorizontalSpacing to remove horizontal padding on modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[UPDATE]** Add `noHorizontalSpacing` prop to disable horizontal padding on `Modal` component.
 [...]
 
 # v37.1.1 (22/07/2020)

--- a/src/modal/Modal.tsx
+++ b/src/modal/Modal.tsx
@@ -34,6 +34,7 @@ export type ModalProps = Readonly<{
   forwardedRef?: Ref<HTMLDivElement>
   ariaLabelledBy?: string
   ariaDescribedBy?: string
+  noHorizontalSpacing?: boolean
 }>
 
 export class Modal extends Component<ModalProps> {

--- a/src/modal/__snapshots__/Modal.unit.tsx.snap
+++ b/src/modal/__snapshots__/Modal.unit.tsx.snap
@@ -284,7 +284,10 @@ exports[`Modal should not have changed 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 24px;
+  padding-top: 24px;
+  padding-bottom: 24px;
+  padding-left: 24px;
+  padding-right: 24px;
   margin: 24px auto;
   width: 662px;
   background-color: #FFF;

--- a/src/modal/index.tsx
+++ b/src/modal/index.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import {
   color,
   componentSizes,
+  horizontalSpace,
   modalSize,
   radius,
   responsiveBreakpoints,
@@ -51,7 +52,10 @@ const StyledModal = styled(Modal)`
   & .kirk-modal-dialog {
     position: relative;
     display: flex;
-    padding: ${space.xl};
+    padding-top: ${space.xl};
+    padding-bottom: ${space.xl};
+    padding-left: ${props => (props.noHorizontalSpacing ? 0 : horizontalSpace.global)};
+    padding-right: ${props => (props.noHorizontalSpacing ? 0 : horizontalSpace.global)};
     margin: ${space.xl} auto;
     width: ${modalSize.m};
     background-color: ${color.white};


### PR DESCRIPTION
## Description

Add prop noHorizontalSpacing to remove horizontal padding on modals.

## How it was tested

Locally + snapshot unit test on CSS.
No story since this is only some internal flag that we don't want to expose in the storybook.
