### PR TITLE
Removed tabs margin bottom as specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-[...]
+- **[FIX]** Removed margin bottom from `Tabs`
 
 # v38.0.0 (24/07/2020)
 

--- a/src/layout/section/tabsSection/__snapshots__/index.unit.tsx.snap
+++ b/src/layout/section/tabsSection/__snapshots__/index.unit.tsx.snap
@@ -22,7 +22,6 @@ exports[`TabsSection should render default TabsSection 1`] = `
 }
 
 .c1 .kirk-tabs {
-  margin-bottom: 16px;
   border-bottom: 1px solid #DDD;
 }
 

--- a/src/tabs/tabs.style.tsx
+++ b/src/tabs/tabs.style.tsx
@@ -10,7 +10,6 @@ export const StyledTabs = styled.div`
   }
 
   & .kirk-tabs {
-    margin-bottom: ${space.l};
     border-bottom: 1px solid ${color.gray};
   }
 


### PR DESCRIPTION
## Description

Removed margin bottom on `Tabs` as specs.

## How it was tested

Locally in storybook and in SPA where we have tabs
