### PR TITLE
Releases/41.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Unreleased
 
+[...]
+
+# v41.1.0 (08/10/2020)
+
 - **[UPDATE]** Migrate `Stepper` to new mdx story format
 - **[FIX]** Set `label` as an optional field in `ItemRadio`
-[...]
 
 # v41.0.0 (05/10/2020)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "41.0.0",
+  "version": "41.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "41.0.0",
+  "version": "41.1.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# v41.1.0 (08/10/2020)

- **[UPDATE]** Migrate `Stepper` to new mdx story format
- **[FIX]** Set `label` as an optional field in `ItemRadio`