### PR TITLE
Add onClick's support onClick for Review widget reply link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- **[NEW]** Add support for onClick handler for `Caption` link.
+- **[NEW]** Add support for replyLinkOnClick handler for `Review` reply link.
+- **[FIX]** Fix `Button` height when using an HTML unstyled button.
 [...]
 
 # v41.3.1 (15/10/2020)

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -65,6 +65,7 @@ const StyledButton = styled(Button)`
     text-align: left;
     min-width: inherit;
     min-height: inherit;
+    height: auto;
   }
 
   &[disabled] {

--- a/src/caption/Caption.tsx
+++ b/src/caption/Caption.tsx
@@ -4,9 +4,13 @@ import cc from 'classcat'
 import { Button, ButtonStatus } from '../button'
 import { StyledCaption } from './Caption.style'
 
-export const renderSecondary = (href?: string | JSX.Element, secondaryText?: string) =>
-  href ? (
-    <Button status={ButtonStatus.UNSTYLED} href={href}>
+export const renderSecondary = (
+  href?: string | JSX.Element,
+  secondaryText?: string,
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void,
+) =>
+  href || onClick ? (
+    <Button status={ButtonStatus.UNSTYLED} href={href} onClick={onClick}>
       {secondaryText}
     </Button>
   ) : (
@@ -18,16 +22,26 @@ export type CaptionProps = Readonly<{
   children: any
   isoDate: string
   href?: string | JSX.Element
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void
   secondaryText?: string
 }>
 
-export const Caption = ({ className, children, href, secondaryText, isoDate }: CaptionProps) => (
+export const Caption = ({
+  className,
+  children,
+  href,
+  onClick,
+  secondaryText,
+  isoDate,
+}: CaptionProps) => (
   <StyledCaption className={cc(['kirk-caption', className])}>
     <time className="kirk-caption-time" dateTime={isoDate || null}>
       {children}
     </time>
     {secondaryText && (
-      <span className="kirk-caption-secondary-content">{renderSecondary(href, secondaryText)}</span>
+      <span className="kirk-caption-secondary-content">
+        {renderSecondary(href, secondaryText, onClick)}
+      </span>
     )}
   </StyledCaption>
 )

--- a/src/caption/Caption.unit.tsx
+++ b/src/caption/Caption.unit.tsx
@@ -5,7 +5,7 @@ import { mount, shallow } from 'enzyme'
 import { renderSecondary } from './Caption'
 import { Caption } from './index'
 
-it('Should have the proper text & attributes with link', () => {
+it('Should have the proper text & attributes with href link', () => {
   const caption = mount(
     <Caption
       href="https://blablacar.com"
@@ -21,6 +21,16 @@ it('Should have the proper text & attributes with link', () => {
   expect(caption.find('span')).toHaveLength(1)
   expect(caption.find('a')).toHaveLength(1)
   expect(caption.find('a').prop('href')).toBe('https://blablacar.com')
+})
+
+it('Should have the proper text & attributes with onClick link', () => {
+  const caption = mount(
+    <Caption onClick={jest.fn()} secondaryText="Go to blablacar" isoDate="2017-08-07T14:10:40.526Z">
+      08th August 2017
+    </Caption>,
+  )
+  expect(caption.find('button')).toHaveLength(1)
+  expect(caption.find('button').prop('onClick')).toEqual(expect.any(Function))
 })
 
 it('Should not have a datetime attribute', () => {

--- a/src/datePicker/__snapshots__/DatePicker.unit.tsx.snap
+++ b/src/datePicker/__snapshots__/DatePicker.unit.tsx.snap
@@ -108,6 +108,7 @@ exports[`DatePicker renderNavbar Should render the previous/next buttons in hori
   text-align: left;
   min-width: inherit;
   min-height: inherit;
+  height: auto;
 }
 
 .c0[disabled] {

--- a/src/hint/__snapshots__/Hint.unit.tsx.snap
+++ b/src/hint/__snapshots__/Hint.unit.tsx.snap
@@ -92,6 +92,7 @@ exports[`Hint Default rendering (above) 1`] = `
   text-align: left;
   min-width: inherit;
   min-height: inherit;
+  height: auto;
 }
 
 .c3[disabled] {
@@ -443,6 +444,7 @@ exports[`Hint Default rendering (below) 1`] = `
   text-align: left;
   min-width: inherit;
   min-height: inherit;
+  height: auto;
 }
 
 .c3[disabled] {

--- a/src/layout/section/mediaContentSection/__snapshots__/MediaContentSection.unit.tsx.snap
+++ b/src/layout/section/mediaContentSection/__snapshots__/MediaContentSection.unit.tsx.snap
@@ -72,6 +72,7 @@ exports[`MediaContentSection should render default MediaContentSection section 1
   text-align: left;
   min-width: inherit;
   min-height: inherit;
+  height: auto;
 }
 
 .c6[disabled] {
@@ -513,6 +514,7 @@ exports[`MediaContentSection should render flipped MediaContentSection section 1
   text-align: left;
   min-width: inherit;
   min-height: inherit;
+  height: auto;
 }
 
 .c6[disabled] {

--- a/src/modal/__snapshots__/Modal.unit.tsx.snap
+++ b/src/modal/__snapshots__/Modal.unit.tsx.snap
@@ -92,6 +92,7 @@ exports[`Modal should not have changed 1`] = `
   text-align: left;
   min-width: inherit;
   min-height: inherit;
+  height: auto;
 }
 
 .c2[disabled] {

--- a/src/phoneField/__snapshots__/PhoneField.unit.tsx.snap
+++ b/src/phoneField/__snapshots__/PhoneField.unit.tsx.snap
@@ -153,6 +153,7 @@ exports[`PhoneField should have the expected markup in the DOM with custom setti
   text-align: left;
   min-width: inherit;
   min-height: inherit;
+  height: auto;
 }
 
 .c4[disabled] {

--- a/src/review/Review.story.mdx
+++ b/src/review/Review.story.mdx
@@ -35,14 +35,26 @@ export const reviewProps = {
   </Story>
 </Preview>
 
-## With reply link
+## With href reply link
 
 <Preview>
   <Story name="withReplyLink">
     <Review
       {...reviewProps}
       replyLinkLabel="Reply to ratings"
-      replyLinkHref={<a href="/edit_ratings">edit_ratings</a>}
+      replyLinkHref={<a target="_blank" href="/reply_ratings">edit_ratings</a>}
+    />
+  </Story>
+</Preview>
+
+## With onClick reply link
+
+<Preview>
+  <Story name="withOnClickLink">
+    <Review
+      {...reviewProps}
+      replyLinkLabel="Reply to ratings"
+      replyLinkOnClick={() => { window.alert('Click!') }}
     />
   </Story>
 </Preview>

--- a/src/review/Review.tsx
+++ b/src/review/Review.tsx
@@ -15,6 +15,7 @@ export type ReviewProps = Readonly<{
   isoDatetime: string
   replyLinkLabel?: string
   replyLinkHref?: string | JSX.Element
+  replyLinkOnClick?: (event: React.MouseEvent<HTMLElement>) => void
 }>
 
 export const Review = (props: ReviewProps) => {
@@ -27,6 +28,7 @@ export const Review = (props: ReviewProps) => {
     isResponse = false,
     replyLinkLabel,
     replyLinkHref,
+    replyLinkOnClick,
   } = props
 
   // For responses, the title is not a rating but the name of the person replying.
@@ -45,10 +47,11 @@ export const Review = (props: ReviewProps) => {
       }
 
   const replyLinkProps =
-    replyLinkLabel && replyLinkHref
+    replyLinkLabel && (replyLinkHref || replyLinkOnClick)
       ? {
           secondaryText: replyLinkLabel,
           href: replyLinkHref,
+          onClick: replyLinkOnClick,
         }
       : {}
 

--- a/src/review/Review.unit.tsx
+++ b/src/review/Review.unit.tsx
@@ -39,12 +39,25 @@ it('Should render review response', () => {
   assertReview(review, 'Review title', 'Review content', '05 jul - 17:39', true)
 })
 
-it('Should render basic review', () => {
+it('Should render basic review with href link', () => {
   const review = mount(
     <Review
       {...defaultReviewProps}
       replyLinkLabel="Reply to this review"
       replyLinkHref="/edit_review"
+    />,
+  )
+  const replyReviewLink = review.find('.kirk-button')
+  expect(replyReviewLink.exists()).toBe(true)
+  expect(replyReviewLink.text()).toBe('Reply to this review')
+})
+
+it('Should render basic review with onClick link', () => {
+  const review = mount(
+    <Review
+      {...defaultReviewProps}
+      replyLinkLabel="Reply to this review"
+      replyLinkOnClick={() => {}}
     />,
   )
   const replyReviewLink = review.find('.kirk-button')

--- a/src/snackbar/__snapshots__/Snackbar.unit.tsx.snap
+++ b/src/snackbar/__snapshots__/Snackbar.unit.tsx.snap
@@ -92,6 +92,7 @@ exports[`Snackbar should not have changed 1`] = `
   text-align: left;
   min-width: inherit;
   min-height: inherit;
+  height: auto;
 }
 
 .c3[disabled] {


### PR DESCRIPTION
## Description

- **[NEW]** Add support for onClick handler for `Caption` link.
- **[NEW]** Add support for replyLinkOnClick handler for `Review` reply link.
- **[FIX]** Fix `Button` height when using an HTML unstyled button.

## TESTED

Locally in storybook + simple unit tests
