### PR TITLE
Fix `statusInformation` padding in `TripCard`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Fix `statusInformation` position in `TripCard`
 - **[FIX]** Add explicit type"button" to Item using an HTML button to avoid accidental activation on form submit.
 - **[FIX]** Make `FilterBar` button not moving when `Loader` is visible
 - **[UPDATE]** Migrate `QrCard` to new mdx story format

--- a/src/tripCard/TripCard.style.tsx
+++ b/src/tripCard/TripCard.style.tsx
@@ -26,6 +26,7 @@ export const StyledTripCard = styled(Card)`
 
   & .kirk-item.kirk-tripCard-top-item {
     padding-top: 0;
+    padding-left: 0 !important;
   }
 
   & .kirk-item--highlighted .kirk-text-body {


### PR DESCRIPTION
## Description

Fix `statusInformation` position in `TripCard`

After: 
<img width="377" alt="Capture d’écran 2020-10-01 à 10 55 46" src="https://user-images.githubusercontent.com/729186/94789060-bd5ef880-03d4-11eb-9ccf-08c09e4814c6.png">
Before: 
<img width="377" alt="Capture d’écran 2020-10-01 à 10 55 13" src="https://user-images.githubusercontent.com/729186/94789065-be902580-03d4-11eb-8476-093108b542e3.png">

## What has been done

Override item padding in `TripCard` styles

## Things to consider

Had to use `!important` cause `Item`s are using it...

## How it was tested

Storybook
