### PR TITLE
Bbc 9604 fix a11y item editable info button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - **[FIX]** Fixed `ItemCheckbox` a11y focus ring display for keyboard navigation
+- **[FIX]** Fixed `ItemEditableInfo` a11y keyboard navigation by Providing a focus ring 
 [...]
 
 # v40.0.0 (24/08/2020)

--- a/src/itemEditableInfo/ItemEditableInfo.story.mdx
+++ b/src/itemEditableInfo/ItemEditableInfo.story.mdx
@@ -1,21 +1,39 @@
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks'
 
 import { ItemEditableInfo } from './index'
+import { FocusVisibleProvider } from '../_utils/focusVisibleProvider'
 
 <Meta title="Items|ItemEditableInfo" />
 
 # ItemEditableInfo
 
+### Link
+
 <Preview>
-  <Story name="Default">
-    <ItemEditableInfo
-      href="http://google.fr`"
-      label="First name"
-      value="John"
-      onClick={() => {
-        window.alert('Clicked')
-      }}
-    />
+  <Story name="Link">
+    <FocusVisibleProvider>
+      <ItemEditableInfo
+        href="http://google.fr`"
+        label="First name"
+        value="John"
+      />
+    </FocusVisibleProvider>
+  </Story>
+</Preview>
+
+### button
+
+<Preview>
+  <Story name="Button">
+    <FocusVisibleProvider>
+      <ItemEditableInfo
+        label="First name"
+        value="John"
+        onClick={() => {
+          window.alert('Clicked')
+        }}
+      />
+    </FocusVisibleProvider>
   </Story>
 </Preview>
 
@@ -23,7 +41,9 @@ import { ItemEditableInfo } from './index'
 
 <Preview>
   <Story name="Read Only">
-    <ItemEditableInfo label="Gender (readonly)" value="Female" readonly />
+    <FocusVisibleProvider>
+      <ItemEditableInfo label="Gender (readonly)" value="Female" readonly />
+    </FocusVisibleProvider>
   </Story>
 </Preview>
 

--- a/src/itemEditableInfo/itemEditableInfo.tsx
+++ b/src/itemEditableInfo/itemEditableInfo.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
+import cc from 'classcat'
 
 import { Item } from '../_internals/item'
 import { color } from '../_utils/branding'
+import { useFocusVisible } from '../_utils/focusVisibleProvider/useFocusVisible'
 import { A11yProps, pickA11yProps } from '../_utils/interfaces'
 import { TextDisplayType } from '../text'
 
@@ -14,6 +16,7 @@ export type ItemEditableInfoProps = A11yProps &
     value: string
     // A href to follow if the modifiable value is activated
     href?: string | JSX.Element
+    tag?: JSX.Element
     onClick?: (event: React.MouseEvent<HTMLElement>) => void
     // Prevent modification of the user input.
     // Used to trigger the behavior of the 'ItemEditableInfo non-editable' from the specs.
@@ -21,12 +24,14 @@ export type ItemEditableInfoProps = A11yProps &
   }>
 
 export const ItemEditableInfo = (props: ItemEditableInfoProps) => {
-  const { className, label, value, href = null, readonly = false, onClick } = props
+  const { className, label, value, href = null, tag, readonly = false, onClick } = props
   const a11yAttrs = pickA11yProps<ItemEditableInfoProps>(props)
+  const { focusVisible, onFocus, onBlur } = useFocusVisible()
 
   const extraProps = {
     isClickable: true,
     href,
+    tag,
     // For the ItemEditableInfo, the value (entered previously by the user)
     // is the most important info and is visually bigger than the
     // label for it.
@@ -47,13 +52,20 @@ export const ItemEditableInfo = (props: ItemEditableInfoProps) => {
   }
 
   if (onClick && !href) {
-    a11yAttrs.role = 'button'
+    extraProps.tag = <button />
   }
 
   return (
     <Item
       onClick={onClick}
-      className={className}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      className={cc([
+        className,
+        {
+          'focus-visible': focusVisible,
+        },
+      ])}
       leftTitle={label}
       leftBody={value}
       {...extraProps}

--- a/src/itemEditableInfo/itemEditableInfo.unit.tsx
+++ b/src/itemEditableInfo/itemEditableInfo.unit.tsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme'
 
 import { ItemEditableInfo } from './index'
 
-it('Should render a basic ItemEditableInfo', () => {
+it('Should render a basic ItemEditableInfo as link', () => {
   const props = {
     label: 'My label',
     value: 'My value',
@@ -16,7 +16,7 @@ it('Should render a basic ItemEditableInfo', () => {
   expect(wrapper.text()).toBe('My labelMy value')
 })
 
-it('Should render an onClick ItemEditableInfo', () => {
+it('Should render an ItemEditableInfo as button', () => {
   const onClickFn = () => {}
   const props = {
     label: 'My label',
@@ -24,6 +24,8 @@ it('Should render an onClick ItemEditableInfo', () => {
     onClick: onClickFn,
   }
   const wrapper = mount(<ItemEditableInfo {...props} />)
+  const button = wrapper.find('button')
+  expect(button).toHaveLength(1)
   expect(wrapper.text()).toBe('My labelMy value')
   expect(wrapper.props().onClick).toBe(onClickFn)
 })


### PR DESCRIPTION
## What has been done
Fix keyboard navigation:
- Use `<button>` instead of `<div role="button">` to make it focusable
- Use the FocusVisibleProvider to display the focus ring

## How it was tested
Locally:
https://www.loom.com/share/7864c97601ad422a83e8768e80ca5d26
