### PR TITLE
Use RTL in SearchForm tests

### DIFF
--- a/__mocks__/focus-trap.ts
+++ b/__mocks__/focus-trap.ts
@@ -1,3 +1,6 @@
-export const createFocusTrap = jest.fn()
+export const createFocusTrap = jest.fn(() => ({
+  activate: jest.fn(),
+  deactivate: jest.fn(),
+}))
 
 export default createFocusTrap

--- a/bin/jestScript.js
+++ b/bin/jestScript.js
@@ -1,7 +1,22 @@
+import { config } from 'react-transition-group'
 import Enzyme from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 
 import '@testing-library/jest-dom'
+import 'jest-date-mock'
 import 'jest-styled-components'
 
+// Make sure transitions are immediate.
+config.disabled = true
+
 Enzyme.configure({ adapter: new Adapter() })
+
+let previousInnerWidth
+
+beforeEach(() => {
+  previousInnerWidth = window.innerWidth
+})
+
+afterEach(() => {
+  window.innerWidth = previousInnerWidth
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -7624,36 +7624,98 @@
       }
     },
     "@testing-library/dom": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.5.8.tgz",
-      "integrity": "sha512-aEK4GDeIk3sHuuF8NNvZrmZg5xfF7llvdlVfjely/fPg/GE4yLa0cVZEBWpS6oVUBk2tEXjwTDPFnMOe/M0GTQ==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.24.2.tgz",
+      "integrity": "sha512-ERxcZSoHx0EcN4HfshySEWmEf5Kkmgi+J7O79yCJ3xggzVlBJ2w/QjJUC+EBkJJ2OeSw48i3IoePN4w8JlVUIA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.9.6",
-        "aria-query": "^4.0.2",
-        "dom-accessibility-api": "^0.4.4",
-        "pretty-format": "^25.5.0"
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.10.3",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.1",
+        "pretty-format": "^26.4.2"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            }
+          }
+        },
         "@babel/runtime": {
-          "version": "7.9.6",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
-          "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
         },
+        "@babel/runtime-corejs3": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
+          "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+          "dev": true,
+          "requires": {
+            "core-js-pure": "^3.0.0",
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
         "@jest/types": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+          "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
-            "chalk": "^3.0.0"
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-report": "*"
           }
         },
         "@types/yargs": {
@@ -7671,34 +7733,45 @@
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
         "aria-query": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.0.2.tgz",
-          "integrity": "sha512-S1G1V790fTaigUSM/Gd0NngzEfiMy9uTUfMyHhKhVyy4cH5O/eTuR01ydhGL0z4Za1PXFTRGH3qL8VhUQuEO5w==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+          "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
           "dev": true,
           "requires": {
-            "@babel/runtime": "^7.7.4",
-            "@babel/runtime-corejs3": "^7.7.4"
+            "@babel/runtime": "^7.10.2",
+            "@babel/runtime-corejs3": "^7.10.2"
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "dev": true,
+              "requires": {
+                "@types/color-name": "^1.1.1",
+                "color-convert": "^2.0.1"
+              }
+            },
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
           }
         },
         "color-convert": {
@@ -7723,15 +7796,27 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
-          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "version": "26.4.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
           "dev": true,
           "requires": {
-            "@jest/types": "^25.5.0",
+            "@jest/types": "^26.3.0",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "dev": true,
+              "requires": {
+                "@types/color-name": "^1.1.1",
+                "color-convert": "^2.0.1"
+              }
+            }
           }
         },
         "react-is": {
@@ -7741,19 +7826,10 @@
           "dev": true
         },
         "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
           "dev": true
-        },
-        "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         }
       }
     },
@@ -7775,9 +7851,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.9.6",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
-          "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
@@ -7893,12 +7969,6 @@
             "pretty-format": "^25.5.0"
           }
         },
-        "lodash": {
-          "version": "4.17.19",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
-          "dev": true
-        },
         "pretty-format": {
           "version": "25.5.0",
           "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
@@ -7928,9 +7998,9 @@
           }
         },
         "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
           "dev": true
         },
         "strip-indent": {
@@ -7943,9 +8013,9 @@
           }
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -7965,18 +8035,18 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.9.6",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
-          "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
         },
         "regenerator-runtime": {
-          "version": "0.13.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
           "dev": true
         }
       }
@@ -7985,6 +8055,12 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
       "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
+      "dev": true
+    },
+    "@types/aria-query": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
+      "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==",
       "dev": true
     },
     "@types/babel-types": {
@@ -8383,227 +8459,22 @@
       "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==",
       "dev": true
     },
-    "@types/testing-library__dom": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-7.0.2.tgz",
-      "integrity": "sha512-8yu1gSwUEAwzg2OlPNbGq+ixhmSviGurBu1+ivxRKq1eRcwdjkmlwtPvr9VhuxTq2fNHBWN2po6Iem3Xt5A6rg==",
-      "dev": true,
-      "requires": {
-        "pretty-format": "^25.1.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^3.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "15.0.5",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
-          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^25.5.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
-          }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "@types/testing-library__jest-dom": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.7.0.tgz",
-      "integrity": "sha512-LoZ3uonlnAbJUz4bg6UoeFl+frfndXngmkCItSjJ8DD5WlRfVqPC5/LgJASsY/dy7AHH2YJ7PcsdASOydcVeFA==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.2.tgz",
+      "integrity": "sha512-K7nUSpH/5i8i0NagTJ+uFUDRueDlnMNhJtMjMwTGPPSqyImbWC/hgKPDCKt6Phu2iMJg2kWqlax+Ucj2DKMwpA==",
       "dev": true,
       "requires": {
         "@types/jest": "*"
       }
     },
     "@types/testing-library__react": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-10.0.1.tgz",
-      "integrity": "sha512-RbDwmActAckbujLZeVO/daSfdL1pnjVqas25UueOkAY5r7vriavWf0Zqg7ghXMHa8ycD/kLkv8QOj31LmSYwww==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-10.2.0.tgz",
+      "integrity": "sha512-KbU7qVfEwml8G5KFxM+xEfentAAVj/SOQSjW0+HqzjPE0cXpt0IpSamfX4jGYCImznDHgQcfXBPajS7HjLZduw==",
       "dev": true,
       "requires": {
-        "@types/react-dom": "*",
-        "@types/testing-library__dom": "*",
-        "pretty-format": "^25.1.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^3.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "15.0.5",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
-          "dev": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "pretty-format": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
-          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^25.5.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
-          }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
+        "@testing-library/react": "*"
       }
     },
     "@types/uglify-js": {
@@ -14085,9 +13956,9 @@
       "dev": true
     },
     "dom-accessibility-api": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.4.4.tgz",
-      "integrity": "sha512-XBM62jdDc06IXSujkqw6BugEWiDkp6jphtzVJf1kgPQGvfzaU7/jRtRSF/mxc8DBCIm2LS3bN1dCa5Sfxx982A==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.2.tgz",
+      "integrity": "sha512-k7hRNKAiPJXD2aBqfahSo4/01cTsKWXf+LqJgglnkN2Nz8TsxXKQBXHhKe0Ye9fEfHEZY49uSA5Sr3AqP/sWKA==",
       "dev": true
     },
     "dom-converter": {
@@ -20649,6 +20520,12 @@
         "pretty-format": "^24.9.0",
         "realpath-native": "^1.1.0"
       }
+    },
+    "jest-date-mock": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/jest-date-mock/-/jest-date-mock-1.0.8.tgz",
+      "integrity": "sha512-0Lyp+z9xvuNmLbK+5N6FOhSiBeux05Lp5bbveFBmYo40Aggl2wwxFoIrZ+rOWC8nDNcLeBoDd2miQdEDSf3iQw==",
+      "dev": true
     },
     "jest-diff": {
       "version": "24.9.0",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "gh-pages": "2.0.1",
     "husky": "1.3.1",
     "jest": "24.9.0",
+    "jest-date-mock": "1.0.8",
     "jest-environment-jsdom-fifteen": "1.0.2",
     "jest-styled-components": "6.3.4",
     "jsdom": "14.0.0",

--- a/src/searchForm/SearchForm.tsx
+++ b/src/searchForm/SearchForm.tsx
@@ -226,10 +226,8 @@ export const SearchForm = ({
     )
   }
 
-  const autocompleteFromValue = formValues[
-    SearchFormElements.AUTOCOMPLETE_FROM
-  ] as AutocompleteOnChange
-  const autocompleteToValue = formValues[SearchFormElements.AUTOCOMPLETE_TO] as AutocompleteOnChange
+  const autocompleteFromValue = formValues[SearchFormElements.AUTOCOMPLETE_FROM]
+  const autocompleteToValue = formValues[SearchFormElements.AUTOCOMPLETE_TO]
 
   const showInvertButton =
     formValues[SearchFormElements.AUTOCOMPLETE_FROM] != null ||
@@ -266,6 +264,7 @@ export const SearchForm = ({
               <span className="kirk-bullet--searchForm">
                 <Bullet type={BulletTypes.SEARCH} />
               </span>
+
               <TextTitle
                 className={cc([
                   'kirk-search-ellipsis',

--- a/src/searchForm/SearchForm.unit.tsx
+++ b/src/searchForm/SearchForm.unit.tsx
@@ -42,14 +42,14 @@ describe('SearchForm', () => {
     jestDateMock.clear()
   })
 
-  describe('From', () => {
+  describe('"From" field', () => {
     it('should hide the autocomplete by default', () => {
       const props = createProps()
       render(<SearchForm {...props} />)
       expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
     })
 
-    it('should display the button', () => {
+    it('should display the value in a button', () => {
       const props = createProps()
       render(<SearchForm {...props} />)
       expect(screen.getByRole('button', { name: 'Leaving from' })).toBeInTheDocument()
@@ -82,14 +82,14 @@ describe('SearchForm', () => {
     })
   })
 
-  describe('To', () => {
+  describe('"To" field', () => {
     it('should hide the autocomplete by default', () => {
       const props = createProps()
       render(<SearchForm {...props} />)
       expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
     })
 
-    it('should display the button', () => {
+    it('should display the value in a button', () => {
       const props = createProps()
       render(<SearchForm {...props} />)
       expect(screen.getByRole('button', { name: 'Going to' })).toBeInTheDocument()
@@ -122,14 +122,14 @@ describe('SearchForm', () => {
     })
   })
 
-  describe('Date', () => {
+  describe('"Date" field', () => {
     it('should hide the dialog by default', () => {
       const props = createProps()
       render(<SearchForm {...props} />)
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
     })
 
-    it('should display the button', () => {
+    it('should display the value in a button', () => {
       const props = createProps()
       render(<SearchForm {...props} />)
       expect(screen.getByRole('button', { name: '2020-01-01T00:00:00.000Z' })).toBeInTheDocument()
@@ -165,14 +165,14 @@ describe('SearchForm', () => {
     })
   })
 
-  describe('Seat count', () => {
+  describe('"Seat count" field', () => {
     it('should hide the dialog by default', () => {
       const props = createProps()
       render(<SearchForm {...props} />)
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
     })
 
-    it('should display the button', () => {
+    it('should display the value in a button', () => {
       const props = createProps()
       render(<SearchForm {...props} />)
       expect(screen.getByRole('button', { name: '1 seat(s)' })).toBeInTheDocument()

--- a/src/searchForm/SearchForm.unit.tsx
+++ b/src/searchForm/SearchForm.unit.tsx
@@ -1,300 +1,217 @@
 import React from 'react'
-import { CSSTransition } from 'react-transition-group'
-import { mount, shallow } from 'enzyme'
 
 import '../../__mocks__/matchMedia'
+import { fireEvent, render, screen } from '@testing-library/react'
+import * as jestDateMock from 'jest-date-mock'
 
-import { MediaSize } from '../_utils/mediaSizeProvider'
 import { AutoComplete } from '../autoComplete/AutoComplete'
-import { TextTitle } from '../typography/title'
-import { AutoCompleteOverlay } from './autoComplete/overlay'
-import { DatePickerOverlay } from './datePicker/overlay'
-import { Overlay } from './overlay'
 import { SearchForm, SearchFormProps } from './SearchForm'
-import { StepperOverlay } from './stepper/overlay'
 
-const today = new Date().toISOString()
+function createProps(props: Partial<SearchFormProps> = {}): SearchFormProps {
+  const today = new Date().toISOString()
 
-const defaultProps: SearchFormProps = {
-  onSubmit: () => {},
-  autocompleteFromPlaceholder: 'Leaving from',
-  autocompleteToPlaceholder: 'Going to',
-  renderAutocompleteFrom: props => <AutoComplete {...props} />,
-  renderAutocompleteTo: props => <AutoComplete {...props} />,
-  datepickerProps: {
-    defaultValue: today,
-    format: value => `Date: ${new Date(value).toISOString()}`,
-  },
-  stepperProps: {
-    defaultValue: 1,
-    min: 1,
-    max: 8,
-    increaseLabel: 'Increase',
-    decreaseLabel: 'Decrease',
-    title: 'Choose your number of seats',
-    format: value => `${value} seat(s)`,
-    confirmLabel: 'Submit',
-  },
+  return {
+    onSubmit: () => {},
+    autocompleteFromPlaceholder: 'Leaving from',
+    autocompleteToPlaceholder: 'Going to',
+    renderAutocompleteFrom: p => <AutoComplete {...p} />,
+    renderAutocompleteTo: p => <AutoComplete {...p} />,
+    datepickerProps: {
+      defaultValue: today,
+    },
+    stepperProps: {
+      defaultValue: 1,
+      min: 1,
+      max: 8,
+      increaseLabel: 'Increase',
+      decreaseLabel: 'Decrease',
+      title: 'Choose your number of seats',
+      format: value => `${value} seat(s)`,
+      confirmLabel: 'Submit',
+    },
+    ...props,
+  }
 }
 
-const withInitialFromTo: SearchFormProps = {
-  ...defaultProps,
-  initialFrom: 'Avignon',
-  initialTo: 'Marseille',
-}
+describe('SearchForm', () => {
+  beforeEach(() => {
+    jestDateMock.advanceTo(Date.UTC(2020, 0, 1))
+  })
 
-const withDisabledFromTo: SearchFormProps = {
-  ...defaultProps,
-  disabledFrom: true,
-  disabledTo: true,
-}
+  afterEach(() => {
+    jestDateMock.clear()
+  })
 
-describe('searchForm', () => {
-  let wrapper
-  const fakeEvent = { e: { relatedTarget: null } }
-
-  describe('interactions', () => {
-    describe('large', () => {
-      beforeEach(() => {
-        jest.spyOn(React, 'useContext').mockImplementation(() => MediaSize.LARGE)
-        wrapper = mount(<SearchForm {...defaultProps} />)
-      })
-
-      it('should have the autocomplete placeholder', () => {
-        expect(wrapper.find('.kirk-searchForm-from').text()).toBe('Leaving from')
-        expect(wrapper.find('.kirk-searchForm-to').text()).toBe('Going to')
-      })
-
-      it('should open the autocomplete from overlay and close it on blur', () => {
-        expect(wrapper.find(AutoCompleteOverlay).exists()).toBe(false)
-        wrapper.find('.kirk-searchForm-from .kirk-search-button').simulate('click')
-        expect(wrapper.find(AutoCompleteOverlay).exists()).toBe(true)
-        expect(
-          wrapper
-            .find(Overlay)
-            .first()
-            .hasClass('kirk-searchForm-autocomplete-from'),
-        ).toBe(true)
-        wrapper
-          .find(Overlay)
-          .first()
-          .simulate('blur', fakeEvent)
-        expect(
-          wrapper
-            .find(Overlay)
-            .first()
-            .prop('shouldDisplay'),
-        ).toBe(false)
-      })
-
-      it('should open the autocomplete to overlay', () => {
-        expect(wrapper.find(AutoCompleteOverlay).exists()).toBe(false)
-        wrapper.find('.kirk-searchForm-to .kirk-search-button').simulate('click')
-        expect(wrapper.find(AutoCompleteOverlay).exists()).toBe(true)
-        expect(
-          wrapper
-            .find(Overlay)
-            .at(1)
-            .hasClass('kirk-searchForm-autocomplete-to'),
-        ).toBe(true)
-      })
-
-      it('should open the datepicker overlay', () => {
-        expect(wrapper.find(DatePickerOverlay).exists()).toBe(false)
-        wrapper.find('.kirk-searchForm-date > .kirk-search-button').simulate('click')
-        expect(wrapper.find(DatePickerOverlay).exists()).toBe(true)
-      })
-
-      it('should open the stepper overlay', () => {
-        expect(wrapper.find(StepperOverlay).exists()).toBe(false)
-        wrapper.find('.kirk-searchForm-seats > .kirk-search-button').simulate('click')
-        expect(wrapper.find(StepperOverlay).exists()).toBe(true)
-      })
-
-      it('should have initial values for From & To', () => {
-        const wrapperWithInitialValues = mount(<SearchForm {...withInitialFromTo} />)
-        expect(wrapperWithInitialValues.find('.kirk-searchForm-from').text()).toBe('Avignon')
-        expect(wrapperWithInitialValues.find('.kirk-searchForm-to').text()).toBe('Marseille')
-      })
-
-      it('should have disabled fields From & To', () => {
-        const wrapperWithDisabledValues = mount(<SearchForm {...withDisabledFromTo} />)
-        expect(
-          wrapperWithDisabledValues
-            .find('.kirk-searchForm-from .kirk-search-button')
-            .prop('disabled'),
-        ).toBe(true)
-        expect(
-          wrapperWithDisabledValues
-            .find('.kirk-searchForm-to .kirk-search-button')
-            .prop('disabled'),
-        ).toBe(true)
-      })
+  describe('From', () => {
+    it('should hide the autocomplete by default', () => {
+      const props = createProps()
+      render(<SearchForm {...props} />)
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
     })
 
-    describe('small', () => {
-      beforeEach(() => {
-        jest.spyOn(React, 'useContext').mockImplementation(() => MediaSize.SMALL)
-        wrapper = shallow(<SearchForm {...defaultProps} />)
-      })
+    it('should display the button', () => {
+      const props = createProps()
+      render(<SearchForm {...props} />)
+      expect(screen.getByRole('button', { name: 'Leaving from' })).toBeInTheDocument()
+    })
 
-      it('should open the autocomplete from section', () => {
-        expect(
-          wrapper
-            .find(CSSTransition)
-            .first()
-            .prop('in'),
-        ).toBe(false)
-        wrapper.find('.kirk-searchForm-from .kirk-search-button').simulate('click')
-        expect(
-          wrapper
-            .find(CSSTransition)
-            .first()
-            .prop('in'),
-        ).toBe(true)
-      })
+    it('should open the autocomplete on click on the button', () => {
+      const props = createProps()
+      render(<SearchForm {...props} />)
+      fireEvent.click(screen.getByRole('button', { name: 'Leaving from' }))
+      expect(screen.getByRole('combobox')).toBeInTheDocument()
+    })
 
-      it('should open the autocomplete to section', () => {
-        expect(
-          wrapper
-            .find(CSSTransition)
-            .at(1)
-            .prop('in'),
-        ).toBe(false)
-        wrapper.find('.kirk-searchForm-to .kirk-search-button').simulate('click')
-        expect(
-          wrapper
-            .find(CSSTransition)
-            .at(1)
-            .prop('in'),
-        ).toBe(true)
-      })
+    it('should autofocus the input in the autocomplete', () => {
+      const props = createProps()
+      render(<SearchForm {...props} />)
+      fireEvent.click(screen.getByRole('button', { name: 'Leaving from' }))
+      expect(screen.getByRole('searchbox')).toHaveFocus()
+    })
 
-      it('should open the datepicker section', () => {
-        expect(
-          wrapper
-            .find(CSSTransition)
-            .at(2)
-            .prop('in'),
-        ).toBe(false)
-        wrapper.find('.kirk-searchForm-date > .kirk-search-button').simulate('click')
-        expect(
-          wrapper
-            .find(CSSTransition)
-            .at(2)
-            .prop('in'),
-        ).toBe(true)
-      })
+    it('should display the given initial value', () => {
+      const props = createProps({ initialFrom: 'Avignon' })
+      render(<SearchForm {...props} />)
+      expect(screen.getByRole('button', { name: 'Avignon' })).toBeInTheDocument()
+    })
 
-      it('should open the stepper section', () => {
-        expect(
-          wrapper
-            .find(CSSTransition)
-            .at(3)
-            .prop('in'),
-        ).toBe(false)
-        wrapper.find('.kirk-searchForm-seats > .kirk-search-button').simulate('click')
-        expect(
-          wrapper
-            .find(CSSTransition)
-            .at(3)
-            .prop('in'),
-        ).toBe(true)
-      })
-
-      it('should have initial values for From & To', () => {
-        const wrapperWithInitialValues = mount(<SearchForm {...withInitialFromTo} />)
-        expect(wrapperWithInitialValues.find('.kirk-searchForm-from').text()).toBe('Avignon')
-        expect(wrapperWithInitialValues.find('.kirk-searchForm-to').text()).toBe('Marseille')
-      })
-
-      it('should have disabled fields From & To', () => {
-        const wrapperWithDisabledValues = mount(<SearchForm {...withDisabledFromTo} />)
-        expect(
-          wrapperWithDisabledValues
-            .find('.kirk-searchForm-from .kirk-search-button')
-            .prop('disabled'),
-        ).toBe(true)
-        expect(
-          wrapperWithDisabledValues
-            .find('.kirk-searchForm-to .kirk-search-button')
-            .prop('disabled'),
-        ).toBe(true)
-      })
+    it('should disable the field when disabledFrom is true', () => {
+      const props = createProps({ disabledFrom: true })
+      render(<SearchForm {...props} />)
+      expect(screen.getByRole('button', { name: 'Leaving from' })).toBeDisabled()
     })
   })
 
-  describe('invert from to', () => {
-    // TODO: implement test when autocomplete list will be available
-    // beforeEach(() => {
-    //   wrapper = shallow(<SearchForm {...defaultProps} />)
-    // })
+  describe('To', () => {
+    it('should hide the autocomplete by default', () => {
+      const props = createProps()
+      render(<SearchForm {...props} />)
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+    })
+
+    it('should display the button', () => {
+      const props = createProps()
+      render(<SearchForm {...props} />)
+      expect(screen.getByRole('button', { name: 'Going to' })).toBeInTheDocument()
+    })
+
+    it('should open the autocomplete on click on the button', () => {
+      const props = createProps()
+      render(<SearchForm {...props} />)
+      fireEvent.click(screen.getByRole('button', { name: 'Going to' }))
+      expect(screen.getByRole('combobox')).toBeInTheDocument()
+    })
+
+    it('should autofocus the input in the autocomplete', () => {
+      const props = createProps()
+      render(<SearchForm {...props} />)
+      fireEvent.click(screen.getByRole('button', { name: 'Going to' }))
+      expect(screen.getByRole('searchbox')).toHaveFocus()
+    })
+
+    it('should display the given initial value', () => {
+      const props = createProps({ initialTo: 'Marseille' })
+      render(<SearchForm {...props} />)
+      expect(screen.getByRole('button', { name: 'Marseille' })).toBeInTheDocument()
+    })
+
+    it('should disable the field when disabledTo is true', () => {
+      const props = createProps({ disabledTo: true })
+      render(<SearchForm {...props} />)
+      expect(screen.getByRole('button', { name: 'Going to' })).toBeDisabled()
+    })
   })
 
-  describe('format', () => {
-    beforeEach(() => {
-      jest.spyOn(React, 'useContext').mockImplementation(() => MediaSize.LARGE)
+  describe('Date', () => {
+    it('should hide the dialog by default', () => {
+      const props = createProps()
+      render(<SearchForm {...props} />)
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
     })
 
-    it('should format the stepper & datepicker values into human readable strings', () => {
-      expect(
-        wrapper
-          .find('.kirk-searchForm-seats')
-          .find(TextTitle)
-          .text(),
-      ).toEqual('1 seat(s)')
-      expect(
-        wrapper
-          .find('.kirk-searchForm-date')
-          .find(TextTitle)
-          .text(),
-      ).toEqual(`Date: ${today}`)
+    it('should display the button', () => {
+      const props = createProps()
+      render(<SearchForm {...props} />)
+      expect(screen.getByRole('button', { name: '2020-01-01T00:00:00.000Z' })).toBeInTheDocument()
     })
 
-    it('should update the datepicker value after changing it', () => {
-      // Expected date is the first day of next month
-      const todayDate = new Date(today)
-
-      const expectedDate = new Date(
-        Date.UTC(todayDate.getFullYear(), todayDate.getMonth() + 1, 1, 0, 0, 0),
-      ).toISOString()
-
-      wrapper = mount(<SearchForm {...defaultProps} />)
-      wrapper.find('.kirk-searchForm-date > .kirk-search-button').simulate('click')
-
-      wrapper
-        .find('.kirk-datepicker-next-month')
-        .at(0)
-        .simulate('click')
-
-      wrapper
-        .find('.DayPicker-Day[aria-disabled=false]')
-        .at(0) // Click on the first day of next month
-        .simulate('click')
-
-      expect(
-        wrapper
-          .find('.kirk-searchForm-date')
-          .find(TextTitle)
-          .text(),
-      ).toEqual(`Date: ${expectedDate}`)
+    it('should open the datepicker on click on the button', () => {
+      const props = createProps()
+      render(<SearchForm {...props} />)
+      fireEvent.click(screen.getByRole('button', { name: '2020-01-01T00:00:00.000Z' }))
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
     })
 
-    it('should update the stepper value after changing it', () => {
-      wrapper = mount(<SearchForm {...defaultProps} />)
-      wrapper.find('.kirk-searchForm-seats > .kirk-search-button').simulate('click')
+    it('should update to the selected date', () => {
+      const props = createProps()
+      render(<SearchForm {...props} />)
+      fireEvent.click(screen.getByRole('button', { name: '2020-01-01T00:00:00.000Z' }))
+      fireEvent.click(screen.getByRole('gridcell', { name: 'Sat Jan 11 2020' }))
+      expect(screen.getByRole('button', { name: '2020-01-11' })).toBeInTheDocument()
+    })
 
-      wrapper
-        .find('.kirk-stepper-increment')
-        .at(0)
-        .simulate('click')
+    it('should format the date using the given formatter', () => {
+      const props = createProps({
+        datepickerProps: {
+          defaultValue: new Date().toISOString(),
+          format: value => new Date(value).toUTCString(),
+        },
+      })
 
+      render(<SearchForm {...props} />)
       expect(
-        wrapper
-          .find('.kirk-searchForm-seats')
-          .find(TextTitle)
-          .text(),
-      ).toEqual('2 seat(s)')
+        screen.getByRole('button', { name: 'Wed, 01 Jan 2020 00:00:00 GMT' }),
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('Seat count', () => {
+    it('should hide the dialog by default', () => {
+      const props = createProps()
+      render(<SearchForm {...props} />)
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+
+    it('should display the button', () => {
+      const props = createProps()
+      render(<SearchForm {...props} />)
+      expect(screen.getByRole('button', { name: '1 seat(s)' })).toBeInTheDocument()
+    })
+
+    it('should open the stepper on click on the button', () => {
+      const props = createProps()
+      render(<SearchForm {...props} />)
+      fireEvent.click(screen.getByRole('button', { name: '1 seat(s)' }))
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    it('should update the value when clicking on the "Increase" button', () => {
+      // Using small screen to force the "Submit" button.
+      window.innerWidth = 360
+      const props = createProps()
+      render(<SearchForm {...props} />)
+      fireEvent.click(screen.getByRole('button', { name: '1 seat(s)' }))
+
+      fireEvent.click(screen.getByRole('button', { name: 'Increase' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Increase' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+      expect(screen.getByRole('button', { name: '3 seat(s)' })).toBeInTheDocument()
+    })
+
+    it('should update the value when clicking on the "Decrease" button', () => {
+      // Using small screen to force the "Submit" button.
+      window.innerWidth = 360
+      const props = createProps()
+      render(<SearchForm {...props} />)
+      fireEvent.click(screen.getByRole('button', { name: '1 seat(s)' }))
+
+      fireEvent.click(screen.getByRole('button', { name: 'Increase' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Increase' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Decrease' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+      expect(screen.getByRole('button', { name: '2 seat(s)' })).toBeInTheDocument()
     })
   })
 })


### PR DESCRIPTION
## Description

In preparation of updates on the `SearchForm`, update its tests to use RTL.

## What has been done

- Replace Enzyme by RTL in tests.
- Improve focus-trap mock.
- Make sure react-transition-group transitions are immediate in tests.
- Reset `window.innerWidth` after each test for a nicer small/large screen testing.
- Add jest-date-mock to make sure to control the current date.

## Things to consider

Nothing.

## How it was tested

- Unit tests.