### PR TITLE
Remove DEFAULT position for SlideSection on small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [...]
 
+- **[UPDATE]** `SlideSection` behavior changed for small screens
+
 # v41.4.0 (19/10/2020)
 
 - **[NEW]** Add support for onClick handler for `Caption` link.

--- a/src/layout/section/slideSection/SlideSection.tsx
+++ b/src/layout/section/slideSection/SlideSection.tsx
@@ -5,6 +5,8 @@ import { Grip } from '../../../grip'
 import { GRIP_HANDLE_HEIGHT } from '../../../grip/GripHandle'
 import { StyledSlideLayout, StyledSlidePanel } from './SlideSection.style'
 
+const SMALL_SCREEN_BREAKPOINT = 450
+
 export enum SlideSectionPosition {
   DEFAULT = 'default',
   REDUCED = 'reduced',
@@ -33,10 +35,20 @@ export const SlideSection = (props: SlideSectionProps): JSX.Element => {
   const reducedContentRef = useRef(null)
   const layoutRef = useRef(null)
 
+  const isScreenTooSmall =
+    layoutRef.current && layoutRef.current.clientHeight <= SMALL_SCREEN_BREAKPOINT
+  useEffect(() => {
+    if (isScreenTooSmall && position === SlideSectionPosition.DEFAULT) {
+      setPosition(SlideSectionPosition.EXPANDED)
+    }
+  }, [position, isScreenTooSmall])
+
   const slideUp = useCallback(() => {
     if (position === SlideSectionPosition.DEFAULT) {
       setPosition(SlideSectionPosition.EXPANDED)
-    } else if (position === SlideSectionPosition.REDUCED) {
+    } else if (position === SlideSectionPosition.REDUCED && isScreenTooSmall) {
+      setPosition(SlideSectionPosition.EXPANDED)
+    } else if (position === SlideSectionPosition.REDUCED && !isScreenTooSmall) {
       setPosition(SlideSectionPosition.DEFAULT)
     }
     setFingerOffset(0)
@@ -45,7 +57,9 @@ export const SlideSection = (props: SlideSectionProps): JSX.Element => {
   const slideDown = useCallback(() => {
     if (position === SlideSectionPosition.DEFAULT) {
       setPosition(SlideSectionPosition.REDUCED)
-    } else if (position === SlideSectionPosition.EXPANDED) {
+    } else if (position === SlideSectionPosition.EXPANDED && isScreenTooSmall) {
+      setPosition(SlideSectionPosition.REDUCED)
+    } else if (position === SlideSectionPosition.EXPANDED && !isScreenTooSmall) {
       setPosition(SlideSectionPosition.DEFAULT)
     }
     setFingerOffset(0)
@@ -67,7 +81,8 @@ export const SlideSection = (props: SlideSectionProps): JSX.Element => {
   const [expandedHeight, setExpandedHeight] = useState<number>(0)
   useEffect(() => {
     // Reduced height is the height of reducedContent element + GripHandle height
-    const reducedContentHeight = reducedContentRef.current.clientHeight
+    // On small screen, we only show a 48px height element for touch control
+    const reducedContentHeight = isScreenTooSmall ? 16 : reducedContentRef.current.clientHeight
     setMinimalHeight(reducedContentHeight + GRIP_HANDLE_HEIGHT)
 
     // Default height is 50% of media height

--- a/src/layout/section/slideSection/SlideSection.tsx
+++ b/src/layout/section/slideSection/SlideSection.tsx
@@ -71,7 +71,15 @@ export const SlideSection = (props: SlideSectionProps): JSX.Element => {
   }, [])
 
   // Methods to manually set the panel position from other components
-  const setDefaultPosition = useRef(() => setPosition(SlideSectionPosition.DEFAULT))
+  const setDefaultPosition = useRef(() => {
+    if (isScreenTooSmall && position === SlideSectionPosition.EXPANDED) {
+      setPosition(SlideSectionPosition.REDUCED)
+    } else if (isScreenTooSmall && position === SlideSectionPosition.REDUCED) {
+      setPosition(SlideSectionPosition.EXPANDED)
+    } else {
+      setPosition(SlideSectionPosition.DEFAULT)
+    }
+  })
   const setReducedPosition = useRef(() => setPosition(SlideSectionPosition.REDUCED))
   const setExpandedPosition = useRef(() => setPosition(SlideSectionPosition.EXPANDED))
 
@@ -82,7 +90,9 @@ export const SlideSection = (props: SlideSectionProps): JSX.Element => {
   useEffect(() => {
     // Reduced height is the height of reducedContent element + GripHandle height
     // On small screen, we only show a 48px height element for touch control
-    const reducedContentHeight = isScreenTooSmall ? 16 : reducedContentRef.current.clientHeight
+    const reducedContentHeight = isScreenTooSmall
+      ? GRIP_HANDLE_HEIGHT
+      : reducedContentRef.current.clientHeight
     setMinimalHeight(reducedContentHeight + GRIP_HANDLE_HEIGHT)
 
     // Default height is 50% of media height


### PR DESCRIPTION
## Description

Small phone screens can't handle displaying both the map and the list, so we remove this layout position if the screen height is too small to handle it. The initial position will be with the list fully open by default for those screens, and you can only switch between this position, and the position where the media is fully shown. We also only show the GripHandle (with a small additional height for touch comfort) for the latter position.

## How it was tested

Locally on Chrome, Firefox and Safari iOS (main reference for screen size: iPhone SE)
