### PR TITLE
[BBC-9714] Fix MediaContentSection display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Unreleased
 
+- **[FIX]** Fixed `MediaContentSection` margins on the title
 [...]
 
 # v40.0.1 (28/08/2020)
 
 - **[FIX]** Fixed `ItemCheckbox` a11y focus ring display for keyboard navigation
-- **[FIX]** Fixed `ItemEditableInfo` a11y keyboard navigation by Providing a focus ring 
+- **[FIX]** Fixed `ItemEditableInfo` a11y keyboard navigation by Providing a focus ring
 
 # v40.0.0 (24/08/2020)
 

--- a/src/layout/section/mediaContentSection/__snapshots__/index.unit.tsx.snap
+++ b/src/layout/section/mediaContentSection/__snapshots__/index.unit.tsx.snap
@@ -273,6 +273,7 @@ exports[`MediaContentSection should render default MediaContentSection section 1
   font-size: 30px;
   line-height: 1.06;
   font-weight: 500;
+  margin-bottom: 8px;
 }
 
 .c0 {
@@ -335,6 +336,12 @@ exports[`MediaContentSection should render default MediaContentSection section 1
 
   .c1 .section-content.section-content--large {
     max-width: 1016px;
+  }
+}
+
+@media (max-width:799px) {
+  .c4 {
+    margin-top: 24px;
   }
 }
 
@@ -699,6 +706,7 @@ exports[`MediaContentSection should render flipped MediaContentSection section 1
   font-size: 30px;
   line-height: 1.06;
   font-weight: 500;
+  margin-bottom: 8px;
 }
 
 .c0 {
@@ -761,6 +769,12 @@ exports[`MediaContentSection should render flipped MediaContentSection section 1
 
   .c1 .section-content.section-content--large {
     max-width: 1016px;
+  }
+}
+
+@media (max-width:799px) {
+  .c4 {
+    margin-top: 24px;
   }
 }
 

--- a/src/layout/section/mediaContentSection/mediaContentSection.tsx
+++ b/src/layout/section/mediaContentSection/mediaContentSection.tsx
@@ -6,7 +6,7 @@ import { Column } from '../../../layout/column'
 import { Columns } from '../../../layout/columns'
 import { BaseSection, SectionContentSize } from '../../../layout/section/baseSection'
 import { Text, TextTagType } from '../../../text'
-import { TextDisplay1 } from '../../../typography/display1'
+import { MediaContentTitle } from './mediaContentTitle'
 
 export type MediaContentSectionProps = Readonly<{
   className?: string
@@ -38,7 +38,7 @@ export const MediaContentSection = (props: MediaContentSectionProps) => {
         </Column>
         <Column>
           <div className="kirk-media-content-wrapper">
-            <TextDisplay1>{title}</TextDisplay1>
+            <MediaContentTitle>{title}</MediaContentTitle>
             {showParagraph && <Text tag={TextTagType.PARAGRAPH}>{content}</Text>}
             {showButton && (
               <Button className="kirk-media-content-button" href={buttonHref}>

--- a/src/layout/section/mediaContentSection/mediaContentTitle.tsx
+++ b/src/layout/section/mediaContentSection/mediaContentTitle.tsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components'
+
+import { responsiveBreakpoints, space } from '../../../_utils/branding'
+import { TextDisplay1 } from '../../../typography/display1'
+
+export const MediaContentTitle = styled(TextDisplay1)`
+  margin-bottom: ${space.m};
+
+  @media (${responsiveBreakpoints.isMediaSmall}) {
+    margin-top: ${space.xl};
+  }
+`


### PR DESCRIPTION
## Description

Noticed a display issue on BBC homepage on mobile device. 
What it looks like:
<img width="390" alt="Capture d’écran 2020-09-01 à 14 01 08" src="https://user-images.githubusercontent.com/729186/91849455-65f62d00-ec5c-11ea-92bd-5e1793f060af.png">
What it should looks like:
<img width="387" alt="Capture d’écran 2020-09-01 à 14 01 18" src="https://user-images.githubusercontent.com/729186/91849447-6262a600-ec5c-11ea-82c1-b0d2b7442e5c.png">

## What has been done

Issue was introduced via 9c4dffecad14de4bc51f54461d0f4fd5222b4cfd. `SubHeader` component has default margins, but it has been replaced by a `TextDisplay1`.
Just wrapped the component to add some style.

## Things to consider

Snapshots will have to be updated

## How it was tested

Storybook + locally on kairos
