### PR TITLE
Do not add type=button to anchor Items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+
+- **[FIX]** Do not add type"button" to anchor-based Items.
 [...]
 
 # v40.6.0 (25/09/2020)

--- a/src/_internals/item/Item.tsx
+++ b/src/_internals/item/Item.tsx
@@ -90,21 +90,6 @@ export const Item = (props: ItemProps) => {
   let Tag = tag.type
   let tagProps = tag.props
 
-  // The code below make sure that if we use a HTML button, a proper type='button' or
-  // type='submit' is added. type='button' is the default.
-  // This type=button is needed to make sure non-submit buttons are not activated when
-  // submitting forms.
-  // See: https://stackoverflow.com/questions/4763638/enter-triggers-button-click
-  let tagTypeProp = {}
-  const isButtonTag = tag.type === 'button' && typeof href !== 'string'
-  if (isButtonTag) {
-    if (tag.props.type) {
-      tagTypeProp = { type: tag.props.type }
-    } else {
-      tagTypeProp = { type: 'button' }
-    }
-  }
-
   if (href) {
     if (typeof href !== 'string') {
       Tag = href.type
@@ -114,6 +99,17 @@ export const Item = (props: ItemProps) => {
       tagProps = { href }
     }
   }
+
+  if (Tag === 'button') {
+    // The code below make sure that if we use a HTML button, a proper type='button' or
+    // type='submit' is added. type='button' is the default.
+    // This type=button is needed to make sure non-submit buttons are not activated when
+    // submitting forms.
+    // See: https://stackoverflow.com/questions/4763638/enter-triggers-button-click
+    const buttonType = tag.props.type || 'button'
+    tagProps = { ...tagProps, type: buttonType }
+  }
+
   const hasRightText = rightTitle || rightBody
 
   const getTextColor = (textColor: string) => (disabled ? color.gray : textColor)
@@ -139,7 +135,6 @@ export const Item = (props: ItemProps) => {
   return (
     <Tag
       {...tagProps}
-      {...tagTypeProp}
       onClick={onClick}
       onFocus={onFocus}
       onBlur={onBlur}

--- a/src/_internals/item/Item.unit.tsx
+++ b/src/_internals/item/Item.unit.tsx
@@ -66,6 +66,17 @@ describe('Item', () => {
     expect(wrapper.find('button[type="button"]').exists()).toBe(true)
   })
 
+  it('Should not add type=button to anchors', () => {
+    // The Item uses a <button> tag and href. Because of the href using an anchor, the item will be
+    // transformed into an HTML anchor, not HTML button.
+    const wrapper = mount(<Item tag={<button />} href={<a href="slug_link" />} />)
+
+    // Verify that there is a proper generated anchor element.
+    expect(wrapper.find('button[type="button"]').exists()).toBe(false)
+    expect(wrapper.find('a[type="button"]').exists()).toBe(false)
+    expect(wrapper.find('a').exists()).toBe(true)
+  })
+
   it('Should use correct button type for submit buttons', () => {
     const wrapper = mount(<Item tag={<button type="submit" />} />)
     expect(wrapper.find('button[type="submit"]').exists()).toBe(true)


### PR DESCRIPTION
In some case a HTML type='button' was added to some anchor-based Items.

Explanation
When using a tag button with an href containing an html anchor to configure an Item e.g.
`<Item tag={<button />} href={<a href='slug_link'>} />`
The resulting HTML was:
`<a href='slug_link' type='button' />`

The tag value inside the tag attribute was taking over the tag value inside the href to decide the HTML type.
The code was modified (and simplified) to cover this case.
A unit tests was added for this edge case.

TESTED=Unit tests.
