### PR TITLE
Grip v2 now with snap effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-[...]
+- **[UPDATE]** `Grip` now has a snap effect when moving the finger around
 
 # v40.1.0 (11/09/2020)
 

--- a/src/grip/Grip.unit.tsx
+++ b/src/grip/Grip.unit.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 
 import { TheVoice } from '../theVoice'
-import { Grip, SLIDE_OFFSET, touchEndListener } from './Grip'
+import { Grip, SLIDE_OFFSET, touchEndListener, touchMoveListener } from './Grip'
 import { GripHandle } from './GripHandle'
 
 describe('Grip', () => {
@@ -74,6 +74,17 @@ describe('Grip', () => {
       )
       expect(slideDownMock).not.toHaveBeenCalled()
       expect(slideUpMock).not.toHaveBeenCalled()
+    })
+  })
+  describe('touchMoveListener', () => {
+    const fingerYPosition = { current: 100 }
+    it('Should call onTouchMove with the offset between current finger position and initial', () => {
+      const touchMoveMock = jest.fn()
+      touchMoveListener(fingerYPosition.current - 10, fingerYPosition, {
+        ...defaultProps,
+        onTouchMove: touchMoveMock,
+      })
+      expect(touchMoveMock).toHaveBeenCalledWith(-10)
     })
   })
 })

--- a/src/grip/Grip.unit.tsx
+++ b/src/grip/Grip.unit.tsx
@@ -61,6 +61,7 @@ describe('Grip', () => {
         fingerYPosition,
         resetFingerYPosition,
         {
+          ...defaultProps,
           onSlideUp: slideUpMock,
           onSlideDown: slideDownMock,
         },
@@ -70,6 +71,7 @@ describe('Grip', () => {
         fingerYPosition,
         resetFingerYPosition,
         {
+          ...defaultProps,
           onSlideUp: slideUpMock,
           onSlideDown: slideDownMock,
         },

--- a/src/grip/Grip.unit.tsx
+++ b/src/grip/Grip.unit.tsx
@@ -9,6 +9,8 @@ describe('Grip', () => {
   const defaultProps = {
     onSlideUp: jest.fn(),
     onSlideDown: jest.fn(),
+    onTouchMove: jest.fn(),
+    onTouchEnd: jest.fn(),
   }
   it('Should render a GripHandle', () => {
     const grip = shallow(<Grip {...defaultProps} />)

--- a/src/layout/section/slideSection/SlideSection.style.tsx
+++ b/src/layout/section/slideSection/SlideSection.style.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-import { color, shadow, transition } from '../../../_utils/branding'
+import { color, shadow } from '../../../_utils/branding'
 
 export const StyledSlideLayout = styled.div`
   position: relative;
@@ -9,8 +9,6 @@ export const StyledSlideLayout = styled.div`
 `
 
 export const StyledSlidePanel = styled.div<{
-  minimalHeight: number
-  defaultHeight: number
   expandedHeight: number
 }>`
   background-color: ${color.white};
@@ -19,19 +17,14 @@ export const StyledSlidePanel = styled.div<{
   top: 100%;
   left: 0;
   right: 0;
-  transition: transform ease ${transition.duration.base};
   box-shadow: ${shadow.slideSection};
-
-  &.default {
-    transform: translateY(-${props => props.defaultHeight}px);
-  }
+  transition: width ease 200ms;
 
   &.expanded {
-    transform: translateY(-${props => props.expandedHeight}px);
     overflow: auto;
   }
 
-  &.reduced {
-    transform: translateY(-${props => props.minimalHeight}px);
+  &.animated {
+    transition: transform ease 200ms;
   }
 `


### PR DESCRIPTION
## Description

![Grip-snap-effect](https://user-images.githubusercontent.com/14176147/93225578-a8e2f500-f772-11ea-9480-5f79a903f96a.gif)

## What has been done

No change on external API for SlideSection, two new optional callbacks for Grip (so no issue with backward compatibility). First version was really basic, now the panel follows the finger before snapping to one of the three set positions. I had delayed this feature until later in the project as it wasn't as critical as others.

Transition effect is only active for the snap feature and when changing the position, so when moving your finger around or during initial mount, there is no animation, making it look super fluid.

## How it was tested

Chrome latest version, Firefox latest version, Safari iOS 13