### PR TITLE
Add missing `spellCheck` prop to `TextField`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 [...]
-
+- **[UPDATE]** Add `spellCheck` prop to `TextField` type
 - **[UPDATE]** Change separator character used in `Breadcrumb`
 
 # v41.1.0 (08/10/2020)

--- a/src/textField/TextField.tsx
+++ b/src/textField/TextField.tsx
@@ -40,6 +40,7 @@ export type CommonFormFields = Readonly<{
   maxLength?: number
   autoCorrect?: 'on' | 'off'
   autoComplete?: string
+  spellCheck?: 'true' | 'false'
   disabled?: boolean
   readOnly?: boolean
   autoFocus?: boolean


### PR DESCRIPTION
## How it was tested

On kairos
