### PR TITLE
Add noHorizontalSpacing props on ItemsSection component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- **[UPDATE]** Add noHorizontalSpacing props on ItemsSection component
+- **[UPDATE]** Remove horizontal spacing on ItemsSection component
   [...]
 
 - **[FIX]** Fixed `ConnectionIcon` spacing on `Itinerary`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-[...]
+- **[UPDATE]** Add noHorizontalSpacing props on ItemsSection component
+  [...]
 
 - **[FIX]** Fixed `ConnectionIcon` spacing on `Itinerary`
 - **[UPDATE]** `SlideSection` behavior changed for small screens

--- a/src/layout/section/itemsSection/__snapshots__/index.unit.tsx.snap
+++ b/src/layout/section/itemsSection/__snapshots__/index.unit.tsx.snap
@@ -226,7 +226,7 @@ button:focus:not(.focus-visible).c2 {
   role="presentation"
 >
   <div
-    className="section-content kirk-items-section-content"
+    className="section-content kirk-items-section-content section-content--noHorizontalSpacing"
   >
     <div
       className="kirk-item c2"
@@ -494,7 +494,7 @@ button:focus:not(.focus-visible).c2 {
   role="presentation"
 >
   <div
-    className="section-content kirk-items-section-content"
+    className="section-content kirk-items-section-content section-content--noHorizontalSpacing"
   >
     <div
       className="kirk-item c2"

--- a/src/layout/section/itemsSection/itemsSection.tsx
+++ b/src/layout/section/itemsSection/itemsSection.tsx
@@ -6,6 +6,7 @@ import { BaseSection } from '../../../layout/section/baseSection'
 export type ItemsSectionProps = Readonly<{
   children: React.ReactElement<ItemInfoProps>[]
   className?: string
+  noHorizontalSpacing?: boolean
   tag?: JSX.Element
 }>
 
@@ -14,13 +15,14 @@ export type ItemsSectionProps = Readonly<{
  * Use with two items.
  */
 export const ItemsSection = (props: ItemsSectionProps) => {
-  const { className, children, tag = <div /> } = props
+  const { className, children, noHorizontalSpacing, tag = <div /> } = props
 
   return (
     <BaseSection
       tagName={tag.type}
       className={className}
       contentClassName="kirk-items-section-content"
+      noHorizontalSpacing={noHorizontalSpacing}
     >
       {children}
     </BaseSection>

--- a/src/layout/section/itemsSection/itemsSection.tsx
+++ b/src/layout/section/itemsSection/itemsSection.tsx
@@ -6,7 +6,6 @@ import { BaseSection } from '../../../layout/section/baseSection'
 export type ItemsSectionProps = Readonly<{
   children: React.ReactElement<ItemInfoProps>[]
   className?: string
-  noHorizontalSpacing?: boolean
   tag?: JSX.Element
 }>
 
@@ -15,14 +14,14 @@ export type ItemsSectionProps = Readonly<{
  * Use with two items.
  */
 export const ItemsSection = (props: ItemsSectionProps) => {
-  const { className, children, noHorizontalSpacing, tag = <div /> } = props
+  const { className, children, tag = <div /> } = props
 
   return (
     <BaseSection
       tagName={tag.type}
       className={className}
       contentClassName="kirk-items-section-content"
-      noHorizontalSpacing={noHorizontalSpacing}
+      noHorizontalSpacing
     >
       {children}
     </BaseSection>


### PR DESCRIPTION
## Description

Forward the noHorizontalSpacing props to the BaseSection to normalise the ItemsSection component.
![image](https://user-images.githubusercontent.com/2495124/96897974-76be6480-148f-11eb-821c-3f502b0f7d60.png)

## How it was tested

locally on storybook