### PR TITLE
Use types for props

### DIFF
--- a/src/_internals/card/Card.tsx
+++ b/src/_internals/card/Card.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import cc from 'classcat'
 
-export interface CardProps {
-  readonly className?: string
-  readonly children?: React.ReactNode
-}
+export type CardProps = Readonly<{
+  className?: string
+  children?: React.ReactNode
+}>
 
 export const Card = ({ className, children }: CardProps) => (
   <li className={cc(['kirk-card', className])}>{children}</li>

--- a/src/_internals/checkboxIcon/index.tsx
+++ b/src/_internals/checkboxIcon/index.tsx
@@ -5,11 +5,11 @@ import { CheckIcon } from '../../icon/checkIcon'
 import { CircleIcon } from '../../icon/circleIcon'
 import { Loader } from '../../loader'
 
-export interface CheckboxIconProps {
-  readonly isChecked?: boolean
-  readonly isLoading?: boolean
-  readonly isDisabled?: boolean
-}
+export type CheckboxIconProps = Readonly<{
+  isChecked?: boolean
+  isLoading?: boolean
+  isDisabled?: boolean
+}>
 
 export const CheckboxIcon = ({
   isChecked = false,

--- a/src/_internals/item/Item.tsx
+++ b/src/_internals/item/Item.tsx
@@ -14,40 +14,42 @@ export enum ItemStatus {
   CHECKED = 'checked',
 }
 
-export interface ItemProps extends A11yProps, NormalizeProps {
-  readonly chevron?: boolean
-  readonly className?: string
-  readonly href?: string | JSX.Element
-  readonly highlighted?: boolean
-  readonly isClickable?: boolean
-  readonly leftTitle?: React.ReactNode
-  readonly leftTitleButtonAddon?: React.ReactElement<Button>
-  readonly leftTitleDisplay?: TextDisplayType
-  readonly leftTitleColor?: string
-  readonly leftBody?: string | React.ReactNode
-  readonly leftBodyDisplay?: TextDisplayType
-  readonly leftBodyColor?: string
-  readonly leftBodyAnnotation?: React.ReactNode
-  readonly leftBodyAnnotationDisplay?: TextDisplayType
-  readonly leftBodyAnnotationColor?: string
-  readonly leftAddon?: React.ReactNode
-  readonly rightTitle?: string | JSX.Element
-  readonly rightTitleDisplay?: TextDisplayType
-  readonly rightTitleStrikeThrough?: boolean
-  readonly rightTitleAriaProps?: A11yProps
-  readonly rightTitleColor?: string
-  readonly rightBody?: React.ReactNode
-  readonly rightBodyDisplay?: TextDisplayType
-  readonly rightBodyColor?: string
-  readonly rightAddon?: React.ReactNode
-  readonly tag?: JSX.Element
-  readonly onClick?: (event: React.MouseEvent<HTMLElement>) => void
-  readonly onBlur?: (event: React.FocusEventHandler<HTMLElement>) => void
-  readonly onFocus?: (event: React.FocusEventHandler<HTMLElement>) => void
-  readonly onMouseDown?: (event: React.MouseEvent<HTMLElement>) => void
-  readonly hideHoverBackground?: boolean
-  readonly disabled?: boolean
-}
+export type ItemProps = A11yProps &
+  NormalizeProps &
+  Readonly<{
+    chevron?: boolean
+    className?: string
+    href?: string | JSX.Element
+    highlighted?: boolean
+    isClickable?: boolean
+    leftTitle?: React.ReactNode
+    leftTitleButtonAddon?: React.ReactElement<Button>
+    leftTitleDisplay?: TextDisplayType
+    leftTitleColor?: string
+    leftBody?: string | React.ReactNode
+    leftBodyDisplay?: TextDisplayType
+    leftBodyColor?: string
+    leftBodyAnnotation?: React.ReactNode
+    leftBodyAnnotationDisplay?: TextDisplayType
+    leftBodyAnnotationColor?: string
+    leftAddon?: React.ReactNode
+    rightTitle?: string | JSX.Element
+    rightTitleDisplay?: TextDisplayType
+    rightTitleStrikeThrough?: boolean
+    rightTitleAriaProps?: A11yProps
+    rightTitleColor?: string
+    rightBody?: React.ReactNode
+    rightBodyDisplay?: TextDisplayType
+    rightBodyColor?: string
+    rightAddon?: React.ReactNode
+    tag?: JSX.Element
+    onClick?: (event: React.MouseEvent<HTMLElement>) => void
+    onBlur?: (event: React.FocusEventHandler<HTMLElement>) => void
+    onFocus?: (event: React.FocusEventHandler<HTMLElement>) => void
+    onMouseDown?: (event: React.MouseEvent<HTMLElement>) => void
+    hideHoverBackground?: boolean
+    disabled?: boolean
+  }>
 
 export const Item = (props: ItemProps) => {
   const {

--- a/src/_internals/itineraryCollapsible/ItineraryCollapsible.tsx
+++ b/src/_internals/itineraryCollapsible/ItineraryCollapsible.tsx
@@ -10,14 +10,15 @@ import { Bullet, BulletTypes } from '../../bullet'
 import { Text, TextDisplayType, TextTagType } from '../../text'
 import { computeKeyFromPlace, ItineraryLocation } from '../itineraryLocation'
 
-export interface ItineraryCollapsibleProps extends A11yProps {
-  readonly places: Place[]
-  readonly className?: string
-  readonly label?: string
-}
+export type ItineraryCollapsibleProps = A11yProps &
+  Readonly<{
+    places: Place[]
+    className?: string
+    label?: string
+  }>
 
-interface ItineraryCollapsibleState {
-  readonly collapsed: boolean
+type ItineraryCollapsibleState = {
+  collapsed: boolean
 }
 
 const collapsibleLocationSize = 32 // default size of a collapsible ItineraryLocation

--- a/src/_internals/itineraryLocation/ItineraryLocation.tsx
+++ b/src/_internals/itineraryLocation/ItineraryLocation.tsx
@@ -8,16 +8,16 @@ import { Bullet, BulletTypes } from '../../bullet'
 import { ChevronIcon } from '../../icon/chevronIcon'
 import { Text, TextDisplayType, TextTagType } from '../../text'
 
-export interface ItineraryLocationProps {
-  readonly place: Place
-  readonly className?: string
-  readonly isSmall?: boolean
-  readonly isArrival?: boolean
-  readonly hasBottomAddon?: boolean
-  readonly hasTime?: boolean
-  readonly hasSubLabel?: boolean
-  readonly displaySubLabelOnly?: boolean
-}
+export type ItineraryLocationProps = Readonly<{
+  place: Place
+  className?: string
+  isSmall?: boolean
+  isArrival?: boolean
+  hasBottomAddon?: boolean
+  hasTime?: boolean
+  hasSubLabel?: boolean
+  displaySubLabelOnly?: boolean
+}>
 
 export const computeKeyFromPlace = (place: Place) => {
   if (place.key && typeof place.key === 'string') {

--- a/src/_internals/radioIcon/index.tsx
+++ b/src/_internals/radioIcon/index.tsx
@@ -4,11 +4,11 @@ import { color } from '../../_utils/branding'
 import { CircleIcon } from '../../icon/circleIcon'
 import { Loader } from '../../loader'
 
-export interface RadioIconProps {
-  readonly isChecked?: boolean
-  readonly isLoading?: boolean
-  readonly isDisabled?: boolean
-}
+export type RadioIconProps = Readonly<{
+  isChecked?: boolean
+  isLoading?: boolean
+  isDisabled?: boolean
+}>
 
 export const RadioIcon = ({
   isChecked = false,

--- a/src/_utils/icon/BaseIcon.tsx
+++ b/src/_utils/icon/BaseIcon.tsx
@@ -16,10 +16,11 @@ export interface Icon {
   readonly isDisabled?: boolean
 }
 
-export interface IconProps extends Icon {
-  readonly children: JSX.Element
-  readonly viewBox?: string
-}
+export type IconProps = Icon &
+  Readonly<{
+    children: JSX.Element
+    viewBox?: string
+  }>
 
 export const BaseIconDefaultProps = {
   className: '',

--- a/src/_utils/mediaSizeProvider/index.tsx
+++ b/src/_utils/mediaSizeProvider/index.tsx
@@ -8,9 +8,9 @@ export enum MediaSize {
   LARGE = 'large',
 }
 
-interface MediaSizeProviderProps {
+export type MediaSizeProviderProps = Readonly<{
   children: ReactNode
-}
+}>
 
 export const MediaSizeContext = React.createContext(MediaSize.SMALL)
 

--- a/src/_utils/rideAxis/index.tsx
+++ b/src/_utils/rideAxis/index.tsx
@@ -19,10 +19,10 @@ const StyledArrowIcon = styled(ArrowIcon)`
   }
 `
 
-export interface RideAxisProps {
-  readonly from?: string
-  readonly to?: string
-}
+export type RideAxisProps = Readonly<{
+  from?: string
+  to?: string
+}>
 
 export const RideAxis = ({ from, to, ...props }: RideAxisProps) => (
   <StyledRideAxis {...props}>

--- a/src/autoComplete/AutoComplete.tsx
+++ b/src/autoComplete/AutoComplete.tsx
@@ -28,57 +28,57 @@ export interface AutocompleteItemToRender {
   readonly index: number
 }
 
-export interface AutoCompleteProps {
-  readonly name: string
-  readonly searchForItems: (query: query) => void
-  readonly isSearching?: boolean
-  readonly searchOnMount?: boolean
-  readonly onInputChange?: (params: Partial<OnChangeParameters>) => void
-  readonly searchForItemsMinChars?: number
-  readonly defaultValue?: string
-  readonly onSelect?: (obj: AutocompleteOnChange) => void
-  readonly onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
-  readonly onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void
-  readonly onClear?: () => void
-  readonly className?: string
-  readonly inputClassName?: string
-  readonly itemClassName?: string
-  readonly bodyClassName?: string
-  readonly items?: AutocompleteItem[]
-  readonly maxItems?: number
-  readonly itemKey?: (item: AutocompleteItem) => string
-  readonly renderBusy?: ({ query }: { query: query }) => React.ReactElement<any>
-  readonly renderNoResults?: ({ query }: { query: query }) => string
-  readonly renderQuery?: (item: AutocompleteItem) => string
-  readonly renderEmptySearch?: AutocompleteItem[]
-  readonly getItemValue?: (item: AutocompleteItem) => string
-  readonly inputAddon?: React.ReactElement<any>
-  readonly placeholder?: string
-  readonly busyTimeout?: number
-  readonly debounceTimeout?: number
-  readonly autoFocus?: boolean
-  readonly focus?: boolean
-  readonly buttonTitle?: string
-  readonly showList?: boolean
-  readonly onDoneAnimationEnd?: () => void
-  readonly autoCorrect?: 'on' | 'off'
-  readonly disabled?: boolean
-  readonly readOnly?: boolean
-  readonly required?: boolean
-  readonly error?: string | JSX.Element
-  readonly selectedItemStatus?: ItemStatus
-  readonly embeddedInSearchForm?: boolean
-}
+export type AutoCompleteProps = Readonly<{
+  name: string
+  searchForItems: (query: query) => void
+  isSearching?: boolean
+  searchOnMount?: boolean
+  onInputChange?: (params: Partial<OnChangeParameters>) => void
+  searchForItemsMinChars?: number
+  defaultValue?: string
+  onSelect?: (obj: AutocompleteOnChange) => void
+  onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
+  onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void
+  onClear?: () => void
+  className?: string
+  inputClassName?: string
+  itemClassName?: string
+  bodyClassName?: string
+  items?: AutocompleteItem[]
+  maxItems?: number
+  itemKey?: (item: AutocompleteItem) => string
+  renderBusy?: ({ query }: { query: query }) => React.ReactElement<any>
+  renderNoResults?: ({ query }: { query: query }) => string
+  renderQuery?: (item: AutocompleteItem) => string
+  renderEmptySearch?: AutocompleteItem[]
+  getItemValue?: (item: AutocompleteItem) => string
+  inputAddon?: React.ReactElement<any>
+  placeholder?: string
+  busyTimeout?: number
+  debounceTimeout?: number
+  autoFocus?: boolean
+  focus?: boolean
+  buttonTitle?: string
+  showList?: boolean
+  onDoneAnimationEnd?: () => void
+  autoCorrect?: 'on' | 'off'
+  disabled?: boolean
+  readOnly?: boolean
+  required?: boolean
+  error?: string | JSX.Element
+  selectedItemStatus?: ItemStatus
+  embeddedInSearchForm?: boolean
+}>
 
-interface AutoCompleteState {
-  readonly busy: boolean
-  readonly items: AutocompleteItem[]
-  readonly formattedValue: string
-  readonly textfieldValue: string
-  readonly lastDefaultValue: string
-  readonly query: query
-  readonly noResults: boolean
-  readonly isSearching: boolean
+type AutoCompleteState = {
+  busy: boolean
+  items: AutocompleteItem[]
+  formattedValue: string
+  textfieldValue: string
+  lastDefaultValue: string
+  query: query
+  noResults: boolean
+  isSearching: boolean
 }
 
 const initialState: AutoCompleteState = {

--- a/src/autoComplete/AutoCompleteList.tsx
+++ b/src/autoComplete/AutoCompleteList.tsx
@@ -16,7 +16,7 @@ export interface AutocompleteItem {
   readonly leftAddon?: JSX.Element
 }
 
-export interface AutoCompleteListProps {
+export type AutoCompleteListProps = Readonly<{
   name: string
   onSelect?: (item: AutocompleteItem) => void
   className?: string
@@ -28,11 +28,11 @@ export interface AutoCompleteListProps {
   visible?: boolean
   selectedItemStatus?: ItemStatus
   withSeparators?: boolean
-}
+}>
 
-interface AutoCompleteListState {
-  readonly highlightedIndex: number
-  readonly selectedIndex: number
+type AutoCompleteListState = {
+  highlightedIndex: number
+  selectedIndex: number
 }
 
 export class AutoCompleteList extends Component<AutoCompleteListProps, AutoCompleteListState> {

--- a/src/autoComplete/story.tsx
+++ b/src/autoComplete/story.tsx
@@ -21,21 +21,21 @@ const places: AutocompleteItem[] = [
   { id: '3', label: 'Paris Rive Gauche' },
 ]
 
-interface AutoCompleteExampleProps {
-  readonly searchOnMount?: boolean
-  readonly searchForItemsDelay?: number
-  readonly renderEmptySearch?: AutocompleteItem[]
-  readonly className?: string
-  readonly inputAddon?: React.ReactElement
-  readonly onSelect?: (obj: AutocompleteOnChange) => void
-  readonly autoFocus?: boolean
-  readonly placeholder?: string
-  readonly embeddedInSearchForm?: boolean
-}
+type AutoCompleteExampleProps = Readonly<{
+  searchOnMount?: boolean
+  searchForItemsDelay?: number
+  renderEmptySearch?: AutocompleteItem[]
+  className?: string
+  inputAddon?: React.ReactElement
+  onSelect?: (obj: AutocompleteOnChange) => void
+  autoFocus?: boolean
+  placeholder?: string
+  embeddedInSearchForm?: boolean
+}>
 
-interface AutoCompleteExampleState {
-  readonly isSearching: boolean
-  readonly items: AutocompleteItem[]
+type AutoCompleteExampleState = {
+  isSearching: boolean
+  items: AutocompleteItem[]
 }
 
 export class AutoCompleteExample extends Component<

--- a/src/avatar/Avatar.tsx
+++ b/src/avatar/Avatar.tsx
@@ -7,17 +7,17 @@ import { Badge } from '../badge'
 import { CheckIcon } from '../icon/checkIcon'
 import { StyledAvatar } from './Avatar.style'
 
-export interface AvatarProps {
-  readonly className?: string
-  readonly image?: string
-  readonly alt?: string
-  readonly isSmall?: boolean
-  readonly isMedium?: boolean
-  readonly isLarge?: boolean
-  readonly isIdChecked?: boolean
-  readonly unreadNotificationsCount?: string
-  readonly unreadNotificationsCountAriaLabel?: string
-}
+export type AvatarProps = Readonly<{
+  className?: string
+  image?: string
+  alt?: string
+  isSmall?: boolean
+  isMedium?: boolean
+  isLarge?: boolean
+  isIdChecked?: boolean
+  unreadNotificationsCount?: string
+  unreadNotificationsCountAriaLabel?: string
+}>
 
 const IdCheckBadge = (
   <Badge className="kirk-avatar-badge--idCheck">

--- a/src/badge/Badge.tsx
+++ b/src/badge/Badge.tsx
@@ -5,10 +5,11 @@ import isEmpty from 'lodash.isempty'
 import { A11yProps, pickA11yProps } from '../_utils/interfaces'
 import { StyledBadge } from './Badge.style'
 
-export interface BadgeProps extends A11yProps {
-  readonly className?: string
-  readonly children: string | JSX.Element | number
-}
+export type BadgeProps = A11yProps &
+  Readonly<{
+    className?: string
+    children: string | JSX.Element | number
+  }>
 
 export const Badge = (props: BadgeProps) => {
   const { className, children } = props

--- a/src/bullet/Bullet.tsx
+++ b/src/bullet/Bullet.tsx
@@ -10,10 +10,10 @@ export enum BulletTypes {
   SEARCH = 'search',
 }
 
-export interface BulletProps {
-  readonly className?: string
-  readonly type?: BulletTypes
-}
+export type BulletProps = Readonly<{
+  className?: string
+  type?: BulletTypes
+}>
 
 export const Bullet = ({ className, type }: BulletProps) => {
   const baseClassName = 'kirk-bullet'

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -16,36 +16,37 @@ export enum ButtonStatus {
   CHECKED = 'checked',
 }
 
-export interface ButtonProps extends A11yProps {
-  readonly children: string | number | React.ReactNode
-  readonly type?: string
-  readonly href?: string | JSX.Element
-  readonly className?: string
-  readonly title?: string
-  readonly status?: ButtonStatus
-  readonly focus?: boolean
-  readonly isBubble?: boolean
-  readonly shadowed?: boolean
-  readonly onClick?: (event: React.MouseEvent<HTMLElement>) => void
-  readonly onBlur?: (event: React.FocusEventHandler<HTMLElement>) => void
-  readonly onFocus?: (event: React.FocusEventHandler<HTMLElement>) => void
-  readonly onMouseDown?: (event: React.MouseEvent<HTMLElement>) => void
-  readonly onMouseUp?: (event: React.MouseEvent<HTMLElement>) => void
-  readonly onTouchStart?: (event: React.TouchEvent<HTMLElement>) => void
-  readonly onTouchEnd?: (event: React.TouchEvent<HTMLElement>) => void
-  readonly onDoneAnimationEnd?: () => void
-  readonly tabIndex?: string
-  readonly disabled?: boolean
-  readonly index?: string
-  buttonRef?: (button: HTMLButtonElement) => void
-}
+export type ButtonProps = A11yProps &
+  Readonly<{
+    children: string | number | React.ReactNode
+    type?: string
+    href?: string | JSX.Element
+    className?: string
+    title?: string
+    status?: ButtonStatus
+    focus?: boolean
+    isBubble?: boolean
+    shadowed?: boolean
+    onClick?: (event: React.MouseEvent<HTMLElement>) => void
+    onBlur?: (event: React.FocusEventHandler<HTMLElement>) => void
+    onFocus?: (event: React.FocusEventHandler<HTMLElement>) => void
+    onMouseDown?: (event: React.MouseEvent<HTMLElement>) => void
+    onMouseUp?: (event: React.MouseEvent<HTMLElement>) => void
+    onTouchStart?: (event: React.TouchEvent<HTMLElement>) => void
+    onTouchEnd?: (event: React.TouchEvent<HTMLElement>) => void
+    onDoneAnimationEnd?: () => void
+    tabIndex?: string
+    disabled?: boolean
+    index?: string
+    buttonRef?: (button: HTMLButtonElement) => void
+  }>
 
-export interface ButtonState {
-  readonly value: {
+export type ButtonState = Readonly<{
+  value: {
     name: string
     value: string
   }
-}
+}>
 
 type ButtonActionEvents =
   | React.MouseEvent<HTMLElement>

--- a/src/buttonGroup/ButtonGroup.tsx
+++ b/src/buttonGroup/ButtonGroup.tsx
@@ -5,13 +5,13 @@ import { prefix } from '../_utils'
 import { ButtonProps, ButtonStatus } from '../button'
 import { StyledButtonGroup } from './ButtonGroup.style'
 
-export interface ButtonGroupProps {
-  readonly children: React.ReactElement<ButtonProps>[]
-  readonly className?: string
-  readonly isInline?: boolean
-  readonly isReverse?: boolean
-  readonly loadingIndex?: string
-}
+export type ButtonGroupProps = Readonly<{
+  children: React.ReactElement<ButtonProps>[]
+  className?: string
+  isInline?: boolean
+  isReverse?: boolean
+  loadingIndex?: string
+}>
 
 const BASE_CLASSNAME = 'button-group'
 

--- a/src/caption/Caption.tsx
+++ b/src/caption/Caption.tsx
@@ -13,13 +13,13 @@ export const renderSecondary = (href?: string, secondaryText?: string) =>
     <span>{secondaryText}</span>
   )
 
-export interface CaptionProps {
-  readonly className?: string
-  readonly children: any
-  readonly isoDate: string
-  readonly href?: string
-  readonly secondaryText?: string
-}
+export type CaptionProps = Readonly<{
+  className?: string
+  children: any
+  isoDate: string
+  href?: string
+  secondaryText?: string
+}>
 
 export const Caption = ({ className, children, href, secondaryText, isoDate }: CaptionProps) => (
   <StyledCaption className={cc(['kirk-caption', className])}>

--- a/src/confirmationModal/ConfirmationModal.tsx
+++ b/src/confirmationModal/ConfirmationModal.tsx
@@ -15,12 +15,14 @@ export enum ConfirmationModalStatus {
   WARNING = 'warning',
   REMINDER = 'reminder',
 }
-export interface ConfirmationModalProps extends ModalProps {
-  readonly status: ConfirmationModalStatus
-  readonly onConfirm?: () => void
-  readonly confirmLabel?: string
-  readonly confirmIsLoading?: boolean
-}
+
+export type ConfirmationModalProps = ModalProps &
+  Readonly<{
+    status: ConfirmationModalStatus
+    onConfirm?: () => void
+    confirmLabel?: string
+    confirmIsLoading?: boolean
+  }>
 
 export class ConfirmationModal extends Component<ConfirmationModalProps> {
   static defaultProps: Partial<ConfirmationModalProps> = {

--- a/src/datePicker/DatePicker.tsx
+++ b/src/datePicker/DatePicker.tsx
@@ -23,28 +23,28 @@ export enum DatePickerOrientation {
   VERTICAL = 'vertical',
 }
 
-export interface DatePickerProps {
-  readonly name: string
-  readonly locale?: string
-  readonly weekdaysShort?: string[]
-  readonly weekdaysLong?: string[]
-  readonly months?: string[]
-  readonly onChange?: (obj: OnChangeParameters) => void
-  readonly initialDate?: Date
-  readonly initialMonth?: Date
-  readonly className?: string
-  readonly numberOfMonths?: number
-  readonly orientation?: DatePickerOrientation
-  readonly isOutsideRange?: (day: Date) => boolean
-  readonly fromMonth?: Date
-  readonly toMonth?: Date
-  readonly firstDayOfWeek?: number
-  readonly stickyPositionTop?: number
-  readonly focus?: boolean
-}
+export type DatePickerProps = Readonly<{
+  name: string
+  locale?: string
+  weekdaysShort?: string[]
+  weekdaysLong?: string[]
+  months?: string[]
+  onChange?: (obj: OnChangeParameters) => void
+  initialDate?: Date
+  initialMonth?: Date
+  className?: string
+  numberOfMonths?: number
+  orientation?: DatePickerOrientation
+  isOutsideRange?: (day: Date) => boolean
+  fromMonth?: Date
+  toMonth?: Date
+  firstDayOfWeek?: number
+  stickyPositionTop?: number
+  focus?: boolean
+}>
 
-export interface DatePickerState {
-  readonly date: Date
+export type DatePickerState = {
+  date: Date
 }
 
 export class DatePicker extends PureComponent<DatePickerProps, DatePickerState> {

--- a/src/disclaimer/Disclaimer.tsx
+++ b/src/disclaimer/Disclaimer.tsx
@@ -8,18 +8,18 @@ import { InfoIcon } from '../icon/infoIcon'
 import { QuestionIcon } from '../icon/questionIcon'
 import { TextDisplayType } from '../text'
 
-export interface DisclaimerProps {
+export type DisclaimerProps = Readonly<{
   // Whether to use a decoration Info icon on the left side of the Disclaimer or not.
-  readonly useInfoIcon?: boolean
-  readonly children: string | JSX.Element
+  useInfoIcon?: boolean
+  children: string | JSX.Element
   // Whether this Disclaimer will be used as caption to another fragment of UI. In that case, it
   // will use some caption visual styles (e.g. smaller font)
-  readonly isCaption?: boolean
+  isCaption?: boolean
   // Whether to use a clickable Question mark blue icon on the right side of the Disclaimer or
   // not. Activating this affordance will redirect to deprecatedHelpUrl.
   // This is deprecated, you should use inline links inside the Disclaimer content instead.
-  readonly deprecatedHelpUrl?: string
-}
+  deprecatedHelpUrl?: string
+}>
 
 const StyledDisclaimer = styled(Item)`
   .kirk-item {

--- a/src/divider/Divider.tsx
+++ b/src/divider/Divider.tsx
@@ -5,9 +5,10 @@ import styled from 'styled-components'
 import { color, space } from '../_utils/branding'
 import { normalizeHorizontally, NormalizeProps } from '../layout/layoutNormalizer'
 
-export interface DividerProps extends NormalizeProps {
-  readonly className?: string
-}
+export type DividerProps = NormalizeProps &
+  Readonly<{
+    className?: string
+  }>
 
 const StyledDivider = styled.div`
   /* HorizontalNormalization */

--- a/src/drawer/Drawer.tsx
+++ b/src/drawer/Drawer.tsx
@@ -11,16 +11,16 @@ const DrawerGlobalStyles = createGlobalStyle`
   }
 `
 
-export interface DrawerProps {
-  readonly children: string | JSX.Element
-  readonly className?: string
-  readonly innerClassName?: string
-  readonly onOpen?: () => void
-  readonly onClose?: () => void
-  readonly onTransitionEnd?: (open: boolean) => void
-  readonly width?: string
-  readonly open?: boolean
-}
+export type DrawerProps = Readonly<{
+  children: string | JSX.Element
+  className?: string
+  innerClassName?: string
+  onOpen?: () => void
+  onClose?: () => void
+  onTransitionEnd?: (open: boolean) => void
+  width?: string
+  open?: boolean
+}>
 
 export class Drawer extends PureComponent<DrawerProps> {
   private contentNode: HTMLDivElement

--- a/src/dropdownButton/DropdownButton.tsx
+++ b/src/dropdownButton/DropdownButton.tsx
@@ -4,13 +4,13 @@ import cc from 'classcat'
 import { color } from '../_utils/branding'
 import { ChevronIcon } from '../icon/chevronIcon'
 
-export interface DropdownButtonProps {
+export type DropdownButtonProps = Readonly<{
   onClick: (event: React.MouseEvent<HTMLElement>) => void
   children: JSX.Element | string
   open?: boolean
   className?: string
   iconPosition?: 'left' | 'right'
-}
+}>
 
 export const DropdownButton = ({
   open = false,

--- a/src/emptyState/EmptyState.tsx
+++ b/src/emptyState/EmptyState.tsx
@@ -4,12 +4,12 @@ import cc from 'classcat'
 import { Title } from '../title'
 import { StyledEmptyState } from './EmptyState.style'
 
-export interface EmptyStateProps {
-  readonly className?: string
-  readonly image: string
-  readonly text: string
-  readonly button?: JSX.Element
-}
+export type EmptyStateProps = Readonly<{
+  className?: string
+  image: string
+  text: string
+  button?: JSX.Element
+}>
 
 export const EmptyState = ({ className, image, text, button }: EmptyStateProps) => (
   <StyledEmptyState className={cc(['kirk-empty-state', className])}>

--- a/src/grip/Grip.tsx
+++ b/src/grip/Grip.tsx
@@ -3,13 +3,14 @@ import React, { useEffect, useRef } from 'react'
 import { A11yProps, pickA11yProps } from '../_utils/interfaces'
 import { GripHandle } from './GripHandle'
 
-export interface GripProps extends A11yProps {
-  children?: React.ReactNode
-  onSlideUp: () => void
-  onSlideDown: () => void
-  className?: string
-  disabled?: boolean
-}
+export type GripProps = A11yProps &
+  Readonly<{
+    children?: React.ReactNode
+    onSlideUp: () => void
+    onSlideDown: () => void
+    className?: string
+    disabled?: boolean
+  }>
 
 export const SLIDE_OFFSET = 20 // To get more precise with feeling/testing
 

--- a/src/hamburgerButton/HamburgerButton.tsx
+++ b/src/hamburgerButton/HamburgerButton.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import cc from 'classcat'
 
-export interface HamburgerButtonProps {
+export type HamburgerButtonProps = Readonly<{
   onClick: (event: React.MouseEvent<HTMLElement>) => void
   open?: boolean
-  readonly className?: string
-}
+  className?: string
+}>
 
 export const HamburgerButton = ({ open = false, onClick, className }: HamburgerButtonProps) => (
   <button className={cc([className])} aria-expanded={open} onClick={onClick}>

--- a/src/hint/Hint.tsx
+++ b/src/hint/Hint.tsx
@@ -6,20 +6,17 @@ import { A11yProps, pickA11yProps } from '../_utils/interfaces'
 import { StyledHint } from './Hint.style'
 import { HintBubble, HintBubblePosition } from './HintBubble'
 
-export interface HintProps extends A11yProps {
-  children: (a11yAttrs: A11yProps) => React.ReactNode
-  title: string
-  closeButtonTitle?: string
-  description?: string
-  position?: HintBubblePosition
-  className?: string
-  onClose?: () => void
-  hidden?: boolean
-}
-
-export interface HintState {
-  hiddenBubble: boolean
-}
+export type HintProps = A11yProps &
+  Readonly<{
+    children: (a11yAttrs: A11yProps) => React.ReactNode
+    title: string
+    closeButtonTitle?: string
+    description?: string
+    position?: HintBubblePosition
+    className?: string
+    onClose?: () => void
+    hidden?: boolean
+  }>
 
 export const Hint = (props: HintProps): JSX.Element => {
   const {

--- a/src/hint/HintBubble.tsx
+++ b/src/hint/HintBubble.tsx
@@ -12,14 +12,15 @@ export enum HintBubblePosition {
   BELOW = 'below',
 }
 
-export interface HintBubbleProps extends A11yProps {
-  title: string
-  className?: string
-  onClose: () => void
-  closeButtonTitle?: string
-  description?: string
-  position?: HintBubblePosition
-}
+export type HintBubbleProps = A11yProps &
+  Readonly<{
+    title: string
+    className?: string
+    onClose: () => void
+    closeButtonTitle?: string
+    description?: string
+    position?: HintBubblePosition
+  }>
 
 const HintBubble = (props: HintBubbleProps): JSX.Element => {
   const a11yProps = pickA11yProps<HintBubbleProps>(props)

--- a/src/icon/arrowIcon.tsx
+++ b/src/icon/arrowIcon.tsx
@@ -2,9 +2,10 @@ import React from 'react'
 
 import { BaseIcon, BaseIconDefaultProps, Icon } from '../_utils/icon'
 
-export interface ArrowIconProps extends Icon {
-  readonly right?: boolean
-}
+export type ArrowIconProps = Icon &
+  Readonly<{
+    right?: boolean
+  }>
 
 export const ArrowIcon = ({ right, ...props }: ArrowIconProps) => (
   <BaseIcon {...props}>

--- a/src/icon/checkIcon.tsx
+++ b/src/icon/checkIcon.tsx
@@ -6,12 +6,13 @@ import styled from 'styled-components'
 import { color } from '../_utils/branding'
 import { BaseIcon, BaseIconDefaultProps, Icon } from '../_utils/icon'
 
-export interface CheckIconProps extends Icon {
-  readonly absolute?: boolean
-  readonly validate?: boolean
-  readonly backgroundColor?: string
-  readonly thin?: boolean
-}
+export type CheckIconProps = Icon &
+  Readonly<{
+    absolute?: boolean
+    validate?: boolean
+    backgroundColor?: string
+    thin?: boolean
+  }>
 
 const defaultBackgroundColor = 'transparent'
 

--- a/src/icon/chevronIcon.tsx
+++ b/src/icon/chevronIcon.tsx
@@ -2,10 +2,11 @@ import React from 'react'
 
 import { BaseIcon, BaseIconDefaultProps, Icon } from '../_utils/icon'
 
-export interface ChevronIconProps extends Icon {
-  readonly down?: boolean
-  readonly left?: boolean
-}
+export type ChevronIconProps = Icon &
+  Readonly<{
+    down?: boolean
+    left?: boolean
+  }>
 
 export const ChevronIcon = ({ down, left, ...props }: ChevronIconProps) => (
   <BaseIcon {...props}>

--- a/src/icon/circleIcon.tsx
+++ b/src/icon/circleIcon.tsx
@@ -6,12 +6,13 @@ import styled, { keyframes } from 'styled-components'
 import { color } from '../_utils/branding'
 import { BaseIcon, BaseIconDefaultProps, Icon } from '../_utils/icon'
 
-export interface CircleIconProps extends Icon {
-  readonly absolute?: boolean
-  readonly spinning?: boolean
-  readonly thin?: boolean
-  readonly innerDisc?: boolean
-}
+export type CircleIconProps = Icon &
+  Readonly<{
+    absolute?: boolean
+    spinning?: boolean
+    thin?: boolean
+    innerDisc?: boolean
+  }>
 
 const offset = 187
 const duration = '1.4s'

--- a/src/icon/eyeIcon.tsx
+++ b/src/icon/eyeIcon.tsx
@@ -3,9 +3,10 @@ import React from 'react'
 
 import { BaseIcon, BaseIconDefaultProps, Icon } from '../_utils/icon'
 
-export interface EyeIconProps extends Icon {
-  readonly off?: boolean
-}
+export type EyeIconProps = Icon &
+  Readonly<{
+    off?: boolean
+  }>
 
 export const EyeIcon = ({ off, ...props }: EyeIconProps) => (
   <BaseIcon {...props}>

--- a/src/icon/meetingPoint.tsx
+++ b/src/icon/meetingPoint.tsx
@@ -5,10 +5,11 @@ import cc from 'classcat'
 import { color } from '../_utils/branding'
 import { BaseIcon, BaseIconDefaultProps, Icon } from '../_utils/icon'
 
-export interface MeetingPointIconProps extends Icon {
-  readonly active?: boolean
-  readonly shadowed?: boolean
-}
+export type MeetingPointIconProps = Icon &
+  Readonly<{
+    active?: boolean
+    shadowed?: boolean
+  }>
 
 export const MeetingPointIcon = ({ active, shadowed, ...props }: MeetingPointIconProps) => {
   const strokeColor = active ? color.white : color.blue

--- a/src/icon/myRides.tsx
+++ b/src/icon/myRides.tsx
@@ -4,9 +4,10 @@ import React from 'react'
 import { color } from '../_utils/branding'
 import { BaseIcon, BaseIconDefaultProps, Icon } from '../_utils/icon'
 
-export interface MyRidesIconProps extends Icon {
-  readonly active?: boolean
-}
+export type MyRidesIconProps = Icon &
+  Readonly<{
+    active?: boolean
+  }>
 
 export const MyRidesIcon = ({ active, ...props }: MyRidesIconProps) => (
   <BaseIcon {...props} viewBox="0 0 24 20">

--- a/src/icon/pinIcon.tsx
+++ b/src/icon/pinIcon.tsx
@@ -3,10 +3,11 @@ import React from 'react'
 import { color } from '../_utils/branding'
 import { BaseIcon, BaseIconDefaultProps, Icon } from '../_utils/icon'
 
-export interface PinIconProps extends Icon {
-  readonly bgColor?: string
-  readonly strokeColor?: string
-}
+export type PinIconProps = Icon &
+  Readonly<{
+    bgColor?: string
+    strokeColor?: string
+  }>
 
 export const PinIcon = ({ bgColor, strokeColor, isDisabled, ...props }: PinIconProps) => (
   <BaseIcon {...props}>

--- a/src/icon/searchIcon.tsx
+++ b/src/icon/searchIcon.tsx
@@ -2,9 +2,10 @@ import React from 'react'
 
 import { BaseIcon, BaseIconDefaultProps, Icon } from '../_utils/icon'
 
-export interface SearchIconProps extends Icon {
-  readonly strokeWidth?: string
-}
+export type SearchIconProps = Icon &
+  Readonly<{
+    strokeWidth?: string
+  }>
 
 export const SearchIcon = ({ strokeWidth, ...props }: SearchIconProps) => (
   <BaseIcon {...props}>

--- a/src/icon/starIcon.tsx
+++ b/src/icon/starIcon.tsx
@@ -3,10 +3,11 @@ import React from 'react'
 import { color } from '../_utils/branding'
 import { BaseIcon, BaseIconDefaultProps, Icon } from '../_utils/icon'
 
-export interface StarIconProps extends Icon {
-  readonly bgColor?: string
-  readonly fill?: number
-}
+export type StarIconProps = Icon &
+  Readonly<{
+    bgColor?: string
+    fill?: number
+  }>
 
 export const StarIcon = ({ bgColor, fill, ...props }: StarIconProps) => {
   // needs to be unique, otherwise all stars will use the first defined linear gradient

--- a/src/itemAction/ItemAction.tsx
+++ b/src/itemAction/ItemAction.tsx
@@ -7,22 +7,24 @@ import { A11yProps, pickA11yProps } from '../_utils/interfaces'
 import { NormalizeProps } from '../layout/layoutNormalizer'
 import { Loader } from '../loader/Loader'
 
-export interface ItemActionProps extends NormalizeProps, A11yProps {
-  readonly highlighted?: boolean
-  readonly tag?: JSX.Element
-  readonly className?: string
-  readonly href?: string | JSX.Element
-  readonly action?: string
-  readonly subLabel?: string
-  readonly status?: ItemStatus
-  readonly leftAddon?: React.ReactNode
-  readonly onClick?: (event: React.MouseEvent<HTMLElement>) => void
-  readonly onBlur?: (event: React.FocusEventHandler<HTMLElement>) => void
-  readonly onFocus?: (event: React.FocusEventHandler<HTMLElement>) => void
-  readonly onMouseDown?: (event: React.MouseEvent<HTMLElement>) => void
-  readonly onDoneAnimationEnd?: () => void
-  readonly hideHoverBackground?: boolean
-}
+export type ItemActionProps = NormalizeProps &
+  A11yProps &
+  Readonly<{
+    highlighted?: boolean
+    tag?: JSX.Element
+    className?: string
+    href?: string | JSX.Element
+    action?: string
+    subLabel?: string
+    status?: ItemStatus
+    leftAddon?: React.ReactNode
+    onClick?: (event: React.MouseEvent<HTMLElement>) => void
+    onBlur?: (event: React.FocusEventHandler<HTMLElement>) => void
+    onFocus?: (event: React.FocusEventHandler<HTMLElement>) => void
+    onMouseDown?: (event: React.MouseEvent<HTMLElement>) => void
+    onDoneAnimationEnd?: () => void
+    hideHoverBackground?: boolean
+  }>
 
 export class ItemAction extends PureComponent<ItemActionProps> {
   static defaultProps: Partial<ItemActionProps> = {

--- a/src/itemBigData/ItemBigData.tsx
+++ b/src/itemBigData/ItemBigData.tsx
@@ -6,12 +6,14 @@ import { A11yProps, pickA11yProps } from '../_utils/interfaces'
 import { NormalizeProps } from '../layout/layoutNormalizer'
 import { TextDisplay2 } from '../typography/display2'
 
-export interface ItemBigDataProps extends NormalizeProps, A11yProps {
-  readonly mainInfo?: string
-  readonly className?: string
-  readonly mainTitle?: string
-  readonly tag?: JSX.Element
-}
+export type ItemBigDataProps = NormalizeProps &
+  A11yProps &
+  Readonly<{
+    mainInfo?: string
+    className?: string
+    mainTitle?: string
+    tag?: JSX.Element
+  }>
 
 const StyledItemBigData = styled(Item)`
   & .kirk-item-leftText {

--- a/src/itemCheckbox/ItemCheckbox.tsx
+++ b/src/itemCheckbox/ItemCheckbox.tsx
@@ -13,20 +13,22 @@ export enum ItemCheckboxStatus {
   LOADING = 'loading',
 }
 
-export interface ItemCheckboxProps extends NormalizeProps, A11yProps {
-  readonly className?: string
-  readonly name: string
-  readonly leftAddon?: React.ReactNode
-  readonly labelTitle?: string
-  readonly label: string
-  readonly data?: string
-  readonly dataInfo?: string
-  readonly checked?: boolean
-  readonly disabled?: boolean
-  readonly onChange?: (obj: OnChangeParameters) => void
-  readonly status?: ItemCheckboxStatus
-  readonly key?: string | number
-}
+export type ItemCheckboxProps = NormalizeProps &
+  A11yProps &
+  Readonly<{
+    className?: string
+    name: string
+    leftAddon?: React.ReactNode
+    labelTitle?: string
+    label: string
+    data?: string
+    dataInfo?: string
+    checked?: boolean
+    disabled?: boolean
+    onChange?: (obj: OnChangeParameters) => void
+    status?: ItemCheckboxStatus
+    key?: string | number
+  }>
 
 export class ItemCheckbox extends Component<ItemCheckboxProps> {
   static defaultProps: Partial<ItemCheckboxProps> = {

--- a/src/itemChoice/ItemChoice.tsx
+++ b/src/itemChoice/ItemChoice.tsx
@@ -17,24 +17,26 @@ export enum ItemChoiceStyle {
 
 export const ItemChoiceStatus = ItemStatus
 
-export interface ItemChoiceProps extends A11yProps, NormalizeProps {
-  readonly label?: string
-  readonly labelInfo?: React.ReactNode
-  readonly data?: string
-  readonly dataInfo?: string
-  readonly leftAddon?: JSX.Element
-  readonly rightAddon?: JSX.Element
-  readonly className?: string
-  readonly href?: string | JSX.Element
-  readonly status?: ItemStatus
-  readonly style?: ItemChoiceStyle
-  readonly disabled?: boolean
-  readonly onClick?: (event: React.MouseEvent<HTMLElement>) => void
-  readonly onBlur?: (event: React.FocusEventHandler<HTMLElement>) => void
-  readonly onFocus?: (event: React.FocusEventHandler<HTMLElement>) => void
-  readonly onMouseDown?: (event: React.MouseEvent<HTMLElement>) => void
-  readonly onDoneAnimationEnd?: () => void
-}
+export type ItemChoiceProps = A11yProps &
+  NormalizeProps &
+  Readonly<{
+    label?: string
+    labelInfo?: React.ReactNode
+    data?: string
+    dataInfo?: string
+    leftAddon?: JSX.Element
+    rightAddon?: JSX.Element
+    className?: string
+    href?: string | JSX.Element
+    status?: ItemStatus
+    style?: ItemChoiceStyle
+    disabled?: boolean
+    onClick?: (event: React.MouseEvent<HTMLElement>) => void
+    onBlur?: (event: React.FocusEventHandler<HTMLElement>) => void
+    onFocus?: (event: React.FocusEventHandler<HTMLElement>) => void
+    onMouseDown?: (event: React.MouseEvent<HTMLElement>) => void
+    onDoneAnimationEnd?: () => void
+  }>
 
 export class ItemChoice extends PureComponent<ItemChoiceProps> {
   static defaultProps: Partial<ItemChoiceProps> = {

--- a/src/itemData/ItemData.tsx
+++ b/src/itemData/ItemData.tsx
@@ -6,18 +6,20 @@ import { Button } from '../button/Button'
 import { NormalizeProps } from '../layout/layoutNormalizer'
 import { TextDisplayType } from '../text'
 
-export interface ItemDataProps extends NormalizeProps, A11yProps {
-  readonly data: string | JSX.Element
-  readonly dataStrikeThrough?: boolean
-  readonly dataAriaProps?: A11yProps
-  readonly mainInfo: React.ReactNode
-  readonly className?: string
-  readonly mainTitle?: string
-  readonly mainTitleButtonAddon?: React.ReactElement<Button>
-  readonly dataInfo?: string
-  readonly tag?: JSX.Element
-  readonly disabled?: boolean
-}
+export type ItemDataProps = NormalizeProps &
+  A11yProps &
+  Readonly<{
+    data: string | JSX.Element
+    dataStrikeThrough?: boolean
+    dataAriaProps?: A11yProps
+    mainInfo: React.ReactNode
+    className?: string
+    mainTitle?: string
+    mainTitleButtonAddon?: React.ReactElement<Button>
+    dataInfo?: string
+    tag?: JSX.Element
+    disabled?: boolean
+  }>
 
 export const ItemData = (props: ItemDataProps) => {
   const {

--- a/src/itemInfo/ItemInfo.tsx
+++ b/src/itemInfo/ItemInfo.tsx
@@ -4,13 +4,15 @@ import { Item } from '../_internals/item'
 import { A11yProps, pickA11yProps } from '../_utils/interfaces'
 import { NormalizeProps } from '../layout/layoutNormalizer'
 
-export interface ItemInfoProps extends A11yProps, NormalizeProps {
-  readonly mainInfo?: string
-  readonly className?: string
-  readonly icon?: React.ReactNode
-  readonly mainTitle?: string
-  readonly tag?: JSX.Element
-}
+export type ItemInfoProps = A11yProps &
+  NormalizeProps &
+  Readonly<{
+    mainInfo?: string
+    className?: string
+    icon?: React.ReactNode
+    mainTitle?: string
+    tag?: JSX.Element
+  }>
 
 export const ItemInfo = (props: ItemInfoProps) => {
   const { mainInfo, className, mainTitle, icon, tag, hasHorizontalSpacing = false } = props

--- a/src/itemRadio/ItemRadio.tsx
+++ b/src/itemRadio/ItemRadio.tsx
@@ -13,27 +13,29 @@ export enum ItemRadioStatus {
   LOADING = 'loading',
 }
 
-export interface ItemRadioProps extends A11yProps, NormalizeProps {
-  readonly className?: string
-  readonly name: string
-  readonly value: string | number
-  readonly leftAddon?: React.ReactNode
-  readonly labelTitle?: string
-  readonly label: string
-  readonly data?: string
-  readonly dataInfo?: string
-  readonly checked?: boolean
-  readonly disabled?: boolean
-  readonly chevron?: boolean
-  readonly highlighted?: boolean
-  readonly onChange?: (obj: OnChangeParameters) => void
-  readonly onClick?: (obj: OnChangeParameters) => void
-  readonly status?: ItemRadioStatus
-  readonly key?: string | number
-}
+export type ItemRadioProps = A11yProps &
+  NormalizeProps &
+  Readonly<{
+    className?: string
+    name: string
+    value: string | number
+    leftAddon?: React.ReactNode
+    labelTitle?: string
+    label: string
+    data?: string
+    dataInfo?: string
+    checked?: boolean
+    disabled?: boolean
+    chevron?: boolean
+    highlighted?: boolean
+    onChange?: (obj: OnChangeParameters) => void
+    onClick?: (obj: OnChangeParameters) => void
+    status?: ItemRadioStatus
+    key?: string | number
+  }>
 
-interface ItemRadioState {
-  readonly focus: boolean
+type ItemRadioState = {
+  focus: boolean
 }
 
 export class ItemRadio extends Component<ItemRadioProps> {

--- a/src/itemRadioGroup/index.tsx
+++ b/src/itemRadioGroup/index.tsx
@@ -5,19 +5,20 @@ import { A11yProps, pickA11yProps } from '../_utils/interfaces'
 import { ItemRadioProps, ItemRadioStatus } from '../itemRadio/ItemRadio'
 import { ItemsList } from '../itemsList'
 
-export interface ItemRadioGroupProps extends A11yProps {
-  readonly name: string
-  readonly children: React.ReactElement<ItemRadioProps>[]
-  readonly className?: string
-  readonly value?: string | number | boolean
-  readonly onChange?: (obj: OnChangeParameters) => void
-  readonly onClick?: (obj: OnChangeParameters) => void
-  readonly status?: ItemRadioStatus
-  readonly withSeparators?: boolean
-  readonly withChevrons?: boolean
-}
+export type ItemRadioGroupProps = A11yProps &
+  Readonly<{
+    name: string
+    children: React.ReactElement<ItemRadioProps>[]
+    className?: string
+    value?: string | number | boolean
+    onChange?: (obj: OnChangeParameters) => void
+    onClick?: (obj: OnChangeParameters) => void
+    status?: ItemRadioStatus
+    withSeparators?: boolean
+    withChevrons?: boolean
+  }>
 
-interface ItemRadioGroupState {
+type ItemRadioGroupState = {
   value: string | number | boolean
 }
 

--- a/src/itemsList/ItemsList.tsx
+++ b/src/itemsList/ItemsList.tsx
@@ -21,12 +21,13 @@ export type ItemsListChild =
   | React.ReactElement<ItemCheckboxProps>
   | null
 
-export interface ItemsListProps extends A11yProps {
-  readonly children: ItemsListChild[]
-  readonly withSeparators?: boolean
-  readonly className?: string
-  readonly keyGenerator?: (index: number) => string | number
-}
+export type ItemsListProps = A11yProps &
+  Readonly<{
+    children: ItemsListChild[]
+    withSeparators?: boolean
+    className?: string
+    keyGenerator?: (index: number) => string | number
+  }>
 
 export const ItemsList = (props: ItemsListProps) => {
   const {

--- a/src/itinerary/Itinerary.tsx
+++ b/src/itinerary/Itinerary.tsx
@@ -13,20 +13,21 @@ import { Bullet, BulletTypes } from '../bullet'
 import { SubHeader } from '../subHeader'
 import { Text, TextDisplayType, TextTagType } from '../text'
 
-export interface ItineraryProps extends A11yProps {
-  readonly places: Place[]
-  readonly className?: string
-  readonly fromAddon?: string
-  readonly toAddon?: string
-  readonly fromAddonAriaLabel?: string
-  readonly toAddonAriaLabel?: string
-  readonly small?: boolean
-  readonly headline?: string
-  readonly highlightRoad?: boolean
-  readonly isCollapsible?: boolean
-  readonly collapsedLabel?: string
-  readonly collapsedAriaProps?: A11yProps
-}
+export type ItineraryProps = A11yProps &
+  Readonly<{
+    places: Place[]
+    className?: string
+    fromAddon?: string
+    toAddon?: string
+    fromAddonAriaLabel?: string
+    toAddonAriaLabel?: string
+    small?: boolean
+    headline?: string
+    highlightRoad?: boolean
+    isCollapsible?: boolean
+    collapsedLabel?: string
+    collapsedAriaProps?: A11yProps
+  }>
 
 interface RootA11yProps {
   'aria-label'?: string

--- a/src/layout/column/column.tsx
+++ b/src/layout/column/column.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import cc from 'classcat'
 
-export interface ColumnProps {
-  readonly className?: string
-  readonly children?: React.ReactNode
-  readonly key?: string
-}
+export type ColumnProps = Readonly<{
+  className?: string
+  children?: React.ReactNode
+  key?: string
+}>
 
 /**
  * A child component for <Columns> parent component.

--- a/src/layout/columns/columns.tsx
+++ b/src/layout/columns/columns.tsx
@@ -3,10 +3,10 @@ import cc from 'classcat'
 
 import { ColumnProps } from '../../layout/column'
 
-export interface ColumnsProps {
-  readonly className?: string
-  readonly children: React.ReactElement<ColumnProps>[]
-}
+export type ColumnsProps = Readonly<{
+  className?: string
+  children: React.ReactElement<ColumnProps>[]
+}>
 
 /**
  * A parent component for <Column> component.

--- a/src/layout/layoutNormalizer.tsx
+++ b/src/layout/layoutNormalizer.tsx
@@ -9,9 +9,10 @@ const horizontalPadding = (props: any): string =>
 const horizontalMargin = (props: any): string | number =>
   props.hasHorizontalSpacing ? horizontalSpace.outer : 0
 
-export interface NormalizeProps {
-  readonly hasHorizontalSpacing?: boolean
-}
+export type NormalizeProps = Readonly<{
+  hasHorizontalSpacing?: boolean
+}>
+
 /**
  * Util method to normalize horizontal spacing
  * using !important because this should never be overridden
@@ -41,9 +42,9 @@ const LayoutNormalizationGlobalStyles = createGlobalStyle`
   // Add normalization styles.
 `
 
-export interface LayoutNormalizerProps {
-  readonly useLegacyNormalization?: boolean
-}
+export type LayoutNormalizerProps = Readonly<{
+  useLegacyNormalization?: boolean
+}>
 
 export const LayoutNormalizer = ({ useLegacyNormalization = true }: LayoutNormalizerProps) => {
   if (useLegacyNormalization) {

--- a/src/layout/section/baseSection/baseSection.tsx
+++ b/src/layout/section/baseSection/baseSection.tsx
@@ -6,16 +6,16 @@ export enum SectionContentSize {
   LARGE = 'large',
 }
 
-export interface BaseSectionProps {
-  readonly className?: string
-  readonly contentClassName?: string
-  readonly backgroundStyle?: object
-  readonly tagName?: string
-  readonly role?: string
-  readonly children: JSX.Element | string | React.ReactNode
-  readonly contentSize?: SectionContentSize
-  readonly noHorizontalSpacing?: boolean
-}
+export type BaseSectionProps = Readonly<{
+  className?: string
+  contentClassName?: string
+  backgroundStyle?: object
+  tagName?: string
+  role?: string
+  children: JSX.Element | string | React.ReactNode
+  contentSize?: SectionContentSize
+  noHorizontalSpacing?: boolean
+}>
 
 /**
  * The core section: It sections horizontally a page while fitting its

--- a/src/layout/section/cardsSection/CardsSection.tsx
+++ b/src/layout/section/cardsSection/CardsSection.tsx
@@ -6,11 +6,11 @@ import { TripCardProps } from '../../../tripCard'
 
 type CardsProps = TripCardProps | QrCardProps
 
-export interface CardsSectionProps {
-  readonly children: React.ReactElement<CardsProps>[] | React.ReactElement<CardsProps>
-  readonly className?: string
-  readonly width?: string
-}
+export type CardsSectionProps = Readonly<{
+  children: React.ReactElement<CardsProps>[] | React.ReactElement<CardsProps>
+  className?: string
+  width?: string
+}>
 
 export const CardsSection = ({ children, className = '' }: CardsSectionProps) => (
   <div className={cc(['kirk-cardsSection-wrapper', className])}>

--- a/src/layout/section/columnedContentSection/columnedContentSection.tsx
+++ b/src/layout/section/columnedContentSection/columnedContentSection.tsx
@@ -7,15 +7,15 @@ import { BaseSection, SectionContentSize } from '../../../layout/section/baseSec
 import { Text, TextTagType } from '../../../text'
 import { Title } from '../../../title'
 
-export interface ColumnedContentSectionProps {
-  readonly className?: string
-  readonly title: string
-  readonly topLinkLabel?: string
-  readonly topLinkHref?: string | JSX.Element
-  readonly columnContentList: ColumnContent[]
-}
+export type ColumnedContentSectionProps = Readonly<{
+  className?: string
+  title: string
+  topLinkLabel?: string
+  topLinkHref?: string | JSX.Element
+  columnContentList: ColumnContent[]
+}>
 
-interface ColumnContent {
+export interface ColumnContent {
   readonly title: string
   readonly content: string
   readonly media?: Media

--- a/src/layout/section/highlightSection/highlightSection.tsx
+++ b/src/layout/section/highlightSection/highlightSection.tsx
@@ -3,12 +3,12 @@ import React from 'react'
 import { BaseSection, SectionContentSize } from '../../../layout/section/baseSection'
 import { SubHeader } from '../../../subHeader'
 
-export interface HighlightSectionProps {
-  readonly className?: string
-  readonly contentClassName?: string
-  readonly children: React.ReactNode
-  readonly title?: string
-}
+export type HighlightSectionProps = Readonly<{
+  className?: string
+  contentClassName?: string
+  children: React.ReactNode
+  title?: string
+}>
 
 /**
  * A specialized section with an highlighting background color.

--- a/src/layout/section/illustratedSection/illustratedSection.tsx
+++ b/src/layout/section/illustratedSection/illustratedSection.tsx
@@ -3,13 +3,13 @@ import React from 'react'
 import { Avatar } from '../../../avatar'
 import { BaseSection, SectionContentSize } from '../../../layout/section/baseSection'
 
-export interface IllustratedSectionProps {
-  readonly children: React.ReactNode
-  readonly className?: string
-  readonly illustrationUrl: string
-  readonly illustrationAlt?: string
-  readonly isAvatar?: boolean
-}
+export type IllustratedSectionProps = Readonly<{
+  children: React.ReactNode
+  className?: string
+  illustrationUrl: string
+  illustrationAlt?: string
+  isAvatar?: boolean
+}>
 
 /**
  * A specialized section which show some content with an illustration.

--- a/src/layout/section/itemsSection/itemsSection.tsx
+++ b/src/layout/section/itemsSection/itemsSection.tsx
@@ -3,11 +3,11 @@ import React from 'react'
 import { ItemInfoProps } from '../../../itemInfo'
 import { BaseSection } from '../../../layout/section/baseSection'
 
-export interface ItemsSectionProps {
-  readonly children: React.ReactElement<ItemInfoProps>[]
-  readonly className?: string
-  readonly tag?: JSX.Element
-}
+export type ItemsSectionProps = Readonly<{
+  children: React.ReactElement<ItemInfoProps>[]
+  className?: string
+  tag?: JSX.Element
+}>
 
 /**
  * Items Section: display a list of items in a display: flex.

--- a/src/layout/section/mediaContentSection/mediaContentSection.tsx
+++ b/src/layout/section/mediaContentSection/mediaContentSection.tsx
@@ -8,15 +8,15 @@ import { BaseSection, SectionContentSize } from '../../../layout/section/baseSec
 import { Text, TextTagType } from '../../../text'
 import { TextDisplay1 } from '../../../typography/display1'
 
-export interface MediaContentSectionProps {
-  readonly className?: string
-  readonly mediaUrl: string
-  readonly title: string
-  readonly content?: string
-  readonly buttonLabel?: string
-  readonly buttonHref?: string | JSX.Element
-  readonly flipped?: boolean
-}
+export type MediaContentSectionProps = Readonly<{
+  className?: string
+  mediaUrl: string
+  title: string
+  content?: string
+  buttonLabel?: string
+  buttonHref?: string | JSX.Element
+  flipped?: boolean
+}>
 
 /**
  * A specialized section which show some marketing content associated with a picture.

--- a/src/layout/section/mediaSection/mediaSection.tsx
+++ b/src/layout/section/mediaSection/mediaSection.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import cc from 'classcat'
 
-export interface MediaSectionProps {
-  readonly className?: string
-  readonly role?: string
-  readonly children: React.ReactNode
-}
+export type MediaSectionProps = Readonly<{
+  className?: string
+  role?: string
+  children: React.ReactNode
+}>
 
 /**
  * The media section: Renders a fullscreen div without margins on small devices

--- a/src/layout/section/slideSection/SlideSection.tsx
+++ b/src/layout/section/slideSection/SlideSection.tsx
@@ -10,13 +10,13 @@ export enum SlideSectionPosition {
   EXPANDED = 'expanded',
 }
 
-export interface SlideSectionProps {
+export type SlideSectionProps = Readonly<{
   children: (d: () => void, r: () => void, e: () => void) => React.ReactNode
   media: React.ReactNode
   reducedContent?: React.ReactNode
   onPositionChange?: (p: SlideSectionPosition) => void
   disabledGestures?: boolean
-}
+}>
 
 export const SlideSection = (props: SlideSectionProps): JSX.Element => {
   const {

--- a/src/layout/section/tabsSection/tabsSection.tsx
+++ b/src/layout/section/tabsSection/tabsSection.tsx
@@ -3,10 +3,10 @@ import cc from 'classcat'
 
 import { Tabs, TabsProps } from '../../../tabs'
 
-export interface TabsSectionProps {
-  readonly className?: string
-  readonly tabsProps: TabsProps
-}
+export type TabsSectionProps = Readonly<{
+  className?: string
+  tabsProps: TabsProps
+}>
 
 /**
  * A specialized section based on the Tabs component.

--- a/src/loader/Loader.tsx
+++ b/src/loader/Loader.tsx
@@ -21,7 +21,7 @@ export enum LoaderLayoutMode {
   BLOCK = 'block',
 }
 
-export interface LoaderProps {
+export type LoaderProps = Readonly<{
   className?: string
   inline?: boolean // Deprecated, use layoutMode instead.
   size?: number
@@ -30,7 +30,7 @@ export interface LoaderProps {
   onDoneAnimationEnd?: () => void
   loadingAriaLabel?: string
   loadedAriaLabel?: string
-}
+}>
 
 export class Loader extends PureComponent<LoaderProps> {
   static defaultProps: Partial<LoaderProps> = {

--- a/src/marketingMessage/MarketingMessage.tsx
+++ b/src/marketingMessage/MarketingMessage.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import cc from 'classcat'
 
-export interface MarketingMessageProps {
-  readonly children: React.ReactNode
-  readonly className?: string
-}
+export type MarketingMessageProps = Readonly<{
+  children: React.ReactNode
+  className?: string
+}>
 
 export const MarketingMessage = ({ children, className }: MarketingMessageProps) => (
   <div className={cc(className)}>{children}</div>

--- a/src/menu/index.tsx
+++ b/src/menu/index.tsx
@@ -4,11 +4,11 @@ import cc from 'classcat'
 import { ItemChoiceProps } from '../itemChoice'
 import { ItemsList, ItemsListDivider } from '../itemsList'
 
-export interface MenuProps {
-  readonly children: React.ReactElement<ItemChoiceProps>[]
-  readonly className?: string
-  readonly withSeparators?: boolean
-}
+export type MenuProps = Readonly<{
+  children: React.ReactElement<ItemChoiceProps>[]
+  className?: string
+  withSeparators?: boolean
+}>
 
 export const Menu = ({ className, children, withSeparators = false }: MenuProps) => (
   /* TODO: BBC-7416 fix a11y issue */

--- a/src/message/Message.tsx
+++ b/src/message/Message.tsx
@@ -6,14 +6,14 @@ import { BlankSeparator, BlankSeparatorSize } from '../blankSeparator'
 import { Text, TextDisplayType } from '../text'
 import { StyledMessage } from './Message.style'
 
-export interface MessageProps {
-  readonly children: string
-  readonly date?: string
-  readonly active?: boolean
-  readonly author?: string | JSX.Element
-  readonly className?: string
-  readonly messageAnnotation?: string
-}
+export type MessageProps = Readonly<{
+  children: string
+  date?: string
+  active?: boolean
+  author?: string | JSX.Element
+  className?: string
+  messageAnnotation?: string
+}>
 
 export const Message = ({ active, children, messageAnnotation, className }: MessageProps) => (
   <StyledMessage className={cc(['kirk-message', prefix({ active }), className])}>

--- a/src/messagingSummaryItem/MessagingSummaryItem.tsx
+++ b/src/messagingSummaryItem/MessagingSummaryItem.tsx
@@ -7,15 +7,16 @@ import { Avatar } from '../avatar'
 import { NormalizeProps } from '../layout/layoutNormalizer'
 import { TextDisplayType } from '../text'
 
-export interface MessagingSummaryItemProps extends NormalizeProps {
-  readonly className?: string
-  readonly url: string
-  readonly pictureUrl: string
-  readonly label: string
-  readonly subLabel: string | JSX.Element
-  readonly timeLabel: string
-  readonly hasUnreadMessages: boolean
-}
+export type MessagingSummaryItemProps = NormalizeProps &
+  Readonly<{
+    className?: string
+    url: string
+    pictureUrl: string
+    label: string
+    subLabel: string | JSX.Element
+    timeLabel: string
+    hasUnreadMessages: boolean
+  }>
 
 const UNREAD_COLOR = color.midnightGreen
 const READ_COLOR = color.lightMidnightGreen

--- a/src/paragraph/Paragraph.tsx
+++ b/src/paragraph/Paragraph.tsx
@@ -7,16 +7,16 @@ import { StyledParagraph } from './Paragraph.style'
 
 const DEFAULT_MAX_CHAR_SIZE = 180
 
-export interface ParagraphProps {
-  readonly className?: string
-  readonly children: string
-  readonly isExpandable?: boolean
-  readonly expandLabel?: string
-  readonly itemProp?: string
-}
+export type ParagraphProps = Readonly<{
+  className?: string
+  children: string
+  isExpandable?: boolean
+  expandLabel?: string
+  itemProp?: string
+}>
 
-interface ParagraphState {
-  readonly isExpanded: boolean
+type ParagraphState = {
+  isExpanded: boolean
 }
 
 export class Paragraph extends PureComponent<ParagraphProps> {

--- a/src/phoneField/PhoneField.tsx
+++ b/src/phoneField/PhoneField.tsx
@@ -42,25 +42,26 @@ export interface PhoneFieldOnChangeParameters {
 }
 
 type errorField = string | JSX.Element
-export interface PhoneFieldProps extends A11yProps {
-  readonly name: string
-  readonly onChange: (obj: PhoneFieldOnChangeParameters) => void
-  readonly className?: string
-  readonly innerWrapperClassName?: string
-  readonly selectFieldLabel?: string
-  readonly textFieldTitle?: string
-  readonly textFieldPlaceholder?: string
-  readonly defaultRegionValue?: string
-  readonly defaultPhoneValue?: string
-  readonly countryWhitelist?: string[]
-  readonly customCountryNames?: PhoneFieldCustomCountryNames
-  readonly isInline?: boolean
-  readonly focus?: boolean
-  readonly selectAutoFocus?: boolean
-  error?: errorField
-}
+export type PhoneFieldProps = A11yProps &
+  Readonly<{
+    name: string
+    onChange: (obj: PhoneFieldOnChangeParameters) => void
+    className?: string
+    innerWrapperClassName?: string
+    selectFieldLabel?: string
+    textFieldTitle?: string
+    textFieldPlaceholder?: string
+    defaultRegionValue?: string
+    defaultPhoneValue?: string
+    countryWhitelist?: string[]
+    customCountryNames?: PhoneFieldCustomCountryNames
+    isInline?: boolean
+    focus?: boolean
+    selectAutoFocus?: boolean
+    error?: errorField
+  }>
 
-interface PhoneFieldState {
+type PhoneFieldState = {
   countryData: MappedCountryPhoneData[]
   countryWhitelist: string[]
   phonePrefix: string

--- a/src/profile/profile.tsx
+++ b/src/profile/profile.tsx
@@ -8,24 +8,25 @@ import { Rating } from '../rating'
 import { TextDisplayType } from '../text'
 import { TextBody } from '../typography/body'
 
-export interface ProfileProps extends A11yProps {
-  readonly className?: string
-  readonly title: string
-  readonly info?: string | JSX.Element
-  readonly isLink?: boolean
-  readonly picture?: string
-  readonly alt?: string
-  readonly isIdChecked?: boolean
-  readonly isMedium?: boolean
-  readonly score?: number
-  readonly ratings?: number
-  readonly ratingsLabel?: string
-  readonly href?: string | JSX.Element
-  readonly onClick?: (event: React.MouseEvent<HTMLElement>) => void
-  readonly onBlur?: (event: React.FocusEventHandler<HTMLElement>) => void
-  readonly onFocus?: (event: React.FocusEventHandler<HTMLElement>) => void
-  readonly onMouseDown?: (event: React.MouseEvent<HTMLElement>) => void
-}
+export type ProfileProps = A11yProps &
+  Readonly<{
+    className?: string
+    title: string
+    info?: string | JSX.Element
+    isLink?: boolean
+    picture?: string
+    alt?: string
+    isIdChecked?: boolean
+    isMedium?: boolean
+    score?: number
+    ratings?: number
+    ratingsLabel?: string
+    href?: string | JSX.Element
+    onClick?: (event: React.MouseEvent<HTMLElement>) => void
+    onBlur?: (event: React.FocusEventHandler<HTMLElement>) => void
+    onFocus?: (event: React.FocusEventHandler<HTMLElement>) => void
+    onMouseDown?: (event: React.MouseEvent<HTMLElement>) => void
+  }>
 
 export const Profile = (props: ProfileProps) => {
   const {

--- a/src/proximity/Proximity.tsx
+++ b/src/proximity/Proximity.tsx
@@ -45,11 +45,11 @@ const getColorAndTitle = (index: string, value: string, title: string) => {
   }
 }
 
-export interface ProximityProps {
-  readonly className?: string
-  readonly value: Distances
-  readonly title?: string
-}
+export type ProximityProps = Readonly<{
+  className?: string
+  value: Distances
+  title?: string
+}>
 
 export const Proximity = ({ value, title, className }: ProximityProps) => (
   <div className={cc(['kirk-proximity', className])}>

--- a/src/pushInfo/PushInfo.tsx
+++ b/src/pushInfo/PushInfo.tsx
@@ -3,13 +3,13 @@ import cc from 'classcat'
 
 import { animationDelay, animationDuration, StyledPushInfo } from './PushInfo.style'
 
-export interface PushInfoProps {
-  readonly className?: string
-  readonly icon?: React.ReactNode
-  readonly headline: string
-  readonly content?: string
-  readonly onAnimationEnd?: Function
-}
+export type PushInfoProps = Readonly<{
+  className?: string
+  icon?: React.ReactNode
+  headline: string
+  content?: string
+  onAnimationEnd?: Function
+}>
 
 export class PushInfo extends Component<PushInfoProps> {
   componentDidMount() {

--- a/src/qrCard/QrCard.tsx
+++ b/src/qrCard/QrCard.tsx
@@ -6,13 +6,14 @@ import { A11yProps, pickA11yProps } from '../_utils/interfaces'
 import { ItemInfo } from '../itemInfo'
 import { SubHeader } from '../subHeader'
 
-export interface QrCardProps extends A11yProps {
-  readonly className?: string
-  readonly imageUrl: string
-  readonly itemMainTitle?: string
-  readonly itemMainInfo?: string
-  readonly title: string
-}
+export type QrCardProps = A11yProps &
+  Readonly<{
+    className?: string
+    imageUrl: string
+    itemMainTitle?: string
+    itemMainInfo?: string
+    title: string
+  }>
 
 export const QrCard = (props: QrCardProps) => {
   const { className, itemMainTitle, imageUrl, itemMainInfo, title } = props

--- a/src/rating/Rating.tsx
+++ b/src/rating/Rating.tsx
@@ -3,12 +3,12 @@ import cc from 'classcat'
 
 import { Stars } from '../stars'
 
-export interface RatingProps {
+export type RatingProps = Readonly<{
   className?: string
   score?: number
   ratings: number
   children: string
-}
+}>
 
 export const Rating = ({
   className = '',

--- a/src/review/Review.tsx
+++ b/src/review/Review.tsx
@@ -6,14 +6,14 @@ import { Paragraph } from '../paragraph'
 import { TextTitle } from '../typography/title'
 import { StyledReview } from './Review.style'
 
-export interface ReviewProps {
-  readonly className?: string
-  readonly isResponse?: boolean
-  readonly title: string
-  readonly text: string
-  readonly formattedDatetime: string
-  readonly isoDatetime: string
-}
+export type ReviewProps = Readonly<{
+  className?: string
+  isResponse?: boolean
+  title: string
+  text: string
+  formattedDatetime: string
+  isoDatetime: string
+}>
 
 export const Review = (props: ReviewProps) => {
   const { className, title, text, formattedDatetime, isoDatetime, isResponse = false } = props

--- a/src/searchForm/SearchForm.tsx
+++ b/src/searchForm/SearchForm.tsx
@@ -26,7 +26,7 @@ import { StepperOverlay } from './stepper/overlay'
 import { StepperSection } from './stepper/section'
 import { TRANSITION_SECTION_CLASS_NAME, transitionSectionTimeout } from './transitionConfig'
 
-export interface SearchFormProps {
+export type SearchFormProps = Readonly<{
   className?: string
   onSubmit: (formValues: SearchFormValues) => void
   disabledFrom?: boolean
@@ -40,14 +40,14 @@ export interface SearchFormProps {
   renderDatePickerComponent?: DatePickerOverlayProps['renderDatePickerComponent']
   datepickerProps: SearchFormDatePickerProps
   stepperProps: SearchFormStepperProps
-}
+}>
 
-export interface SearchFormDatePickerProps {
+export type SearchFormDatePickerProps = Readonly<{
   defaultValue: string
   format?: (value: string) => string
-}
+}>
 
-export interface SearchFormStepperProps {
+export type SearchFormStepperProps = Readonly<{
   min: number
   max: number
   defaultValue: number
@@ -56,7 +56,7 @@ export interface SearchFormStepperProps {
   title: string
   confirmLabel: string
   format?: (value: number) => string
-}
+}>
 
 export enum SearchFormElements {
   DATEPICKER = 'DATEPICKER',

--- a/src/searchForm/stepper/overlay/StepperOverlay.tsx
+++ b/src/searchForm/stepper/overlay/StepperOverlay.tsx
@@ -6,9 +6,10 @@ import { Divider } from '../../../divider'
 import { StandardSeatIcon as StandardSeat } from '../../../icon/standardSeat'
 import { Stepper, StepperDisplay, StepperProps } from '../../../stepper'
 
-export interface StepperOverlayProps extends StepperProps {
-  itemTitle: string
-}
+export type StepperOverlayProps = StepperProps &
+  Readonly<{
+    itemTitle: string
+  }>
 
 export const StepperOverlay = ({ itemTitle, className, ...props }: StepperOverlayProps) => (
   <div className={cc(['kirk-stepperOverlay', className])}>

--- a/src/searchForm/stepper/section/StepperSection.tsx
+++ b/src/searchForm/stepper/section/StepperSection.tsx
@@ -12,12 +12,13 @@ import { BaseSection as Section } from '../../../layout/section/baseSection'
 import { Stepper, StepperDisplay, StepperProps } from '../../../stepper'
 import { TransitionSection } from '../../baseStyles'
 
-export interface StepperSectionProps extends StepperProps {
-  itemTitle: string
-  confirmLabel: string
-  onClose: () => void
-  onConfirm?: (event: React.MouseEvent<HTMLElement>) => void
-}
+export type StepperSectionProps = StepperProps &
+  Readonly<{
+    itemTitle: string
+    confirmLabel: string
+    onClose: () => void
+    onConfirm?: (event: React.MouseEvent<HTMLElement>) => void
+  }>
 
 const FullHeightSection = styled(Section)`
   height: 100%;

--- a/src/searchRecap/SearchRecap.tsx
+++ b/src/searchRecap/SearchRecap.tsx
@@ -7,12 +7,12 @@ import { SearchIcon } from '../icon/searchIcon'
 import { Text, TextTagType } from '../text'
 import { UneditableTextField } from '../uneditableTextField'
 
-export interface SearchRecapProps {
+export type SearchRecapProps = Readonly<{
   className?: string
   from?: string
   to?: string
   info?: string
-}
+}>
 
 export const separatorWidth: number = 14
 

--- a/src/selectField/SelectField.tsx
+++ b/src/selectField/SelectField.tsx
@@ -8,22 +8,25 @@ import { ChevronIcon } from '../icon/chevronIcon'
 
 export const selectHeight = '52px'
 
-export interface SelectFieldItem extends A11yProps {
-  readonly value: string | number
-  readonly label: string
-}
+export type SelectFieldItem = A11yProps &
+  Readonly<{
+    value: string | number
+    label: string
+  }>
 
-export interface SelectFieldProps extends Partial<CommonFieldsProps>, A11yProps {
-  readonly options: SelectFieldItem[]
-  readonly defaultValue?: string
-  readonly onChange?: (obj: OnChangeParameters) => void
-  readonly onFocus?: (event: React.FocusEvent<HTMLSelectElement>) => void
-  readonly onBlur?: (event: React.FocusEvent<HTMLSelectElement>) => void
-  readonly focus?: boolean
-  readonly focusBorder?: boolean
-  readonly autoFocus?: boolean
-  readonly autoComplete?: string
-}
+export type SelectFieldProps = Partial<CommonFieldsProps> &
+  A11yProps &
+  Readonly<{
+    options: SelectFieldItem[]
+    defaultValue?: string
+    onChange?: (obj: OnChangeParameters) => void
+    onFocus?: (event: React.FocusEvent<HTMLSelectElement>) => void
+    onBlur?: (event: React.FocusEvent<HTMLSelectElement>) => void
+    focus?: boolean
+    focusBorder?: boolean
+    autoFocus?: boolean
+    autoComplete?: string
+  }>
 
 export const SelectField = React.forwardRef(
   (props: SelectFieldProps, ref: RefObject<HTMLSelectElement>) => {

--- a/src/snackbar/Snackbar.tsx
+++ b/src/snackbar/Snackbar.tsx
@@ -10,13 +10,13 @@ import { CrossIcon } from '../icon/crossIcon'
 import { Text, TextDisplayType } from '../text'
 import { AnimationType, Transitions as CustomTransition } from '../transitions'
 
-export interface SnackbarProps {
-  readonly close: () => void
-  readonly isOpen: boolean
-  readonly className?: string
-  readonly extraClassName?: string
-  readonly children: JSX.Element
-}
+export type SnackbarProps = Readonly<{
+  close: () => void
+  isOpen: boolean
+  className?: string
+  extraClassName?: string
+  children: JSX.Element
+}>
 
 export class Snackbar extends PureComponent<SnackbarProps> {
   private portalNode: HTMLElement

--- a/src/stars/Stars.tsx
+++ b/src/stars/Stars.tsx
@@ -4,10 +4,10 @@ import cc from 'classcat'
 import { StarIcon as Star } from '../icon/starIcon'
 import { StyledStars } from './Stars.style'
 
-export interface StarsProps {
-  readonly className?: string
-  readonly stars: number
-}
+export type StarsProps = Readonly<{
+  className?: string
+  stars: number
+}>
 
 const MIN_STARS = 0
 const MAX_STARS = 5

--- a/src/stepper/Stepper.tsx
+++ b/src/stepper/Stepper.tsx
@@ -25,7 +25,7 @@ export const StepperButtonSize = {
   [StepperDisplay.LARGE]: 48,
 }
 
-export interface StepperProps {
+export type StepperProps = Readonly<{
   name: string
   increaseLabel: string
   decreaseLabel: string
@@ -42,9 +42,9 @@ export interface StepperProps {
   focus?: boolean
   leftAddon?: React.ReactNode
   disabled?: boolean
-}
+}>
 
-interface StepperState {
+type StepperState = {
   value: number
   fontSize?: number
 }

--- a/src/subHeader/SubHeader.tsx
+++ b/src/subHeader/SubHeader.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 
 import { StyledSubHeader } from './SubHeader.style'
 
-export interface SubHeaderProps {
-  readonly children: string
-}
+export type SubHeaderProps = Readonly<{
+  children: string
+}>
 
 export const SubHeader = ({ children }: SubHeaderProps) => (
   <StyledSubHeader headingLevel="2">{children}</StyledSubHeader>

--- a/src/tabs/Tabs.tsx
+++ b/src/tabs/Tabs.tsx
@@ -21,16 +21,16 @@ export interface Tab {
   readonly badgeAriaLabel?: string
 }
 
-export interface TabsProps {
-  readonly tabs: Tab[]
-  readonly activeTabId: string
-  readonly onChange?: Function
-  readonly status?: TabStatus
-  readonly className?: string
-  readonly tabsClassName?: string
-}
+export type TabsProps = Readonly<{
+  tabs: Tab[]
+  activeTabId: string
+  onChange?: Function
+  status?: TabStatus
+  className?: string
+  tabsClassName?: string
+}>
 
-interface TabsState {
+type TabsState = {
   // The currently selected tab id
   activeTabId: string
   // A map from tab ids to refs, this is to allow focusing the next or previous tab when

--- a/src/text/Text.tsx
+++ b/src/text/Text.tsx
@@ -23,15 +23,16 @@ export enum TextTagType {
   SPAN = 'span',
 }
 
-export interface TextProps extends A11yProps {
-  readonly className?: string
-  readonly children: string | number | React.ReactNode
-  readonly display?: TextDisplayType
-  readonly tag?: TextTagType
-  readonly textColor?: string
-  readonly newlineToBr?: boolean
-  readonly itemProp?: string
-}
+export type TextProps = A11yProps &
+  Readonly<{
+    className?: string
+    children: string | number | React.ReactNode
+    display?: TextDisplayType
+    tag?: TextTagType
+    textColor?: string
+    newlineToBr?: boolean
+    itemProp?: string
+  }>
 
 const baseClassName = 'kirk-text'
 const cssColorRegex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i

--- a/src/textField/TextField.tsx
+++ b/src/textField/TextField.tsx
@@ -31,7 +31,7 @@ export enum inputModes {
   URL = 'url',
 }
 
-export interface CommonFormFields {
+export type CommonFormFields = Readonly<{
   name: string
   id?: string
   type?: inputTypes
@@ -46,37 +46,38 @@ export interface CommonFormFields {
   title?: string
   onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void
-}
+}>
 
 type errorField = string | JSX.Element
 
-export interface TextFieldProps extends CommonFormFields {
-  defaultValue?: string
-  labelledBy?: string
-  onChange?: (obj: OnChangeParameters) => void
-  onClear?: () => void
-  className?: string
-  errorClassName?: string
-  error?: errorField
-  addon?: JSX.Element
-  label?: string
-  buttonTitle?: string
-  focus?: boolean
-  inputMode?: inputModes
-  pattern?: string
-  inputRef?: (input: textfield) => void
-  format?: (value: string, previousValue: string) => string
-  focusBorder?: boolean
-  loader?: JSX.Element
-  inputAttributes: InputHTMLAttributes<HTMLInputElement>
-}
+export type TextFieldProps = CommonFormFields &
+  Readonly<{
+    defaultValue?: string
+    labelledBy?: string
+    onChange?: (obj: OnChangeParameters) => void
+    onClear?: () => void
+    className?: string
+    errorClassName?: string
+    error?: errorField
+    addon?: JSX.Element
+    label?: string
+    buttonTitle?: string
+    focus?: boolean
+    inputMode?: inputModes
+    pattern?: string
+    inputRef?: (input: textfield) => void
+    format?: (value: string, previousValue: string) => string
+    focusBorder?: boolean
+    loader?: JSX.Element
+    inputAttributes: InputHTMLAttributes<HTMLInputElement>
+  }>
 
-export interface TextFieldState {
-  readonly value: string
-  readonly previousValue: string
-  readonly defaultValue: string
-  readonly showPassword: boolean
-  readonly hasFocus: boolean
+export type TextFieldState = {
+  value: string
+  previousValue: string
+  defaultValue: string
+  showPassword: boolean
+  hasFocus: boolean
 }
 
 export class TextField extends PureComponent<TextFieldProps, TextFieldState> {

--- a/src/textarea/Textarea.tsx
+++ b/src/textarea/Textarea.tsx
@@ -10,7 +10,7 @@ import { prefix } from '../_utils'
 import { Button, ButtonStatus } from '../button'
 import { StyledTextarea } from './Textarea.style'
 
-export interface CommonFormFields {
+export type CommonFormFields = Readonly<{
   name: string
   id?: string
   placeholder?: string
@@ -24,30 +24,31 @@ export interface CommonFormFields {
   title?: string
   onFocus?: (event: React.FocusEvent<HTMLTextAreaElement>) => void
   onBlur?: (event: React.FocusEvent<HTMLTextAreaElement>) => void
-}
+}>
 
 type errorField = string | JSX.Element
 
-export interface TextareaProps extends CommonFormFields {
-  defaultValue?: string
-  labelledBy?: string
-  onChange?: (obj: OnChangeParameters) => void
-  className?: string
-  errorClassName?: string
-  error?: errorField
-  label?: string
-  focus?: boolean
-  pattern?: string
-  fieldRef?: (textarea: HTMLTextAreaElement) => void
-  focusBorder?: boolean
-  fitContent?: boolean // Allow the textarea to grow/shrink with its content.
-  // To display the buttom, you need to specify onButtonClick, buttonIcon and buttonTitle.
-  onButtonClick?: (event: React.MouseEvent<HTMLElement>) => void
-  buttonIcon?: JSX.Element
-  buttonTitle?: string
-}
+export type TextareaProps = CommonFormFields &
+  Readonly<{
+    defaultValue?: string
+    labelledBy?: string
+    onChange?: (obj: OnChangeParameters) => void
+    className?: string
+    errorClassName?: string
+    error?: errorField
+    label?: string
+    focus?: boolean
+    pattern?: string
+    fieldRef?: (textarea: HTMLTextAreaElement) => void
+    focusBorder?: boolean
+    fitContent?: boolean // Allow the textarea to grow/shrink with its content.
+    // To display the buttom, you need to specify onButtonClick, buttonIcon and buttonTitle.
+    onButtonClick?: (event: React.MouseEvent<HTMLElement>) => void
+    buttonIcon?: JSX.Element
+    buttonTitle?: string
+  }>
 
-interface TextAreaAttributes extends CommonFormFields {
+type TextAreaAttributes = CommonFormFields & {
   className?: string
   value: string
   ['aria-invalid']?: 'true' | 'false'
@@ -56,10 +57,10 @@ interface TextAreaAttributes extends CommonFormFields {
   onChange?: (event: React.ChangeEvent<HTMLTextAreaElement>) => void
 }
 
-export interface TextAreaState {
-  readonly value: string
-  readonly defaultValue: string
-  readonly hasFocus: boolean
+export type TextAreaState = {
+  value: string
+  defaultValue: string
+  hasFocus: boolean
 }
 
 export class Textarea extends PureComponent<TextareaProps, TextAreaState> {

--- a/src/theVoice/TheVoice.tsx
+++ b/src/theVoice/TheVoice.tsx
@@ -2,12 +2,12 @@ import React, { ReactNode } from 'react'
 
 import { Title } from '../title'
 
-export interface TheVoiceProps {
-  readonly id?: string
-  readonly className?: string
-  readonly children: ReactNode
-  readonly isInverted?: boolean
-}
+export type TheVoiceProps = Readonly<{
+  id?: string
+  className?: string
+  children: ReactNode
+  isInverted?: boolean
+}>
 
 export const TheVoice = ({ id, className, children }: TheVoiceProps) => (
   <Title id={id} className={className} headingLevel="1">

--- a/src/timePicker/TimePicker.tsx
+++ b/src/timePicker/TimePicker.tsx
@@ -28,18 +28,18 @@ export const getTodayDate = () => {
   return date
 }
 
-export interface TimePickerProps {
-  readonly name: string
-  readonly className?: string
-  readonly defaultValue?: string
-  readonly disabled?: boolean
-  readonly minuteStep?: number
-  readonly renderTime?: (dt: Date) => string
-  readonly onChange?: (obj: OnChangeParameters) => void
-  readonly timeStart?: string
-  readonly focus?: boolean
-  readonly small?: boolean
-}
+export type TimePickerProps = Readonly<{
+  name: string
+  className?: string
+  defaultValue?: string
+  disabled?: boolean
+  minuteStep?: number
+  renderTime?: (dt: Date) => string
+  onChange?: (obj: OnChangeParameters) => void
+  timeStart?: string
+  focus?: boolean
+  small?: boolean
+}>
 
 type Steps = { [propName: string]: string }
 
@@ -48,10 +48,10 @@ type TimeSteps = {
   timeStart?: string
 }
 
-interface TimePickerState {
-  readonly value: string
-  readonly steps: Steps
-  readonly isFocused: boolean
+type TimePickerState = {
+  value: string
+  steps: Steps
+  isFocused: boolean
 }
 
 export class TimePicker extends PureComponent<TimePickerProps, TimePickerState> {

--- a/src/toggleButton/ToggleButton.tsx
+++ b/src/toggleButton/ToggleButton.tsx
@@ -6,18 +6,19 @@ import { Item } from '../_internals/item/index'
 import { ItemProps } from '../_internals/item/Item'
 import { OnChangeParameters } from '../_internals/onChange'
 
-export interface ToggleButtonProps extends ItemProps {
-  readonly name: string
-  readonly label: string
-  readonly sublabel?: string
-  readonly status?: ToggleButtonStatus
-  readonly checked?: boolean
-  readonly disabled?: boolean
-  readonly onChange?: (obj: OnChangeParameters) => void
-}
+export type ToggleButtonProps = ItemProps &
+  Readonly<{
+    name: string
+    label: string
+    sublabel?: string
+    status?: ToggleButtonStatus
+    checked?: boolean
+    disabled?: boolean
+    onChange?: (obj: OnChangeParameters) => void
+  }>
 
-interface ToggleButtonState {
-  readonly checked: boolean
+type ToggleButtonState = {
+  checked: boolean
 }
 
 export enum ToggleButtonStatus {

--- a/src/topBar/TopBar.tsx
+++ b/src/topBar/TopBar.tsx
@@ -1,16 +1,16 @@
 import React, { Fragment } from 'react'
 import cc from 'classcat'
 
-export interface TopBarProps {
-  readonly className?: string
-  readonly leftItem?: JSX.Element
-  readonly rightItem?: JSX.Element
-  readonly centerItem?: JSX.Element
-  readonly fixed?: boolean
-  readonly bgTransparent?: boolean
-  readonly bgShadedTransparent?: boolean
-  readonly innerWrapperClassName?: string
-}
+export type TopBarProps = Readonly<{
+  className?: string
+  leftItem?: JSX.Element
+  rightItem?: JSX.Element
+  centerItem?: JSX.Element
+  fixed?: boolean
+  bgTransparent?: boolean
+  bgShadedTransparent?: boolean
+  innerWrapperClassName?: string
+}>
 
 export const TopBar = ({
   className,

--- a/src/transitions/Transitions.tsx
+++ b/src/transitions/Transitions.tsx
@@ -9,15 +9,15 @@ export enum AnimationType {
   SLIDE_UP = 'slide-up',
 }
 
-export interface TransitionsProps {
-  readonly className?: string
-  readonly children: JSX.Element
-  readonly animationName?: AnimationType
-  readonly delayEnter?: number
-  readonly delayLeave?: number
-  readonly in?: boolean
-  readonly onEntered?: () => void
-}
+export type TransitionsProps = Readonly<{
+  className?: string
+  children: JSX.Element
+  animationName?: AnimationType
+  delayEnter?: number
+  delayLeave?: number
+  in?: boolean
+  onEntered?: () => void
+}>
 
 export class Transitions extends PureComponent<TransitionsProps> {
   static defaultProps: Partial<TransitionsProps> = {

--- a/src/tripCard/TripCard.tsx
+++ b/src/tripCard/TripCard.tsx
@@ -33,34 +33,35 @@ export interface User {
   rating?: string
 }
 
-export interface TripCardProps extends A11yProps {
-  href: string | JSX.Element
-  itinerary: Place[]
-  driver?: User
-  passengers?: User[]
-  price?: string
-  flags?: {
-    ladiesOnly?: boolean
-    aloneInTheBack?: boolean
-    maxTwo?: boolean
-    autoApproval?: boolean
-  }
-  titles?: {
-    ladiesOnly?: string
-    aloneInTheBack?: string
-    maxTwo?: string
-    autoApproval?: string
-  }
-  metaUrl?: string
-  className?: string
-  statusInformation?: {
-    icon: JSX.Element
-    text: string
-    highlighted?: boolean
-  }
-  badge?: string
-  title?: string
-}
+export type TripCardProps = A11yProps &
+  Readonly<{
+    href: string | JSX.Element
+    itinerary: Place[]
+    driver?: User
+    passengers?: User[]
+    price?: string
+    flags?: {
+      ladiesOnly?: boolean
+      aloneInTheBack?: boolean
+      maxTwo?: boolean
+      autoApproval?: boolean
+    }
+    titles?: {
+      ladiesOnly?: string
+      aloneInTheBack?: string
+      maxTwo?: string
+      autoApproval?: string
+    }
+    metaUrl?: string
+    className?: string
+    statusInformation?: {
+      icon: JSX.Element
+      text: string
+      highlighted?: boolean
+    }
+    badge?: string
+    title?: string
+  }>
 
 const renderPassenger = (passenger: User) => (
   <li className="kirk-tripCard-avatar" key={`${passenger.firstName}-${passenger.avatarUrl}`}>

--- a/src/typography/Text.tsx
+++ b/src/typography/Text.tsx
@@ -2,13 +2,13 @@ import React, { ReactNode } from 'react'
 
 import { replaceNewLineWithBR } from '../_utils'
 
-export interface TextProps {
-  readonly className?: string
-  readonly children: string | ReactNode
-  readonly isInverted?: boolean // Switch colors based on backgournd
-  readonly isDisabled?: boolean // Ligthen the text color to emphasis on disabled state
-  readonly itemProp?: string // Allows microdata annotation on Text
-}
+export type TextProps = Readonly<{
+  className?: string
+  children: string | ReactNode
+  isInverted?: boolean // Switch colors based on backgournd
+  isDisabled?: boolean // Ligthen the text color to emphasis on disabled state
+  itemProp?: string // Allows microdata annotation on Text
+}>
 
 export const Text = ({ children, className, isInverted, isDisabled, ...props }: TextProps) => {
   const content = typeof children === 'string' ? replaceNewLineWithBR(children) : children

--- a/src/uneditableTextField/UneditableTextField.tsx
+++ b/src/uneditableTextField/UneditableTextField.tsx
@@ -2,13 +2,13 @@ import React, { Fragment } from 'react'
 import cc from 'classcat'
 import isEmpty from 'lodash.isempty'
 
-export interface UneditableTextFieldProps {
-  readonly children: JSX.Element | string
-  readonly className?: string
-  readonly addOn?: JSX.Element
-  readonly href?: JSX.Element | string
-  readonly ellipsis?: boolean
-}
+export type UneditableTextFieldProps = Readonly<{
+  children: JSX.Element | string
+  className?: string
+  addOn?: JSX.Element
+  href?: JSX.Element | string
+  ellipsis?: boolean
+}>
 
 export const UneditableTextField = ({
   children,

--- a/src/why/Why.tsx
+++ b/src/why/Why.tsx
@@ -4,12 +4,12 @@ import cc from 'classcat'
 import { useFocusVisible } from '../_utils/focusVisibleProvider/useFocusVisible'
 import { QuestionIcon } from '../icon/questionIcon'
 
-export interface WhyProps {
-  readonly children: string
-  readonly title: string
-  readonly className?: string
-  readonly onClick?: () => void
-}
+export type WhyProps = Readonly<{
+  children: string
+  title: string
+  className?: string
+  onClick?: () => void
+}>
 
 export const Why = ({ className, children, title, onClick }: WhyProps) => {
   const { focusVisible, onFocus, onBlur } = useFocusVisible()

--- a/tools/component/component.tsx
+++ b/tools/component/component.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { Styled__COMPONENT_NAME__ } from './__COMPONENT_NAME__.style'
 
-export interface __COMPONENT_NAME__ {}
+export type __COMPONENT_NAME__Props = Readonly<{}>
 
 export const __COMPONENT_NAME__ = ({}: __COMPONENT_NAME__Props) => {
   return <Styled__COMPONENT_NAME__> Content </Styled__COMPONENT_NAME__>


### PR DESCRIPTION
## Description

Ensure type/interface usage are aligned with our conventions.

## What has been done

- Replace all interfaces with types for component props and states.
- Make sure all prop-types are readonly.

## How it was tested

- Unit tests
- TSC
- Canary release
