### PR TITLE
Fixed click areas too small on SearchForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - **[UPDATE]** Add basic a11y to `Loader` component
 - **[FIX]** Fix Grip crashing with `useEffect` cleanup
-  [...]
+- **[FIX]** Fix `SearchForm` click area too small
 
 # v38.2.0 (31/07/2020)
 

--- a/src/searchForm/SlideSwitchTransition.tsx
+++ b/src/searchForm/SlideSwitchTransition.tsx
@@ -12,7 +12,7 @@ export enum SlideSwitchTransitionSide {
 }
 
 const DIRECTION_TRANSFORM_VALUES: {
-  [key in SlideSwitchTransitionSide]: AnimatedSpanProps['transform']
+  [key in SlideSwitchTransitionSide]: AnimatedDivProps['transform']
 } = {
   [SlideSwitchTransitionSide.TOP]: { in: 'translateY(0)', out: 'translateY(-100%)' },
   [SlideSwitchTransitionSide.RIGHT]: { in: 'translateX(0)', out: 'translateX(100%)' },
@@ -20,7 +20,7 @@ const DIRECTION_TRANSFORM_VALUES: {
   [SlideSwitchTransitionSide.LEFT]: { in: 'translateX(0)', out: 'translateX(-100%)' },
 }
 
-type AnimatedSpanProps = {
+type AnimatedDivProps = {
   transitionDuration: TransitionDuration
   transform: {
     /**
@@ -35,8 +35,7 @@ type AnimatedSpanProps = {
   }
 }
 
-const AnimatedSpan = styled.span<AnimatedSpanProps>`
-  display: inline-block;
+const AnimatedDiv = styled.div<AnimatedDivProps>`
   opacity: 1;
   transform: ${p => p.transform.in};
   transition-property: opacity, transform;
@@ -86,12 +85,12 @@ export function SlideSwitchTransition({
   return (
     <SwitchTransition>
       <CSSTransition key={childrenKey} timeout={transitionDuration} classNames="slide">
-        <AnimatedSpan
+        <AnimatedDiv
           transform={DIRECTION_TRANSFORM_VALUES[side]}
           transitionDuration={transitionDuration}
         >
           {children}
-        </AnimatedSpan>
+        </AnimatedDiv>
       </CSSTransition>
     </SwitchTransition>
   )


### PR DESCRIPTION
## Description

Expanded the click area on search form from & to fields

![Kapture 2020-08-03 at 17 10 53](https://user-images.githubusercontent.com/1606624/89197753-7c9d5b80-d5ac-11ea-9b2f-b922ecb22a91.gif)

## What has been done

Turned `span` animation container into a `div`

## Things to consider

Tested the animation between from & to, I didn't notice any regression

## How it was tested

Storybook
