### PR TITLE
Display itemCheckbox focus ring on keyboard nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Fixed `ItemCheckbox` a11y focus ring display for keyboard navigation
 [...]
 
 # v40.0.0 (24/08/2020)

--- a/src/itemCheckbox/ItemCheckbox.story.mdx
+++ b/src/itemCheckbox/ItemCheckbox.story.mdx
@@ -2,6 +2,7 @@ import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks'
 import { action, boolean, select } from '@storybook/addon-actions'
 import { LadyIcon } from '../icon/ladyIcon'
 import { ItemCheckbox, ItemCheckboxStatus } from '../itemCheckbox'
+import { FocusVisibleProvider } from '../_utils/focusVisibleProvider'
 
 <Meta title="Items|ItemCheckbox" />
 
@@ -9,17 +10,19 @@ import { ItemCheckbox, ItemCheckboxStatus } from '../itemCheckbox'
 
 <Preview>
   <Story name="Default">
-    <ItemCheckbox
-      name="InputName"
-      labelTitle="Label title"
-      label="Main information"
-      data="Data"
-      dataInfo="Data info"
-      checked={true}
-      disabled={false}
-      leftAddon={<LadyIcon isDisabled={false} />}
-      status={ItemCheckboxStatus.DEFAULT}
-    />
+    <FocusVisibleProvider>
+      <ItemCheckbox
+        name="InputName"
+        labelTitle="Label title"
+        label="Main information"
+        data="Data"
+        dataInfo="Data info"
+        checked={true}
+        disabled={false}
+        leftAddon={<LadyIcon isDisabled={false} />}
+        status={ItemCheckboxStatus.DEFAULT}
+      />
+    </FocusVisibleProvider>
   </Story>
 </Preview>
 

--- a/src/itemCheckbox/ItemCheckbox.style.tsx
+++ b/src/itemCheckbox/ItemCheckbox.style.tsx
@@ -1,9 +1,14 @@
 import styled from 'styled-components'
 
 import { Item } from '../_internals/item'
+import { color, inputBorderSize } from '../_utils/branding'
 
 export const StyledItemCheckbox = styled(Item)`
   cursor: ${props => (props.disabled ? 'default' : 'pointer')};
+
+  &.focus-visible {
+    outline: ${inputBorderSize.focus} solid ${color.blue};
+  }
 
   & input {
     position: absolute;

--- a/src/itemCheckbox/ItemCheckbox.tsx
+++ b/src/itemCheckbox/ItemCheckbox.tsx
@@ -3,6 +3,7 @@ import cc from 'classcat'
 
 import { CheckboxIcon } from '../_internals/checkboxIcon'
 import { OnChangeParameters } from '../_internals/onChange'
+import { FocusVisibleContext } from '../_utils/focusVisibleProvider'
 import { A11yProps, pickA11yProps } from '../_utils/interfaces'
 import { NormalizeProps } from '../layout/layoutNormalizer'
 import { TextDisplayType } from '../text'
@@ -30,15 +31,31 @@ export type ItemCheckboxProps = NormalizeProps &
     key?: string | number
   }>
 
+type ItemCheckboxState = {
+  focus: boolean
+}
+
 export class ItemCheckbox extends Component<ItemCheckboxProps> {
   static defaultProps: Partial<ItemCheckboxProps> = {
     onChange() {},
     checked: false,
   }
 
+  state: ItemCheckboxState = {
+    focus: false,
+  }
+
   onChange = () => {
     const { name, checked } = this.props
     this.props.onChange({ name, value: !checked })
+  }
+
+  onFocus = () => {
+    this.setState({ focus: true })
+  }
+
+  onBlur = () => {
+    this.setState({ focus: false })
   }
 
   render() {
@@ -64,6 +81,8 @@ export class ItemCheckbox extends Component<ItemCheckboxProps> {
           name={name}
           checked={checked}
           onChange={this.onChange}
+          onFocus={this.onFocus}
+          onBlur={this.onBlur}
           disabled={disabled || isLoading}
         />
         <CheckboxIcon isChecked={checked} isLoading={isLoading} isDisabled={disabled} />
@@ -71,26 +90,35 @@ export class ItemCheckbox extends Component<ItemCheckboxProps> {
     )
 
     return (
-      <StyledItemCheckbox
-        className={cc(['kirk-item-checkbox', className])}
-        leftTitle={labelTitle}
-        leftBody={label}
-        leftAddon={leftAddon}
-        rightTitle={data}
-        rightTitleDisplay={TextDisplayType.SUBHEADERSTRONG}
-        rightBody={dataInfo}
-        /* No a11y issue here
+      <FocusVisibleContext.Consumer>
+        {context => (
+          <StyledItemCheckbox
+            className={cc([
+              'kirk-item-checkbox',
+              {
+                'focus-visible': context && this.state.focus,
+              },
+              className,
+            ])}
+            leftTitle={labelTitle}
+            leftBody={label}
+            leftAddon={leftAddon}
+            rightTitle={data}
+            rightTitleDisplay={TextDisplayType.SUBHEADERSTRONG}
+            rightBody={dataInfo}
+            /* No a11y issue here
           - The input is well wrapped with the label
           - The linter can't access the complex components implementation
         */
-        // eslint-disable-next-line jsx-a11y/label-has-associated-control
-        tag={<label />}
-        rightAddon={checkbox}
-        isClickable={!disabled}
-        disabled={disabled}
-        hasHorizontalSpacing={hasHorizontalSpacing}
-        {...a11yAttrs}
-      />
+            // eslint-disable-next-line jsx-a11y/label-has-associated-control
+            tag={<label />}
+            rightAddon={checkbox}
+            disabled={disabled}
+            hasHorizontalSpacing={hasHorizontalSpacing}
+            {...a11yAttrs}
+          />
+        )}
+      </FocusVisibleContext.Consumer>
     )
   }
 }

--- a/src/itemCheckbox/ItemCheckbox.unit.tsx
+++ b/src/itemCheckbox/ItemCheckbox.unit.tsx
@@ -51,12 +51,10 @@ describe('ItemCheckbox', () => {
     })
   })
   it('Should handle disabled prop', () => {
-    const itemCheckbox = shallow(<ItemCheckbox {...defaultProps} />)
-    expect(itemCheckbox.prop('isClickable')).toBeTruthy()
+    const itemCheckbox = mount(<ItemCheckbox {...defaultProps} />)
     expect(itemCheckbox.prop('disabled')).toBeFalsy()
 
     itemCheckbox.setProps({ disabled: true })
-    expect(itemCheckbox.prop('isClickable')).toBeFalsy()
     expect(itemCheckbox.prop('disabled')).toBeTruthy()
   })
   it('Should call the onChange prop with name and value when the input changes (uncheck)', () => {

--- a/src/itemCheckbox/__snapshots__/ItemCheckbox.unit.tsx.snap
+++ b/src/itemCheckbox/__snapshots__/ItemCheckbox.unit.tsx.snap
@@ -242,6 +242,10 @@ button:focus:not(.focus-visible).c0 {
   bottom: 0;
 }
 
+.c0.focus-visible {
+  outline: 3px solid #00AFF5;
+}
+
 .c0 input {
   position: absolute;
   -webkit-clip: rect(0,0,0,0);
@@ -249,7 +253,7 @@ button:focus:not(.focus-visible).c0 {
 }
 
 <label
-  className="kirk-item kirk-item--clickable kirk-item-checkbox custom-class-name c0"
+  className="kirk-item kirk-item-checkbox custom-class-name c0"
 >
   <span
     className="kirk-item-leftText"
@@ -286,7 +290,9 @@ button:focus:not(.focus-visible).c0 {
       checked={true}
       disabled={false}
       name="name"
+      onBlur={[Function]}
       onChange={[Function]}
+      onFocus={[Function]}
       type="checkbox"
     />
     <svg
@@ -631,6 +637,10 @@ button:focus:not(.focus-visible).c0 {
   bottom: 0;
 }
 
+.c0.focus-visible {
+  outline: 3px solid #00AFF5;
+}
+
 .c0 input {
   position: absolute;
   -webkit-clip: rect(0,0,0,0);
@@ -638,7 +648,7 @@ button:focus:not(.focus-visible).c0 {
 }
 
 <label
-  className="kirk-item kirk-item--clickable kirk-item-checkbox custom-class-name c0"
+  className="kirk-item kirk-item-checkbox custom-class-name c0"
 >
   <span
     className="kirk-item-leftText"
@@ -675,7 +685,9 @@ button:focus:not(.focus-visible).c0 {
       checked={false}
       disabled={true}
       name="name"
+      onBlur={[Function]}
       onChange={[Function]}
+      onFocus={[Function]}
       type="checkbox"
     />
     <div
@@ -977,6 +989,10 @@ button:focus:not(.focus-visible).c0 {
   bottom: 0;
 }
 
+.c0.focus-visible {
+  outline: 3px solid #00AFF5;
+}
+
 .c0 input {
   position: absolute;
   -webkit-clip: rect(0,0,0,0);
@@ -984,7 +1000,7 @@ button:focus:not(.focus-visible).c0 {
 }
 
 <label
-  className="kirk-item kirk-item--clickable kirk-item-checkbox custom-class-name c0"
+  className="kirk-item kirk-item-checkbox custom-class-name c0"
 >
   <span
     className="kirk-item-leftText"
@@ -1021,7 +1037,9 @@ button:focus:not(.focus-visible).c0 {
       checked={false}
       disabled={false}
       name="name"
+      onBlur={[Function]}
       onChange={[Function]}
+      onFocus={[Function]}
       type="checkbox"
     />
     <svg


### PR DESCRIPTION
## Description

Apply the FocusVisible context to ItemCheckbox to solve keyboard navigation focus ring

## How it was tested

Locally:
https://www.loom.com/share/ccd316b85ad44efe84a1e4d5a3f2a1eb
