### PR TITLE
Release/41.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 [...]
 
-# v40.8.0 (05/10/2020)
+# v41.0.0 (05/10/2020)
 
 - **[BREAKING CHANGE]** Rename `BlankSeparator` to `divider/spacingDivider`
 - **[BREAKING CHANGE]** Rename `Divider` to `divider/contentDivider`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+[...]
+
+# v40.8.0 (05/10/2020)
+
 - **[BREAKING CHANGE]** Rename `BlankSeparator` to `divider/spacingDivider`
 - **[BREAKING CHANGE]** Rename `Divider` to `divider/contentDivider`
 - **[NEW]** Create `divider/sectionDivider`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "40.8.0",
+  "version": "41.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "40.8.0",
+  "version": "41.0.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Description

- **[BREAKING CHANGE]** Rename `BlankSeparator` to `divider/spacingDivider`
- **[BREAKING CHANGE]** Rename `Divider` to `divider/contentDivider`
- **[NEW]** Create `divider/sectionDivider`
- **[FIX]** Improved position of the title of `HeroSection`
- **[BREAKING CHANGE]** Remove `ClassicHeroSection` variant of `HeroSection` and make `IllustrationHeroSection` the default case