### PR TITLE
[BBC-9295]  Center canvas layout to some ui delight

### DIFF
--- a/stories/stories.css
+++ b/stories/stories.css
@@ -31,3 +31,11 @@ ul {
   margin: 0;
   padding: 0;
 }
+
+/* SBDOCS */
+/* Storybook style only applied to canvas*/
+#root {
+  margin: 0 auto;
+  padding: 4rem 20px;
+  max-width: 1016px; /*content-section*/
+}


### PR DESCRIPTION
## Description
<!-- Give some context of this PR. Illustrate with screenshots or a video (gif, loom, etc.) -->

Canvas displays stories way to close to the border. 
Improve visibility / style / presentation of each component avoiding using `<Section />` component for that

**BEFORE**
![Screenshot 2020-08-03 at 21 53 54](https://user-images.githubusercontent.com/2952998/89222108-bb470c00-d5d4-11ea-8f21-adba1153bc01.png)

**AFTER**
![Screenshot 2020-08-03 at 21 58 25](https://user-images.githubusercontent.com/2952998/89222110-bbdfa280-d5d4-11ea-982a-f21bfbcee173.png)



## What has been done

<!-- How do you solve the problem? -->
- add some style to Storybook element root

## Things to consider

<!-- Explain your changes. What are you expecting for the reviewers? -->
- I've chosen do not to wrap stories with a style decorator since it applied to Canvas and Docs. Since are looking for only style storybook, I've used stories.css as the way to go.
- Used same values as `Sbdocs` and `BaseSection` component

## How it was tested

<!-- Local environment with ui-library only, integrated within the main project, on which browsers, etc. -->
- 👀  visually
