### PR TITLE
Release/38.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 [...]
 
-# v38.0.0 (28/07/2020)
+# v38.1.0 (28/07/2020)
 
 - **[FIX]** Removed margin bottom from `Tabs`
 - **[NEW]** Added `RedCircleIcon`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+[...]
+
+# v38.0.0 (28/07/2020)
+
 - **[FIX]** Removed margin bottom from `Tabs`
 - **[NEW]** Added `RedCircleIcon`
 - **[UPDATE]** Added `ModalBody`, `ModalFooter`, `ModalFog` components, and `isLoading`, `layoutModeEnabled` props on `Modal`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "38.0.0",
+  "version": "38.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "38.0.0",
+  "version": "38.1.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# v38.1.0 (28/07/2020)

- **[FIX]** Removed margin bottom from `Tabs`
- **[NEW]** Added `RedCircleIcon`
- **[UPDATE]** Added `ModalBody`, `ModalFooter`, `ModalFog` components, and `isLoading`, `layoutModeEnabled` props on `Modal`