### PR TITLE
Release/v40.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Unreleased
 
+[...]
+
+# v40.0.1 (28/08/2020)
+
 - **[FIX]** Fixed `ItemCheckbox` a11y focus ring display for keyboard navigation
 - **[FIX]** Fixed `ItemEditableInfo` a11y keyboard navigation by Providing a focus ring 
-[...]
 
 # v40.0.0 (24/08/2020)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "40.0.0",
+  "version": "40.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "40.0.0",
+  "version": "40.0.1",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Things to consider

# v40.0.1 (28/08/2020)

- **[FIX]** Fixed `ItemCheckbox` a11y focus ring display for keyboard navigation
- **[FIX]** Fixed `ItemEditableInfo` a11y keyboard navigation by Providing a focus ring 
