### PR TITLE
Increase line-height in tabs to support all diacritics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-[...]
+- **[UPDATE]** Set line height to `normal` in `Tabs` to support all diacritics
+  [...]
 
 # v40.1.0 (09/09/2020)
 

--- a/src/layout/section/tabsSection/__snapshots__/index.unit.tsx.snap
+++ b/src/layout/section/tabsSection/__snapshots__/index.unit.tsx.snap
@@ -67,6 +67,7 @@ exports[`TabsSection should render default TabsSection 1`] = `
   border: none;
   background-color: #FFF;
   color: #00AFF5;
+  line-height: normal;
   font-size: 16px;
 }
 

--- a/src/tabs/tabs.style.tsx
+++ b/src/tabs/tabs.style.tsx
@@ -20,6 +20,7 @@ export const StyledTabs = styled.div`
     -ms-overflow-style: none; /* Remove scrollbar visually IE 10+ */
     scrollbar-width: none; /* Remove scrollbar visually Firefox */
   }
+
   /* Remove scrollbar */
   & .kirk-tablist::-webkit-scrollbar {
     display: none;
@@ -38,6 +39,10 @@ export const StyledTabs = styled.div`
     border: none;
     background-color: ${color.white};
     color: ${color.blue};
+
+    /* Make sure the diacritics are not cropped. */
+    line-height: normal;
+
     font-size: ${font.base.size};
   }
 


### PR DESCRIPTION
## Description

Make sure all diacritics are properly displayed in the tabs.

## What has been done

Set the line height to `normal`: it's the default value.

**Before**

<img width="213" alt="Screenshot 2020-09-09 at 11 18 55" src="https://user-images.githubusercontent.com/17502801/92581925-98bda800-f290-11ea-8080-e05de0ae44a1.png">

**After**

<img width="213" alt="Screenshot 2020-09-09 at 11 19 15" src="https://user-images.githubusercontent.com/17502801/92581971-a83cf100-f290-11ea-9460-74561e6b4161.png">

## Things to consider

For accessibility, the line-height should be at least 1.5, `normal` is roughly around 1.2.

## How it was tested

- Storybook
