### PR TITLE
Fix external touch events triggering Grip touch callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@
 - **[UPDATE]** Migrate `DatePicker` to new mdx story format
 - **[NEW]** Add `LoadingPage` component
 - **[UPDATE]** Add white background to `LoadingPage` component to enable superposition
-[...]
-
+- **[FIX]** Prevent all touch events from triggering `Grip` `onTouchMove` and `onTouchEnd` callbacks
+  [...]
 
 # v40.6.1 (25/09/2020)
+
 - **[FIX]** Do not add type"button" to anchor-based Items.
 
 # v40.6.0 (25/09/2020)

--- a/src/grip/Grip.tsx
+++ b/src/grip/Grip.tsx
@@ -98,7 +98,6 @@ export const Grip = (props: GripProps): JSX.Element => {
     <div
       className={className}
       onTouchStart={e => {
-        console.log('START')
         fingerYPosition.current = e.touches.item(0).clientY
       }}
       {...a11yAttrs}

--- a/src/grip/Grip.tsx
+++ b/src/grip/Grip.tsx
@@ -23,7 +23,7 @@ export const touchEndListener = (
   props: GripProps,
 ) => {
   const { onSlideDown, onSlideUp, onTouchEnd } = props
-  if (fingerYPosition !== null) {
+  if (fingerYPosition.current !== null) {
     onTouchEnd()
     if (clientY < fingerYPosition.current - SLIDE_OFFSET) {
       onSlideUp()
@@ -40,7 +40,7 @@ export const touchMoveListener = (
   props: GripProps,
 ) => {
   const { onTouchMove } = props
-  if (fingerYPosition !== null) {
+  if (fingerYPosition.current !== null) {
     onTouchMove(clientY - fingerYPosition.current)
   }
 }
@@ -98,6 +98,7 @@ export const Grip = (props: GripProps): JSX.Element => {
     <div
       className={className}
       onTouchStart={e => {
+        console.log('START')
         fingerYPosition.current = e.touches.item(0).clientY
       }}
       {...a11yAttrs}


### PR DESCRIPTION
## Description

Touching the media component (ex: map zooming) would trigger the `Grip` `onTouchMove` and `onTouchEnd` callbacks. Looks like I wasn't checking my refs right...

## What has been done

Fixed the condition that was checking that a previous `touchstart` event was done on the Grip itself before triggering `move` and `end` events.

## How it was tested

Locally with Chrome and iOS Safari
