### PR TITLE
Add explicit type='button' to Item using an HTML button to avoid accidental activations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Add explicit type"button" to Item using an HTML button to avoid accidental activation on form submit.
 [...]
 
 # v40.5.0 (23/09/2020)

--- a/src/_internals/item/Item.tsx
+++ b/src/_internals/item/Item.tsx
@@ -89,6 +89,22 @@ export const Item = (props: ItemProps) => {
   const a11yAttrs = pickA11yProps<ItemProps>(props)
   let Tag = tag.type
   let tagProps = tag.props
+
+  // The code below make sure that if we use a HTML button, a proper type='button' or
+  // type='submit' is added. type='button' is the default.
+  // This type=button is needed to make sure non-submit buttons are not activated when
+  // submitting forms.
+  // See: https://stackoverflow.com/questions/4763638/enter-triggers-button-click
+  let tagTypeProp = {}
+  const isButtonTag = tag.type === 'button' && typeof href !== 'string'
+  if (isButtonTag) {
+    if (tag.props.type) {
+      tagTypeProp = { type: tag.props.type }
+    } else {
+      tagTypeProp = { type: 'button' }
+    }
+  }
+
   if (href) {
     if (typeof href !== 'string') {
       Tag = href.type
@@ -123,6 +139,7 @@ export const Item = (props: ItemProps) => {
   return (
     <Tag
       {...tagProps}
+      {...tagTypeProp}
       onClick={onClick}
       onFocus={onFocus}
       onBlur={onBlur}

--- a/src/_internals/item/Item.unit.tsx
+++ b/src/_internals/item/Item.unit.tsx
@@ -61,6 +61,16 @@ describe('Item', () => {
     expect(onButtonClick).toHaveBeenCalledTimes(1)
   })
 
+  it('Should use correct button type for normal buttons', () => {
+    const wrapper = mount(<Item tag={<button />} />)
+    expect(wrapper.find('button[type="button"]').exists()).toBe(true)
+  })
+
+  it('Should use correct button type for submit buttons', () => {
+    const wrapper = mount(<Item tag={<button type="submit" />} />)
+    expect(wrapper.find('button[type="submit"]').exists()).toBe(true)
+  })
+
   it("Should't display left button addon if no title", () => {
     const wrapper = mount(
       <Item leftTitleButtonAddon={<Button onClick={() => {}}>More info</Button>} />,


### PR DESCRIPTION
When creating an Item (or derived ItemAction) using an HTML button tag,  there is no default type used.
By default, the browser (at least Chrome) considers that the button type is 'submit' and not 'button'.

It leads to issues in forms having one submit button plus (at least) another ItemAction button (inside the form). When emitting the submit event in the form, the browser will pick the first type='submit' in the form and activate it. If a button without an explicit type comes before the submit button, it will be activated first.

The fix is to add an explicit type='button' on non-submit buttons as explained here: https://stackoverflow.com/questions/4763638/enter-triggers-button-click

TESTED=Unit tests