### PR TITLE
Set label as optional in ItemRadio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Set `label` as an optional field in `ItemRadio`
 [...]
 
 # v41.0.0 (05/10/2020)

--- a/src/itemRadio/ItemRadio.tsx
+++ b/src/itemRadio/ItemRadio.tsx
@@ -22,7 +22,7 @@ export type ItemRadioProps = A11yProps &
     value: string | number
     leftAddon?: React.ReactNode
     labelTitle?: string
-    label: string
+    label?: string
     data?: string
     dataInfo?: string
     checked?: boolean


### PR DESCRIPTION
## Description

We're using `labelTitle` for the `ReasonStep` in kairos, so this field shouldn't be required

## What has been done

Updated type

## How it was tested

On kairos
