### PR TITLE
Only use knobs in stories

### DIFF
--- a/src/layout/section/tabsSection/story.tsx
+++ b/src/layout/section/tabsSection/story.tsx
@@ -28,30 +28,32 @@ const panels = [
   </BaseSection>,
 ]
 
-const tabs = {
-  activeTabId: 'tab1',
-  status: select('status', TabStatus, TabStatus.FIXED),
-  tabs: [
-    {
-      id: 'tab1',
-      label: text('Tab label 1', 'Tab 1'),
-      panelContent: panels[0],
-      badgeContent: text('Badge content 1', ''),
-    },
-    {
-      id: 'tab2',
-      label: text('Tab label 2', 'Very Very Long Tab 2'),
-      panelContent: panels[1],
-      badgeContent: text('Badge content 2', '2'),
-      badgeAriaLabel: 'Unread Message',
-    },
-    {
-      id: 'tab3',
-      label: text('Tab label 3', 'Tab 3'),
-      panelContent: panels[2],
-      badgeContent: text('Badge content 3', ''),
-    },
-  ],
-}
-
-stories.add('default', () => <TabsSection tabsProps={tabs} />)
+stories.add('default', () => (
+  <TabsSection
+    tabsProps={{
+      activeTabId: 'tab1',
+      status: select('status', TabStatus, TabStatus.FIXED),
+      tabs: [
+        {
+          id: 'tab1',
+          label: text('Tab label 1', 'Tab 1'),
+          panelContent: panels[0],
+          badgeContent: text('Badge content 1', ''),
+        },
+        {
+          id: 'tab2',
+          label: text('Tab label 2', 'Very Very Long Tab 2'),
+          panelContent: panels[1],
+          badgeContent: text('Badge content 2', '2'),
+          badgeAriaLabel: 'Unread Message',
+        },
+        {
+          id: 'tab3',
+          label: text('Tab label 3', 'Tab 3'),
+          panelContent: panels[2],
+          badgeContent: text('Badge content 3', ''),
+        },
+      ],
+    }}
+  />
+))


### PR DESCRIPTION
## Description

When starting storybooks, there are some knobs displayed on all stories as a side effect of one story.

## What has been done

Make sure the knobs are called only in the scope of a story.

**Example with `ButtonGroup` story**

Before | After
------------ | -------------
<img width="378" alt="Screenshot 2020-09-17 at 16 43 39" src="https://user-images.githubusercontent.com/17502801/93487358-787f9000-f905-11ea-894b-22b4ba7e0f0d.png"> | <img width="377" alt="Screenshot 2020-09-17 at 16 44 08" src="https://user-images.githubusercontent.com/17502801/93487384-7fa69e00-f905-11ea-9980-945dc52aecf4.png">

## Things to consider

Nothing.

## How it was tested

- Storybook
