### PR TITLE
Release/40.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
-
-- **[FIX]** Do not add type"button" to anchor-based Items.
 [...]
+
+# v40.6.1 (25/09/2020)
+- **[FIX]** Do not add type"button" to anchor-based Items.
 
 # v40.6.0 (25/09/2020)
 
@@ -9,7 +10,6 @@
 - **[FIX]** Add normalized horizontal padding to `Review` component
 - **[UPDATE]** Add support for reply link to `Review` component
 - **[UPDATE]** Update `Caption` to support additional links properly.
-
 
 # v40.5.0 (23/09/2020)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "40.6.0",
+  "version": "40.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "40.6.0",
+  "version": "40.6.1",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# v40.6.1 (25/09/2020)
- **[FIX]** Do not add type"button" to anchor-based Items.
