### PR TITLE
Fixed spacing on Connection Icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 [...]
 
+- **[FIX]** Fixed `ConnectionIcon` spacing on `Itinerary`
 - **[UPDATE]** `SlideSection` behavior changed for small screens
 
 # v41.4.0 (19/10/2020)

--- a/src/_internals/itineraryLocation/ItineraryLocation.tsx
+++ b/src/_internals/itineraryLocation/ItineraryLocation.tsx
@@ -180,7 +180,7 @@ export const ItineraryLocation = ({
           {renderLabel(place.mainLabel, place.subLabel)}
           {displayConnection && (
             <div className="kirk-itineraryLocation-connection">
-              <ConnectionIcon />
+              <ConnectionIcon className="kirk-itineraryLocation-connectionIcon" />
               <TextCaption>{place.connectionLabel}</TextCaption>
             </div>
           )}

--- a/src/_internals/itineraryLocation/index.tsx
+++ b/src/_internals/itineraryLocation/index.tsx
@@ -71,6 +71,10 @@ const StyledItineraryLocation = styled(ItineraryLocation)`
     margin-right: ${space.s};
   }
 
+  & .kirk-itineraryLocation-connection .kirk-itineraryLocation-connectionIcon {
+    margin-right: ${space.s};
+  }
+
   & .kirk-itineraryLocation-label-text {
     text-overflow: ellipsis;
     overflow: hidden;


### PR DESCRIPTION
## Description

Fixed spacing on Connection Icon
Before | After
----|----
![image](https://user-images.githubusercontent.com/1606624/97439443-75c18300-1926-11eb-88b2-4cdedff9994f.png)|![image](https://user-images.githubusercontent.com/1606624/97439480-7f4aeb00-1926-11eb-81c3-921461c0fec1.png)

## What has been done

Added the missing margin from specs.

## Things to consider

Nothing.

## How it was tested

In storybook locally.
