### PR TITLE
Support trip changes in trip card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - **[UPDATE]** Update `Itinerary` to handle segments and connections
 - **[NEW]** Add `ConnectionIcon`
+- **[UPDATE]** Add `subText` to `TripCard`'s driver
+  [...]
 
 # v40.7.0 (01/10/2020)
 

--- a/src/tripCard/TripCard.story.mdx
+++ b/src/tripCard/TripCard.story.mdx
@@ -50,10 +50,10 @@ import { TripCard } from '.'
       badge="The Closest"
       title="Sun march 8th, 18:00"
       driver={{
-          avatarUrl: '//placehold.it/500x500',
-            firstName: 'Jane',
-            rating: '4.9',
-        }}
+        avatarUrl: '//placehold.it/500x500',
+        firstName: 'Jane',
+        rating: '4.9',
+      }}
     />
   </Story>
 </Preview>
@@ -88,7 +88,7 @@ Use backgroundless components to represent card’s content.
 ```jsx
 import { TripCard } from '@blablacar/ui-library/build/tripCard'
 
-<TripCard />
+const card = <TripCard />
 ```
 
 <Props of={TripCard} />

--- a/src/tripCard/TripCard.tsx
+++ b/src/tripCard/TripCard.tsx
@@ -65,7 +65,7 @@ export type TripCardProps = A11yProps &
 
 const renderPassenger = (passenger: User) => (
   <li className="kirk-tripCard-avatar" key={`${passenger.firstName}-${passenger.avatarUrl}`}>
-    <Avatar image={passenger.avatarUrl} isSmall />
+    <Avatar image={passenger.avatarUrl} alt={passenger.firstName} isSmall />
   </li>
 )
 
@@ -190,7 +190,11 @@ export const TripCard = (props: TripCardProps) => {
                   <div className="kirk-tripCard-bottom-left">
                     {driver && (
                       <div className="kirk-tripCard-driver">
-                        <Avatar className="kirk-tripCard-avatar" image={driver.avatarUrl} />
+                        <Avatar
+                          className="kirk-tripCard-avatar"
+                          image={driver.avatarUrl}
+                          alt={driver.firstName}
+                        />
                         <div className="kirk-tripCard-driver-info">
                           <Text
                             className="kirk-tripCard-driver-name"

--- a/src/tripCard/TripCard.tsx
+++ b/src/tripCard/TripCard.tsx
@@ -211,11 +211,7 @@ export const TripCard = (props: TripCardProps) => {
                   <div className="kirk-tripCard-bottom-left">
                     {driver && (
                       <div className="kirk-tripCard-driver">
-                        <Avatar
-                          className="kirk-tripCard-avatar"
-                          image={driver.avatarUrl}
-                          alt={driver.firstName}
-                        />
+                        <Avatar className="kirk-tripCard-avatar" image={driver.avatarUrl} />
                         <div className="kirk-tripCard-driver-info">
                           <Text
                             className="kirk-tripCard-driver-name"

--- a/src/tripCard/TripCard.tsx
+++ b/src/tripCard/TripCard.tsx
@@ -27,17 +27,21 @@ import { StyledTripCard } from './TripCard.style'
  */
 const PASSENGERS_TO_DISPLAY = 5
 
-export interface User {
+export type User = {
   avatarUrl: string
   firstName: string
   rating?: string
+}
+
+export type Driver = User & {
+  subText?: string
 }
 
 export type TripCardProps = A11yProps &
   Readonly<{
     href: string | JSX.Element
     itinerary: Place[]
-    driver?: User
+    driver?: Driver
     passengers?: User[]
     price?: string
     flags?: {
@@ -117,6 +121,23 @@ export const TripCard = (props: TripCardProps) => {
       href,
       rel: 'nofollow',
       ...a11yAttrs,
+    }
+  }
+
+  let driverSubText: React.ReactElement | null = null
+
+  if (shouldDisplayBottom && driver != null) {
+    if (driver.subText != null) {
+      driverSubText = (
+        <TextBody className="kirk-tripCard-ratingContainer">{driver.subText}</TextBody>
+      )
+    } else if (driver.rating != null) {
+      driverSubText = (
+        <TextBody className="kirk-tripCard-ratingContainer">
+          <Star fill={1} size={16} />
+          <span className="kirk-tripCard-rating">{driver.rating}</span>
+        </TextBody>
+      )
     }
   }
 
@@ -203,12 +224,7 @@ export const TripCard = (props: TripCardProps) => {
                           >
                             {driver.firstName}
                           </Text>
-                          {driver.rating && (
-                            <TextBody className="kirk-tripCard-ratingContainer">
-                              <Star fill={1} size={16} />
-                              <span className="kirk-tripCard-rating">{driver.rating}</span>
-                            </TextBody>
-                          )}
+                          {driverSubText}
                         </div>
                       </div>
                     )}

--- a/src/tripCard/TripCard.unit.tsx
+++ b/src/tripCard/TripCard.unit.tsx
@@ -185,7 +185,20 @@ describe('TripCard', () => {
     expect(container.querySelector('img[src="//placehold.it/500x500"]')).toBeInTheDocument()
   })
 
-  it('Should render driver sub text', () => {
+  it("Should show the driver's ratings", () => {
+    const props = createProps({
+      driver: {
+        avatarUrl: '//placehold.it/500x500',
+        firstName: 'Jane',
+        rating: '3 stars',
+      },
+    })
+
+    render(<TripCard {...props} />)
+    expect(screen.getByText('3 stars')).toBeInTheDocument()
+  })
+
+  it("Should render driver's sub text", () => {
     const props = createProps({
       driver: {
         avatarUrl: '//placehold.it/500x500',

--- a/src/tripCard/TripCard.unit.tsx
+++ b/src/tripCard/TripCard.unit.tsx
@@ -173,6 +173,19 @@ describe('TripCard', () => {
     expect(screen.getByAltText('Jane')).toBeInTheDocument()
   })
 
+  it('Should render driver sub text', () => {
+    const props = createProps({
+      driver: {
+        avatarUrl: '//placehold.it/500x500',
+        firstName: 'BlaBlaCar',
+        subText: '3 changes',
+      },
+    })
+
+    render(<TripCard {...props} />)
+    expect(screen.getByText('3 changes')).toBeInTheDocument()
+  })
+
   it('Should render 3 passengers', () => {
     const props = createProps({ passengers: createPassengers(3) })
     render(<TripCard {...props} />)

--- a/src/tripCard/TripCard.unit.tsx
+++ b/src/tripCard/TripCard.unit.tsx
@@ -1,161 +1,212 @@
 import React from 'react'
-import { mount, shallow } from 'enzyme'
 
-import { Avatar } from '../avatar'
-import { AloneInTheBackIcon } from '../icon/aloneInTheBackIcon'
-import { ComfortIcon } from '../icon/comfortIcon'
-import { LadyIcon } from '../icon/ladyIcon'
-import { LightningIcon } from '../icon/lightningIcon'
+import { render, screen } from '@testing-library/react'
+
 import { WarningIcon } from '../icon/warningIcon'
-import { Text } from '../text'
-import { TripCard } from './TripCard'
-import { StyledTripCard } from './TripCard.style'
+import { TripCard, TripCardProps, User } from './TripCard'
 
-const mockedProps = {
-  href: '#',
-  itinerary: [
-    {
-      mainLabel: 'Paris',
-      subLabel: 'Porte de Vincennes',
-      time: '09:00',
-      isoDate: '2017-12-11T09:00',
-      distanceFromPoint: '1,5km',
-    },
-    {
-      mainLabel: 'Bordeaux',
-      subLabel: 'Gare Bordeaux Saint-Jean',
-      time: '12:00',
-      isoDate: '2017-12-11T12:00',
-      distanceFromPoint: '8km',
-    },
-  ],
-  driver: {
-    avatarUrl: '//placehold.it/500x500',
-    firstName: 'Jane',
-  },
-  flags: {
-    ladiesOnly: true,
-    aloneInTheBack: true,
-    maxTwo: true,
-    autoApproval: true,
-  },
-  price: '8,00€',
-}
+function createPassengers(count: number): User[] {
+  const passengers: User[] = []
 
-const createPassengers = count => {
-  let passengerIdx = 1
-  const passengers = Array(count).fill({
-    avatarUrl: '//placehold.it/500x500',
-    firstName: `Jane ${(passengerIdx += 1)}`,
-  })
+  for (let index = 0; index < count; index += 1) {
+    passengers.push({
+      avatarUrl: '//placehold.it/500x500',
+      firstName: `Jane ${index}`,
+    })
+  }
 
   return passengers
 }
 
-const Div = () => <div className="divTest" />
+function createProps(props: Partial<TripCardProps> = {}): TripCardProps {
+  return {
+    href: '#',
+    itinerary: [
+      {
+        mainLabel: 'Paris',
+        subLabel: 'Porte de Vincennes',
+        time: '09:00',
+        isoDate: '2017-12-11T09:00',
+        distanceFromPoint: '1,5km',
+      },
+      {
+        mainLabel: 'Bordeaux',
+        subLabel: 'Gare Bordeaux Saint-Jean',
+        time: '12:00',
+        isoDate: '2017-12-11T12:00',
+        distanceFromPoint: '8km',
+      },
+    ],
+    ...props,
+  }
+}
 
-describe('TripCard component', () => {
-  it('Should wrap the content in a Card', () => {
-    const tripCard = shallow(<TripCard {...mockedProps} />)
+describe('TripCard', () => {
+  it('should have aria-label attribute on the wrapper link', () => {
+    const props = createProps({ 'aria-label': 'Trip label' })
+    render(<TripCard {...props} />)
 
-    expect(tripCard.first().type()).toBe(StyledTripCard)
-  })
-
-  it('Should have the base class and no aria attribute', () => {
-    const tripCard = shallow(<TripCard {...mockedProps} />)
-    expect(tripCard.hasClass('kirk-tripCard')).toBe(true)
-    expect(tripCard.prop('aria-label')).toBeFalsy()
-  })
-
-  it('Should have `aria-label` attribute on the wrapper link', () => {
-    const tripCard = shallow(<TripCard {...mockedProps} aria-label="testLabel" />)
-    expect(tripCard.find('a').prop('aria-label')).toEqual('testLabel')
+    expect(screen.getByRole('link', { name: 'Trip label' })).toBeInTheDocument()
   })
 
   it('Should have the test class', () => {
-    const tripCard = shallow(<TripCard {...mockedProps} className="test" />)
-    expect(tripCard.hasClass('test')).toBe(true)
+    const props = createProps({ className: 'test' })
+    const { container } = render(<TripCard {...props} />)
+    expect(container.firstChild).toHaveClass('test')
   })
 
   it('Should use the right element (specified in href prop)', () => {
-    const tripCard = mount(<TripCard {...mockedProps} href={<Div />} />)
-    expect(tripCard.find(Div).exists()).toBe(true)
-    expect(tripCard.find('.divTest').exists()).toBe(true)
+    const props = createProps({ href: <div data-testid="href" /> })
+    render(<TripCard {...props} />)
+    expect(screen.getByTestId('href')).toBeInTheDocument()
   })
 
-  it('Should have only the Ladies Only icon', () => {
-    const tripCard = shallow(<TripCard {...mockedProps} flags={{ ladiesOnly: true }} />)
-    expect(tripCard.find(LadyIcon).exists()).toBe(true)
-    expect(tripCard.find(AloneInTheBackIcon).exists()).toBe(false)
-    expect(tripCard.find(ComfortIcon).exists()).toBe(false)
-    expect(tripCard.find(LightningIcon).exists()).toBe(false)
+  it('Should not have the ladies only icon by default', () => {
+    const props = createProps({
+      titles: { ladiesOnly: 'Ladies only title' },
+    })
+
+    render(<TripCard {...props} />)
+    expect(screen.queryByText('Ladies only title')).not.toBeInTheDocument()
   })
 
-  it('Should render metaUrl if provided', () => {
-    const tripCard = shallow(<TripCard {...mockedProps} metaUrl={null} />)
-    expect(tripCard.find('meta')).toHaveLength(0)
+  it('Should have the ladies only icon', () => {
+    const props = createProps({
+      flags: { ladiesOnly: true },
+      titles: { ladiesOnly: 'Ladies only title' },
+    })
 
-    const tripCardWithMetaUrl = shallow(<TripCard {...mockedProps} metaUrl="blablacar.fr" />)
-    expect(tripCardWithMetaUrl.find('meta')).toHaveLength(4)
+    render(<TripCard {...props} />)
+    expect(screen.getByText('Ladies only title')).toBeInTheDocument()
+  })
+
+  it('Should not have the alone in the back icon by default', () => {
+    const props = createProps({
+      titles: { aloneInTheBack: 'Alone in the back' },
+    })
+
+    render(<TripCard {...props} />)
+    expect(screen.queryByText('Alone in the back')).not.toBeInTheDocument()
+  })
+
+  it('Should have the alone in the back icon', () => {
+    const props = createProps({
+      flags: { aloneInTheBack: true },
+      titles: { aloneInTheBack: 'Alone in the back' },
+    })
+
+    render(<TripCard {...props} />)
+    expect(screen.getByText('Alone in the back')).toBeInTheDocument()
+  })
+
+  it('Should not have the max two icon by default', () => {
+    const props = createProps({
+      titles: { maxTwo: 'Max two' },
+    })
+
+    render(<TripCard {...props} />)
+    expect(screen.queryByText('Max two')).not.toBeInTheDocument()
+  })
+
+  it('Should have the max two icon', () => {
+    const props = createProps({
+      flags: { maxTwo: true },
+      titles: { maxTwo: 'Max two' },
+    })
+
+    render(<TripCard {...props} />)
+    expect(screen.getByText('Max two')).toBeInTheDocument()
+  })
+
+  it('Should not have the auto approval icon by default', () => {
+    const props = createProps({
+      titles: { autoApproval: 'Auto approval' },
+    })
+
+    render(<TripCard {...props} />)
+    expect(screen.queryByText('Auto approval')).not.toBeInTheDocument()
+  })
+
+  it('Should have the auto approval icon', () => {
+    const props = createProps({
+      flags: { autoApproval: true },
+      titles: { autoApproval: 'Auto approval' },
+    })
+
+    render(<TripCard {...props} />)
+    expect(screen.getByText('Auto approval')).toBeInTheDocument()
+  })
+
+  it('Should not render meta tags by default', () => {
+    const props = createProps()
+    render(<TripCard {...props} />)
+    expect(screen.queryByRole('meta')).not.toBeInTheDocument()
+  })
+
+  it('Should render meta tags if provided', () => {
+    const props = createProps({ metaUrl: 'blablacar.fr' })
+    const { container } = render(<TripCard {...props} />)
+
+    expect(
+      container.querySelector('meta[itemprop="url"][content="blablacar.fr"]'),
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('meta[itemprop="name"][content="Paris → Bordeaux"]'),
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('meta[itemprop="startDate"][content="2017-12-11T09:00"]'),
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('meta[itemprop="endDate"][content="2017-12-11T12:00"]'),
+    ).toBeInTheDocument()
   })
 
   it('Should show driver avatar', () => {
-    const driver = {
-      avatarUrl: '//placehold.it/500x500',
-      firstName: 'Jane',
-    }
+    const props = createProps({
+      driver: {
+        avatarUrl: '//placehold.it/500x500',
+        firstName: 'Jane',
+      },
+    })
 
-    const component = shallow(<TripCard {...mockedProps} driver={driver} passengers={null} />)
-    expect(component.find(Avatar)).toHaveLength(1)
+    render(<TripCard {...props} />)
+    expect(screen.getByAltText('Jane')).toBeInTheDocument()
   })
 
   it('Should render 3 passengers', () => {
-    const passengersCount = 3
-    const component = shallow(
-      <TripCard {...mockedProps} driver={null} passengers={createPassengers(passengersCount)} />,
-    )
-    expect(component.find(Avatar)).toHaveLength(passengersCount)
-    expect(component.find('.kirk-tripCard-passengers-more').exists()).toBe(false)
+    const props = createProps({ passengers: createPassengers(3) })
+    render(<TripCard {...props} />)
+    expect(screen.getAllByAltText(/^Jane \d$/)).toHaveLength(3)
   })
 
   it('Should render 5 passengers', () => {
-    const passengersCount = 5
-    const component = shallow(
-      <TripCard {...mockedProps} driver={null} passengers={createPassengers(passengersCount)} />,
-    )
-    expect(component.find(Avatar)).toHaveLength(passengersCount)
-    expect(component.find('.kirk-tripCard-passengers-more').exists()).toBe(false)
+    const props = createProps({ passengers: createPassengers(5) })
+    render(<TripCard {...props} />)
+    expect(screen.getAllByAltText(/^Jane \d$/)).toHaveLength(5)
   })
 
   it('Should render 4 passengers and a +6 icon', () => {
-    const passengersCount = 10
-    const component = shallow(
-      <TripCard {...mockedProps} driver={null} passengers={createPassengers(passengersCount)} />,
-    )
-    expect(component.find(Avatar)).toHaveLength(4)
-    expect(component.find('.kirk-tripCard-passengers-more').exists()).toBe(true)
-    expect(
-      component
-        .find('.kirk-tripCard-passengers-more')
-        .find(Text)
-        .html(),
-    ).toMatch(/\+6/)
+    const props = createProps({ passengers: createPassengers(10) })
+    render(<TripCard {...props} />)
+    expect(screen.getAllByAltText(/^Jane \d+$/)).toHaveLength(4)
+    expect(screen.getByText('+6')).toBeInTheDocument()
   })
 
   it('Should render status information', () => {
-    const statusInformation = { icon: <WarningIcon />, text: 'Warning!' }
-    const component = shallow(<TripCard {...mockedProps} statusInformation={statusInformation} />)
-    expect(component.find('.kirk-tripCard-top-item').exists()).toBe(true)
+    const props = createProps({ statusInformation: { icon: <WarningIcon />, text: 'Warning!' } })
+    render(<TripCard {...props} />)
+    expect(screen.getByText('Warning!')).toBeInTheDocument()
   })
 
   it('Should render badge', () => {
-    const component = shallow(<TripCard {...mockedProps} badge="Cheapest!" />)
-    expect(component.hasClass('kirk-tripCard--with-badge')).toBe(true)
-    expect(component.find('.kirk-tripCard-badge').exists()).toBe(true)
+    const props = createProps({ badge: 'Cheapest!' })
+    render(<TripCard {...props} />)
+    expect(screen.getByText('Cheapest!')).toBeInTheDocument()
   })
 
   it('Should render title', () => {
-    const component = shallow(<TripCard {...mockedProps} title="Sun 3 march, 18:00" />)
-    expect(component.find('.kirk-tripCard-title').exists()).toBe(true)
+    const props = createProps({ title: 'Sun 3 march, 18:00' })
+    render(<TripCard {...props} />)
+    expect(screen.getByText('Sun 3 march, 18:00')).toBeInTheDocument()
   })
 })

--- a/src/tripCard/TripCard.unit.tsx
+++ b/src/tripCard/TripCard.unit.tsx
@@ -161,7 +161,7 @@ describe('TripCard', () => {
     ).toBeInTheDocument()
   })
 
-  it('Should show driver avatar', () => {
+  it("Should show the driver's name", () => {
     const props = createProps({
       driver: {
         avatarUrl: '//placehold.it/500x500',
@@ -170,7 +170,19 @@ describe('TripCard', () => {
     })
 
     render(<TripCard {...props} />)
-    expect(screen.getByAltText('Jane')).toBeInTheDocument()
+    expect(screen.getByText('Jane')).toBeInTheDocument()
+  })
+
+  it("Should show the driver's avatar", () => {
+    const props = createProps({
+      driver: {
+        avatarUrl: '//placehold.it/500x500',
+        firstName: 'Jane',
+      },
+    })
+
+    const { container } = render(<TripCard {...props} />)
+    expect(container.querySelector('img[src="//placehold.it/500x500"]')).toBeInTheDocument()
   })
 
   it('Should render driver sub text', () => {


### PR DESCRIPTION
## Description

Allow the TripCard component to display a sub text in the driver section.

## What has been done

Add an optional `subText` attribute in the `driver` prop.

<img width="348" alt="Screenshot 2020-09-30 at 18 16 34" src="https://user-images.githubusercontent.com/17502801/94711986-2305a300-0349-11eb-93bc-793f64c1668d.png">

## Things to consider

The `driver` prop makes no sens for buses but until we change it, `subText` should be near `ratings` as it is displayed in its place.

## How it was tested

- Storybook
- Unit tests
