### PR TITLE
Fixed wrong spacing between icon & text in Button component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - **[UPDATE]** Update `EmptyState` component type for `text` prop (`string | JSX.Element`)
 - **[UPDATE]** Migrate `MediaSection` to new mdx story format
-  [...]
+- **[FIX]** Fixed wrong spacing between icon & text in `Button`
 
 # v40.0.3 (03/09/2020)
 

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -36,8 +36,7 @@ const StyledButton = styled(Button)`
   }
 
   & svg {
-    margin-right: ${space.s};
-    margin-left: -${space.m};
+    margin-right: ${space.m};
   }
 
   &.kirk-button-bubble svg {

--- a/src/button/story.tsx
+++ b/src/button/story.tsx
@@ -7,6 +7,7 @@ import { color } from '../_utils/branding'
 import { Button, ButtonStatus } from '../button'
 import { ArrowIcon } from '../icon/arrowIcon'
 import { LockIcon } from '../icon/lockIcon'
+import { RedCircleIcon } from '../icon/redCircleIcon'
 import { BaseSection as Section } from '../layout/section/baseSection'
 import { primaryDoc } from './specifications/primary.md'
 import { secondaryDoc } from './specifications/secondary.md'
@@ -143,6 +144,15 @@ stories.add('icon + text', () => (
   <Section>
     <Button status={ButtonStatus.PRIMARY} {...commonProps}>
       <LockIcon iconColor={color.white} />
+      {label('Content')}
+    </Button>
+  </Section>
+))
+
+stories.add('red circle icon + text', () => (
+  <Section>
+    <Button status={ButtonStatus.PRIMARY} {...commonProps}>
+      <RedCircleIcon iconColor={color.white} />
       {label('Content')}
     </Button>
   </Section>

--- a/src/datePicker/__snapshots__/DatePicker.unit.tsx.snap
+++ b/src/datePicker/__snapshots__/DatePicker.unit.tsx.snap
@@ -79,8 +79,7 @@ exports[`DatePicker renderNavbar Should render the previous/next buttons in hori
 }
 
 .c0 svg {
-  margin-right: 4px;
-  margin-left: -8px;
+  margin-right: 8px;
 }
 
 .c0.kirk-button-bubble svg {

--- a/src/hint/__snapshots__/Hint.unit.tsx.snap
+++ b/src/hint/__snapshots__/Hint.unit.tsx.snap
@@ -63,8 +63,7 @@ exports[`Hint Default rendering (above) 1`] = `
 }
 
 .c3 svg {
-  margin-right: 4px;
-  margin-left: -8px;
+  margin-right: 8px;
 }
 
 .c3.kirk-button-bubble svg {
@@ -415,8 +414,7 @@ exports[`Hint Default rendering (below) 1`] = `
 }
 
 .c3 svg {
-  margin-right: 4px;
-  margin-left: -8px;
+  margin-right: 8px;
 }
 
 .c3.kirk-button-bubble svg {

--- a/src/icon/redCircleIcon.tsx
+++ b/src/icon/redCircleIcon.tsx
@@ -3,12 +3,8 @@ import React from 'react'
 import { BaseIcon, BaseIconDefaultProps, Icon } from '../_utils/icon'
 
 const RedCircleIcon = (props: Icon) => (
-  <BaseIcon {...props} size={16} viewBox="0 0 16 16">
-    <path
-      d="M15.5 8C15.5 3.85786 12.1421 0.5 8 0.5C3.85786 0.5 0.5 3.85786 0.5 8C0.5 12.1421 3.85786 15.5 8 15.5C12.1421 15.5 15.5 12.1421 15.5 8Z"
-      fill="#F53F5B"
-      stroke="white"
-    />
+  <BaseIcon {...props} size={24} viewBox="0 0 24 24">
+    <circle cx="12" cy="12" r="7.5" fill="#F53F5B" stroke="white" />
   </BaseIcon>
 )
 

--- a/src/layout/section/mediaContentSection/__snapshots__/MediaContentSection.unit.tsx.snap
+++ b/src/layout/section/mediaContentSection/__snapshots__/MediaContentSection.unit.tsx.snap
@@ -43,8 +43,7 @@ exports[`MediaContentSection should render default MediaContentSection section 1
 }
 
 .c6 svg {
-  margin-right: 4px;
-  margin-left: -8px;
+  margin-right: 8px;
 }
 
 .c6.kirk-button-bubble svg {
@@ -480,8 +479,7 @@ exports[`MediaContentSection should render flipped MediaContentSection section 1
 }
 
 .c6 svg {
-  margin-right: 4px;
-  margin-left: -8px;
+  margin-right: 8px;
 }
 
 .c6.kirk-button-bubble svg {

--- a/src/modal/__snapshots__/Modal.unit.tsx.snap
+++ b/src/modal/__snapshots__/Modal.unit.tsx.snap
@@ -63,8 +63,7 @@ exports[`Modal should not have changed 1`] = `
 }
 
 .c2 svg {
-  margin-right: 4px;
-  margin-left: -8px;
+  margin-right: 8px;
 }
 
 .c2.kirk-button-bubble svg {

--- a/src/phoneField/__snapshots__/PhoneField.unit.tsx.snap
+++ b/src/phoneField/__snapshots__/PhoneField.unit.tsx.snap
@@ -124,8 +124,7 @@ exports[`PhoneField should have the expected markup in the DOM with custom setti
 }
 
 .c4 svg {
-  margin-right: 4px;
-  margin-left: -8px;
+  margin-right: 8px;
 }
 
 .c4.kirk-button-bubble svg {

--- a/src/snackbar/__snapshots__/Snackbar.unit.tsx.snap
+++ b/src/snackbar/__snapshots__/Snackbar.unit.tsx.snap
@@ -63,8 +63,7 @@ exports[`Snackbar should not have changed 1`] = `
 }
 
 .c3 svg {
-  margin-right: 4px;
-  margin-left: -8px;
+  margin-right: 8px;
 }
 
 .c3.kirk-button-bubble svg {


### PR DESCRIPTION
## Description

Fixed wrong spacing between icon & text in Button component
![image](https://user-images.githubusercontent.com/1606624/92502291-f229c680-f1ff-11ea-8c75-60cf61c51c69.png)
![image](https://user-images.githubusercontent.com/1606624/92502297-f655e400-f1ff-11ea-9571-12c41a4bedf9.png)


## What has been done

- Re-exported `RedCircleIcon` which was not exported properly from Figma and resulted in an icon of 16x16px instead of 24x24px
- Removed negative margins and use the same as design specs (8px right margin on icon)

## How it was tested

Storybook locally
