### PR TITLE
Fix Grip crashing on useEffect cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
 
 - **[UPDATE]** Add basic a11y to `Loader` component
-[...]
+- **[FIX]** Fix Grip crashing with `useEffect` cleanup
+  [...]
 
 # v38.2.0 (31/07/2020)
 

--- a/src/grip/Grip.tsx
+++ b/src/grip/Grip.tsx
@@ -54,7 +54,7 @@ export const Grip = (props: GripProps): JSX.Element => {
         window.removeEventListener('touchend', delegatedTouchEndListener)
       }
     }
-    return null
+    return () => {}
   }, [disabled, onSlideUp, onSlideDown])
 
   return (


### PR DESCRIPTION
## Description

When integrating the component in the page, got a warning and then an error caused by `useEffect` not returning a function in all cases. This fixes it :)

## How it was tested

Tested locally with the integration in our application.
