### PR TITLE
Set storybook port number

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "npm": "^6.13.4"
   },
   "scripts": {
-    "start": "export NODE_PATH=src && start-storybook",
+    "start": "export NODE_PATH=src && start-storybook -p 4000",
     "build": "rimraf build && tsc && npm run build-babel && npm run build-rename-jsx-map && npm run build-cleanup",
     "build-babel": "babel build/src --copy-files --out-dir build",
     "build-rename-jsx-map": "renamer --find jsx.map --replace js.map \"build/**\"",


### PR DESCRIPTION
## Description

Set the port number of Storybook to `4000` so developers don't have to change tabs each time it is launched.

## What has been done

Add the `-p` option to the Storybook CLI.

## Things to consider

This shouldn't affect much developers who didn't care about this feature.

## How it was tested

By launching Storybook multiple times 👌.