### PR TITLE
Update text prop to allow jsx element in EmptyState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
 
+- **[UPDATE]** Update `EmptyState` component type for `text` prop (`string | JSX.Element`)
 - **[UPDATE]** Migrate `MediaSection` to new mdx story format
-[...]
+  [...]
 
 # v40.0.3 (03/09/2020)
 

--- a/src/emptyState/EmptyState.story.mdx
+++ b/src/emptyState/EmptyState.story.mdx
@@ -1,4 +1,5 @@
 import { Meta, Preview, Props, Story } from '@storybook/addon-docs/blocks'
+import { text } from '@storybook/addon-knobs'
 
 import { Button } from '../button'
 import { EmptyState } from './index'
@@ -7,11 +8,35 @@ import { EmptyState } from './index'
 
 # EmptyState
 
+### with simple text
+
 <Preview>
-  <Story name="WithButton">
+  <Story name="With simple text">
     <EmptyState
       image="https://cdn.blablacar.com/kairos/assets/build/images/astronaut-79c2cfcb1a66f7c9afc1bbc50f0037fd.svg"
-      text="Nothing here!"
+      text={text('text', 'Nothing there...')}
+    />
+  </Story>
+</Preview>
+
+### with JSX text
+
+<Preview>
+  <Story name="With JSX text">
+    <EmptyState
+      image="https://cdn.blablacar.com/kairos/assets/build/images/astronaut-79c2cfcb1a66f7c9afc1bbc50f0037fd.svg"
+      text={<h1>This H1 contains a span!<span style={{ color: 'gray' }}> But nothing else.</span></h1>}
+    />
+  </Story>
+</Preview>
+
+### with button
+
+<Preview>
+  <Story name="With button">
+    <EmptyState
+      image="https://cdn.blablacar.com/kairos/assets/build/images/astronaut-79c2cfcb1a66f7c9afc1bbc50f0037fd.svg"
+      text={text('text', 'Please click the button below:')}
       button={<Button>Go there!</Button>}
     />
   </Story>

--- a/src/emptyState/EmptyState.tsx
+++ b/src/emptyState/EmptyState.tsx
@@ -7,14 +7,23 @@ import { StyledEmptyState } from './EmptyState.style'
 export type EmptyStateProps = Readonly<{
   className?: string
   image: string
-  text: string
+  text: string | JSX.Element
   button?: JSX.Element
 }>
 
-export const EmptyState = ({ className, image, text, button }: EmptyStateProps) => (
-  <StyledEmptyState className={cc(['kirk-empty-state', className])}>
-    <img src={image} alt="" />
-    <Title>{text}</Title>
-    {button}
-  </StyledEmptyState>
-)
+export const EmptyState = ({ className, image, text, button }: EmptyStateProps) => {
+  let title
+  if (typeof text === 'string') {
+    title = <Title>{text}</Title>
+  } else {
+    title = text
+  }
+
+  return (
+    <StyledEmptyState className={cc(['kirk-empty-state', className])}>
+      <img src={image} alt="" />
+      {title}
+      {button}
+    </StyledEmptyState>
+  )
+}

--- a/src/emptyState/EmptyState.unit.tsx
+++ b/src/emptyState/EmptyState.unit.tsx
@@ -18,6 +18,12 @@ describe('EmptyState', () => {
     expect(wrapper.find(Button).exists()).toBe(false)
   })
 
+  it('Should render a JSX element instead of a title if text is not provided as a string', () => {
+    const wrapper = shallow(<EmptyState {...defaultProps} text={<h2>not a Title</h2>} />)
+    expect(wrapper.find(Title).exists()).toBe(false)
+    expect(wrapper.find('h2').exists()).toBe(true)
+  })
+
   it('Should render button if provided', () => {
     const wrapper = shallow(<EmptyState {...defaultProps} button={<Button>Action</Button>} />)
     expect(wrapper.find(Button).exists()).toBe(true)


### PR DESCRIPTION
Update EmptyState so that "text" prop can also be a JSX element. It still defaults to a "Title" component if a string is provided.

Context: for SEO purposes, we want to be able to add more info in the title but with different styles (else you might end up with the inclusion of a very long city name written as a big title).

Tested locally on Firefox, with a canary deployment to test in the main app.
![Screen Shot 2020-09-07 at 16 17 33](https://user-images.githubusercontent.com/373381/92396695-bde1d780-f125-11ea-9869-2c0e160034e4.png)

