### PR TITLE
Modal Layout for Filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **[FIX]** Removed margin bottom from `Tabs`
 - **[NEW]** Added `RedCircleIcon`
+- **[UPDATE]** Added `ModalBody`, `ModalFooter`, `ModalFog` components, and `isLoading`, `layoutModeEnabled` props on `Modal`
 
 # v38.0.0 (24/07/2020)
 

--- a/src/_internals/item/__snapshots__/Item.unit.tsx.snap
+++ b/src/_internals/item/__snapshots__/Item.unit.tsx.snap
@@ -89,8 +89,8 @@ exports[`Item Should not have changed 1`] = `
 .c0 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c0 {

--- a/src/filterBar/FilterBar.style.tsx
+++ b/src/filterBar/FilterBar.style.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-import { space } from '../_utils/branding'
+import { componentSizes, space } from '../_utils/branding'
 import { normalizeHorizontally } from '../layout/layoutNormalizer'
 
 const supplyItemHeight = '52px'
@@ -11,6 +11,8 @@ export const StyledFilterBar = styled.div`
   ${normalizeHorizontally};
   padding-top: ${space.xl};
   padding-bottom: ${space.xl};
+  max-width: ${componentSizes.smallSectionWidth};
+  margin: auto;
 `
 
 export const StyledSupplyInfo = styled.ul`

--- a/src/itemCheckbox/__snapshots__/ItemCheckbox.unit.tsx.snap
+++ b/src/itemCheckbox/__snapshots__/ItemCheckbox.unit.tsx.snap
@@ -119,8 +119,8 @@ exports[`ItemCheckbox Should display a CheckIcon when the input is checked 1`] =
 .c0 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c0 {
@@ -498,8 +498,8 @@ exports[`ItemCheckbox Should display a Loader when the component is in loading s
 .c0 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c0 {
@@ -833,8 +833,8 @@ exports[`ItemCheckbox Should forward its props to the Item component 1`] = `
 .c0 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c0 {

--- a/src/itemChoice/__snapshots__/index.unit.tsx.snap
+++ b/src/itemChoice/__snapshots__/index.unit.tsx.snap
@@ -109,8 +109,8 @@ exports[`ItemChoice Should display a Loader when the component is in loading sta
 .c0 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c0 {
@@ -561,8 +561,8 @@ exports[`ItemChoice Should display a done Loader when the component is in checke
 .c0 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c0 {
@@ -983,8 +983,8 @@ exports[`ItemChoice Should forward its props to the Item component 1`] = `
 .c0 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c0 {
@@ -1362,8 +1362,8 @@ exports[`ItemChoice Should support a disabled state 1`] = `
 .c0 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c0 {
@@ -1723,8 +1723,8 @@ exports[`ItemChoice Should use a button tag if no href is given 1`] = `
 .c0 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c0 {

--- a/src/itemRadio/__snapshots__/ItemRadio.unit.tsx.snap
+++ b/src/itemRadio/__snapshots__/ItemRadio.unit.tsx.snap
@@ -89,8 +89,8 @@ exports[`ItemRadio Should display a CircleIcon with an innerDisc when the input 
 .c0 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c0 {
@@ -410,8 +410,8 @@ exports[`ItemRadio Should display a Loader when the component is in loading stat
 .c0 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c0 {
@@ -796,8 +796,8 @@ exports[`ItemRadio Should forward its props to the Item component 1`] = `
 .c0 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c0 {

--- a/src/itemRadioGroup/__snapshots__/index.unit.tsx.snap
+++ b/src/itemRadioGroup/__snapshots__/index.unit.tsx.snap
@@ -89,8 +89,8 @@ exports[`ItemRadioGroup Should map its children and render them with specific pr
 .c2 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c2 {

--- a/src/itemsList/__snapshots__/ItemsList.unit.tsx.snap
+++ b/src/itemsList/__snapshots__/ItemsList.unit.tsx.snap
@@ -89,8 +89,8 @@ exports[`ItemsList Should render an unordered list 1`] = `
 .c1 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c1 {
@@ -463,8 +463,8 @@ exports[`ItemsList Should render an unordered list with some separators 1`] = `
 .c1 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c1 {
@@ -589,8 +589,8 @@ button:focus:not(.focus-visible).c1 {
 .c4 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c4 {
@@ -862,8 +862,8 @@ exports[`ItemsList Should render an unordered list with the separators classname
 .c1 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c1 {
@@ -988,8 +988,8 @@ button:focus:not(.focus-visible).c1 {
 .c4 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c4 {

--- a/src/layout/layoutNormalizer.tsx
+++ b/src/layout/layoutNormalizer.tsx
@@ -19,8 +19,8 @@ export interface NormalizeProps {
 export const normalizeHorizontally = (props: NormalizeProps): string => `
   padding-left: ${horizontalPadding(props)} !important;
   padding-right: ${horizontalPadding(props)} !important;
-  margin-left: ${horizontalMargin(props)} !important;
-  margin-right: ${horizontalMargin(props)} !important;
+  margin-left: ${horizontalMargin(props)};
+  margin-right: ${horizontalMargin(props)};
   `
 
 // Legacy layout rules from production BBC.

--- a/src/layout/section/itemsSection/__snapshots__/index.unit.tsx.snap
+++ b/src/layout/section/itemsSection/__snapshots__/index.unit.tsx.snap
@@ -69,8 +69,8 @@ exports[`ItemsSection should render default items section 1`] = `
 .c2 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c2 {
@@ -332,8 +332,8 @@ exports[`ItemsSection should render non-default items section 1`] = `
 .c2 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c2 {

--- a/src/messagingSummaryItem/__snapshots__/MessagingSummaryItem.unit.tsx.snap
+++ b/src/messagingSummaryItem/__snapshots__/MessagingSummaryItem.unit.tsx.snap
@@ -89,8 +89,8 @@ exports[`Should render properly with read messages 1`] = `
 .c0 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c0 {
@@ -462,8 +462,8 @@ exports[`Should render properly with unread messages 1`] = `
 .c0 {
   padding-left: 24px !important;
   padding-right: 24px !important;
-  margin-left: 0 !important;
-  margin-right: 0 !important;
+  margin-left: 0;
+  margin-right: 0;
 }
 
 .c0 {

--- a/src/modal/Modal.tsx
+++ b/src/modal/Modal.tsx
@@ -35,6 +35,8 @@ export type ModalProps = A11yProps &
     closeButtonTitle?: string
     forwardedRef?: Ref<HTMLDivElement>
     noHorizontalSpacing?: boolean
+    layoutModeEnabled?: boolean
+    isLoading?: boolean
   }>
 
 export class Modal extends Component<ModalProps> {
@@ -50,6 +52,11 @@ export class Modal extends Component<ModalProps> {
     size: ModalSize.MEDIUM,
     displayDimmer: true,
     forwardedRef: null,
+    isLoading: false,
+  }
+
+  state = {
+    showFooterBorder: true,
   }
 
   constructor(props: ModalProps) {
@@ -140,6 +147,14 @@ export class Modal extends Component<ModalProps> {
     this.focusTrap.activate()
   }
 
+  onScroll = (e: React.UIEvent<HTMLElement>): void => {
+    const element = e.currentTarget
+    const isAtBottom = element.clientHeight + element.scrollTop >= element.scrollHeight
+    this.setState({
+      showFooterBorder: !isAtBottom,
+    })
+  }
+
   render() {
     const baseClassName = 'kirk-modal'
     const a11yAttrs = pickA11yProps<ModalProps>(this.props)
@@ -171,6 +186,7 @@ export class Modal extends Component<ModalProps> {
                 {...a11yAttrs}
                 role="dialog"
                 aria-modal="true"
+                onScroll={this.onScroll}
               >
                 <div className={`${baseClassName}-dialog`}>
                   {this.props.displayCloseButton && (
@@ -183,7 +199,14 @@ export class Modal extends Component<ModalProps> {
                       <CrossIcon size="18" iconColor={color.blue} />
                     </Button>
                   )}
-                  <div className={`${baseClassName}-body`}>{this.props.children}</div>
+                  <div
+                    className={cc([
+                      `${baseClassName}-body`,
+                      this.state.showFooterBorder ? `${baseClassName}-modalFooterBorder` : '',
+                    ])}
+                  >
+                    {this.props.children}
+                  </div>
                 </div>
               </div>
             </CustomTransition>

--- a/src/modal/__snapshots__/Modal.unit.tsx.snap
+++ b/src/modal/__snapshots__/Modal.unit.tsx.snap
@@ -349,6 +349,7 @@ exports[`Modal should not have changed 1`] = `
     <div
       aria-modal="true"
       className="c1 kirk-modal kirk-modal--medium kirk-modal--hasCloseButton slide-up slide-up-entered"
+      onScroll={[Function]}
       role="dialog"
     >
       <div
@@ -387,7 +388,7 @@ exports[`Modal should not have changed 1`] = `
           </svg>
         </button>
         <div
-          className="kirk-modal-body"
+          className="kirk-modal-body kirk-modal-modalFooterBorder"
         />
       </div>
     </div>

--- a/src/modal/index.tsx
+++ b/src/modal/index.tsx
@@ -53,7 +53,7 @@ const StyledModal = styled(Modal)`
     position: relative;
     display: flex;
     padding-top: ${space.xl};
-    padding-bottom: ${space.xl};
+    padding-bottom: ${props => (props.layoutModeEnabled ? 0 : space.xl)};
     padding-left: ${props => (props.noHorizontalSpacing ? 0 : horizontalSpace.global)};
     padding-right: ${props => (props.noHorizontalSpacing ? 0 : horizontalSpace.global)};
     margin: ${space.xl} auto;
@@ -71,6 +71,8 @@ const StyledModal = styled(Modal)`
   }
 
   & .kirk-modal-body {
+    display: ${props => (props.layoutModeEnabled ? 'flex' : '')};
+    flex-direction: ${props => (props.layoutModeEnabled ? 'column' : '')};
     flex: 1;
   }
 
@@ -103,6 +105,45 @@ const StyledModal = styled(Modal)`
   }
 `
 
+const ModalBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  position: relative;
+`
+
+const ModalFooter = styled.div`
+  position: -webkit-sticky;
+  position: sticky;
+  bottom: 0;
+  background-color: ${color.white};
+  flex-shrink: 0;
+  z-index: 2;
+
+  .kirk-modal-modalFooterBorder & {
+    border-top: 1px solid ${color.gray};
+  }
+`
+
+type ModalFogProps = {
+  isLoading?: boolean
+}
+
+const transitionDelay = '420ms'
+const transitionTimingFunction = 'ease-in-out'
+
+const ModalFog = styled.div<ModalFogProps>`
+  position: absolute;
+  background: ${color.white};
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+  opacity: ${props => (props.isLoading ? 0.64 : 0)};
+  visibility: ${props => (props.isLoading ? '' : 'hidden')};
+  transition: opacity ${transitionDelay} ${transitionTimingFunction},
+    visibility ${transitionDelay} ${transitionTimingFunction};
+`
+
 export { ModalSize, ModalProps } from './Modal'
-export { StyledModal as Modal }
+export { StyledModal as Modal, ModalBody, ModalFooter, ModalFog }
 export default StyledModal

--- a/src/modal/story.tsx
+++ b/src/modal/story.tsx
@@ -2,8 +2,13 @@ import React, { Component, createRef } from 'react'
 import { boolean, select, text, withKnobs } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 
+import FilterBar from '../filterBar'
+import { CarpoolIcon } from '../icon'
+import ItemCheckbox from '../itemCheckbox'
 import { BaseSection as Section } from '../layout/section/baseSection'
-import { Modal, ModalSize } from '../modal'
+import { Modal, ModalBody, ModalFog, ModalFooter, ModalSize } from '../modal'
+import { SubHeader } from '../subHeader/SubHeader'
+import { TheVoice } from '../theVoice'
 import { ModalProps } from './Modal'
 import modalDoc from './specifications/modal.md'
 
@@ -38,7 +43,7 @@ class ModalOpener extends Component<ModalProps> {
     return (
       <Section>
         <button onClick={this.openModal}>Open modal 1</button>
-        <button onClick={this.openModal2}>Open modal 2</button>
+        <button onClick={this.openModal2}>Open modal using Layout components</button>
         <Modal {...this.props} onClose={this.closeModal} isOpen={this.state.modalOpen}>
           <div>
             <h1 id="label1">Modal 1</h1>
@@ -47,12 +52,48 @@ class ModalOpener extends Component<ModalProps> {
           </div>
         </Modal>
 
-        <Modal {...this.props} onClose={this.closeModal2} isOpen={this.state.modalOpen2}>
-          <div>
-            <h1 id="label2">Modal 2</h1>
-            <p id="description2">This is the description of my modal</p>
-            <img src="http://placekitten.com/g/216/144" width="216" height="144" alt="A kitten" />
-          </div>
+        <Modal
+          {...this.props}
+          onClose={this.closeModal2}
+          isOpen={this.state.modalOpen2}
+          noHorizontalSpacing
+          layoutModeEnabled
+        >
+          <ModalBody>
+            <ModalFog aria-hidden="true" isLoading={this.props.isLoading} />
+            <TheVoice>Filters</TheVoice>
+            <Section>
+              <SubHeader>Amenities & Services</SubHeader>
+            </Section>
+            <Section noHorizontalSpacing>
+              <ItemCheckbox label="Ladies only" />
+              <ItemCheckbox label="Automatic Approval" />
+              <ItemCheckbox label="Wifi" />
+              <ItemCheckbox label="Air conditioning" />
+              <ItemCheckbox label="Reclining seats" />
+              <ItemCheckbox label="Personal power outlets" />
+              <ItemCheckbox label="Ladies only" />
+              <ItemCheckbox label="Automatic Approval" />
+              <ItemCheckbox label="Wifi" />
+              <ItemCheckbox label="Air conditioning" />
+              <ItemCheckbox label="Reclining seats" />
+              <ItemCheckbox label="Personal power outlets" />
+            </Section>
+          </ModalBody>
+          <ModalFooter>
+            <FilterBar
+              ctaText="See rides"
+              supplyInfo={[
+                {
+                  icon: CarpoolIcon,
+                  iconTitle: 'Carpooling',
+                  liquidity: 20,
+                  ariaLabel: 'Carpool available',
+                },
+              ]}
+              onClick={() => {}}
+            />
+          </ModalFooter>
         </Modal>
       </Section>
     )
@@ -72,6 +113,7 @@ stories.add(
       aria-labelledby="label1"
       aria-describedby="description1"
       size={select('size', ModalSize, ModalSize.MEDIUM)}
+      isLoading={boolean('isLoading', false)}
     />
   ),
   {
@@ -90,5 +132,6 @@ stories.add('fullscreen', () => (
     aria-labelledby="label2"
     aria-describedby="description2"
     size={select('size', ModalSize, ModalSize.FULLSCREEN)}
+    isLoading={boolean('isLoading', false)}
   />
 ))


### PR DESCRIPTION
## Description

Layout for Modal that will be used for Filters feature in SPA

## What has been done

- Used styled components `ModalBody` `ModalFooter` `ModalFog` 
- Kept current modal retro-compatible
- Removed `!important` from `normalizeHorizontally`, I checked and it has no impact.

## Things to consider

- Couldn't really unit test this, I'd like to move the modal to RTL in a next PR
- This new layout should be moved out of the `Modal` and should be a Page layout, but right now we need this to progress on the filtres feature

## How it was tested

Storybook locally
![Kapture 2020-07-23 at 15 08 21](https://user-images.githubusercontent.com/1606624/88544459-b359fb80-d019-11ea-883e-db5b05b7a899.gif)


