### PR TITLE
change separator character used in breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [...]
 
+- **[UPDATE]** Change separator character used in `Breadcrumb`
+
 # v41.1.0 (08/10/2020)
 
 - **[UPDATE]** Migrate `Stepper` to new mdx story format

--- a/src/breadcrumb/Breadcrumb.tsx
+++ b/src/breadcrumb/Breadcrumb.tsx
@@ -41,7 +41,7 @@ export const Breadcrumb = ({ crumbs }: BreadcrumbProps) => (
 
               {position < crumbs.length && (
                 <span role="separator" className="breadcrumb-separator">
-                  {' > '}
+                  {' › '}
                 </span>
               )}
             </TextCaption>

--- a/src/breadcrumb/Breadcrumb.unit.tsx
+++ b/src/breadcrumb/Breadcrumb.unit.tsx
@@ -23,6 +23,6 @@ describe('Breadcrumb', () => {
   it('renders with 2 links and a separator', () => {
     render(<Breadcrumb crumbs={[crumb1, crumb2]} />)
     expect(screen.getAllByRole('listitem')).toHaveLength(2)
-    expect(screen.getByRole('list')).toHaveTextContent('Fhtagn > Cthulhu')
+    expect(screen.getByRole('list')).toHaveTextContent('Fhtagn › Cthulhu')
   })
 })


### PR DESCRIPTION
BEFORE
![Screen Shot 2020-10-09 at 12 16 54](https://user-images.githubusercontent.com/373381/95571901-73f05800-0a29-11eb-95e2-44669ef5a159.png)

AFTER
![Screen Shot 2020-10-09 at 12 17 11](https://user-images.githubusercontent.com/373381/95571915-7b176600-0a29-11eb-9cac-841d9dead8fc.png)

Tested locally on Firefox Macos