### PR TITLE
Refactor Avatar tests with RTL

### DIFF
--- a/src/avatar/Avatar.unit.tsx
+++ b/src/avatar/Avatar.unit.tsx
@@ -1,28 +1,57 @@
 import React from 'react'
-import { shallow } from 'enzyme'
 
-import { Badge } from '../badge'
-import { Avatar } from './index'
+import { render, screen } from '@testing-library/react'
 
-it('Should have the proper default state.', () => {
-  const avatar = shallow(<Avatar image="//placehold.it/80x80" alt="my alternative txt" />)
-  expect(avatar.find('img').prop('src')).toEqual('//placehold.it/80x80')
-  expect(avatar.find(Badge).exists()).toBe(false)
-})
+import { Avatar, AvatarProps } from './index'
 
-it('Should show a Badge if there are unread notifications.', () => {
-  const avatar = shallow(<Avatar image="//placehold.it/80x80" unreadNotificationsCount="345" />)
-  expect(avatar.find(Badge).hasClass('kirk-avatar-badge--unreadNotifications')).toBe(true)
-})
+function createProps(props: Partial<AvatarProps> = {}): AvatarProps {
+  return {
+    image: '//placehold.it/80x80',
+    ...props,
+  }
+}
 
-it('Should show a Badge if ID checked.', () => {
-  const avatar = shallow(<Avatar image="//placehold.it/80x80" isIdChecked />)
-  expect(avatar.find(Badge).hasClass('kirk-avatar-badge--idCheck')).toBe(true)
-})
+describe('Avatar', () => {
+  it('should render the given image', () => {
+    const props = createProps()
+    render(<Avatar {...props} />)
+    expect(screen.getByRole('img')).toHaveAttribute('src', props.image)
+  })
 
-it('Should allow for size, image and alt modifiers', () => {
-  const avatar = shallow(<Avatar image="//placehold.it/80x80" isMedium alt="my alternative txt" />)
-  expect(avatar.hasClass('kirk-avatar--medium')).toBe(true)
-  expect(avatar.hasClass('kirk-avatar--image')).toBe(true)
-  expect(avatar.find('img').prop('alt')).toBe('my alternative txt')
+  it('should render the alt text', () => {
+    const props = createProps({ alt: 'Alternative text' })
+    render(<Avatar {...props} />)
+    expect(screen.getByRole('img', { name: 'Alternative text' })).toBeInTheDocument()
+  })
+
+  it('should render a badge if there are unread notifications', () => {
+    const props = createProps({ unreadNotificationsCount: '345' })
+    render(<Avatar {...props} />)
+    expect(screen.getByText('345')).toBeInTheDocument()
+  })
+
+  it('should render a check bage if `isIdChecked` is `true`', () => {
+    const props = createProps({ isIdChecked: true })
+    render(<Avatar {...props} />)
+    // There are no accessible way to check the badge is rendered.
+    expect(document.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('should render a small avatar when `isSmall` is `true`', () => {
+    const props = createProps({ isSmall: true })
+    const { container } = render(<Avatar {...props} />)
+    expect(container.firstChild).toHaveClass('kirk-avatar--small')
+  })
+
+  it('should render a medium avatar when `isMedium` is `true`', () => {
+    const props = createProps({ isMedium: true })
+    const { container } = render(<Avatar {...props} />)
+    expect(container.firstChild).toHaveClass('kirk-avatar--medium')
+  })
+
+  it('should render a medium avatar when `isLarge` is `true`', () => {
+    const props = createProps({ isLarge: true })
+    const { container } = render(<Avatar {...props} />)
+    expect(container.firstChild).toHaveClass('kirk-avatar--large')
+  })
 })


### PR DESCRIPTION
## Description

Rewrite Avatar's tests with RTL.

## Things to consider

The component is not fully accessible which cause some tests to depend on tag names. 

## How it was tested

- Unit tests
