### PR TITLE
Fixed non displayed loader in autocomplete searchform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-[...]
+- **[FIX]** Fixed non-displayed loader in Search Form `Autocomplete`
 
 # v39.0.0 (07/08/2020)
 

--- a/src/autoComplete/AutoComplete.tsx
+++ b/src/autoComplete/AutoComplete.tsx
@@ -290,7 +290,9 @@ export class AutoComplete extends Component<AutoCompleteProps, AutoCompleteState
     const shouldDisplayDivider =
       this.props.embeddedInSearchForm && (listItems.length > 0 || shouldDisplayNoResults)
     const loader =
-      this.props.embeddedInSearchForm && this.state.isSearching ? <Loader size={24} inline /> : null
+      this.props.embeddedInSearchForm && this.state.isSearching ? (
+        <Loader className="kirk-autoComplete-loader" size={24} inline />
+      ) : null
 
     return (
       /* TODO: BBC-7413 fix a11y issue */

--- a/src/searchForm/baseStyles.tsx
+++ b/src/searchForm/baseStyles.tsx
@@ -43,10 +43,8 @@ export const autoCompleteBaseStyle = `
       border-radius: 0;
     }
 
-    .kirk-loader {
-      position: absolute;
-      top: 12px;
-      right: 12px;
+    .kirk-autoComplete-loader {
+      padding-top: 12px;
     }
   }
 

--- a/src/searchForm/story.tsx
+++ b/src/searchForm/story.tsx
@@ -7,7 +7,6 @@ import { MediaSizeProvider } from '../_utils/mediaSizeProvider'
 import { knobEnum } from '../../.storybook/knobs'
 import { AutoCompleteExample } from '../autoComplete/story'
 import { DatePicker } from '../datePicker'
-import { CrossIcon } from '../icon/crossIcon'
 import { BaseSection, SectionContentSize } from '../layout/section/baseSection'
 import { AutoCompleteOverlay } from './autoComplete/overlay'
 import { AutoCompleteSection } from './autoComplete/section'
@@ -92,10 +91,8 @@ stories.add(
           disabledTo={boolean('disabledTo', false)}
           autocompleteFromPlaceholder={text('autocompleteFromPlaceholder', 'Leaving From')}
           autocompleteToPlaceholder={text('autocompleteToPlaceholder', 'Going to')}
-          renderAutocompleteFrom={props => (
-            <AutoCompleteExample inputAddon={<CrossIcon />} autoFocus={false} {...props} />
-          )}
-          renderAutocompleteTo={props => <AutoCompleteExample {...props} />}
+          renderAutocompleteFrom={props => <AutoCompleteExample {...props} embeddedInSearchForm />}
+          renderAutocompleteTo={props => <AutoCompleteExample {...props} embeddedInSearchForm />}
           datepickerProps={{
             defaultValue: new Date().toISOString(),
             format: value => new Date(value).toLocaleDateString(),


### PR DESCRIPTION
## Description

![Kapture 2020-08-07 at 17 17 31](https://user-images.githubusercontent.com/1606624/89660785-1c6f2800-d8d2-11ea-8da4-742553f843b2.gif)


## What has been done

The loader was misplaced because the className that targeted it had been removed.
I added a specific className for the autocomplete loader so we no longer have coupling between Loader & Autocomplete.

## Things to consider

To have the loader in SPA, we'll need to use the `embeddedInSearchForm` prop. I'll prepare a branch with this.

## How it was tested

Storybook locally
