### PR TITLE
Added new prop for handling stopover on Itinerary segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-[...]
+- **[UPDATE]** Added new prop `segmentCollapsedLabels` on `Itinerary` to show the correct number of stopovers per segment
 
 # v41.5.0 (29/10/2020)
 

--- a/src/itinerary/Itinerary.tsx
+++ b/src/itinerary/Itinerary.tsx
@@ -15,7 +15,7 @@ import { Text, TextDisplayType, TextTagType } from '../text'
 
 export type ItineraryProps = A11yProps &
   Readonly<{
-    places: Place[]
+    places?: Place[]
     className?: string
     fromAddon?: string
     toAddon?: string
@@ -26,6 +26,7 @@ export type ItineraryProps = A11yProps &
     highlightRoad?: boolean
     isCollapsible?: boolean
     collapsedLabel?: string
+    segmentCollapsedLabels?: Array<string>
     collapsedAriaProps?: A11yProps
     segments?: Array<Array<Place>>
   }>
@@ -154,7 +155,7 @@ const renderStopover = ({
 export const Itinerary = (props: ItineraryProps) => {
   const {
     className,
-    places,
+    places = [],
     fromAddon,
     toAddon,
     fromAddonAriaLabel,
@@ -166,6 +167,7 @@ export const Itinerary = (props: ItineraryProps) => {
     collapsedLabel,
     collapsedAriaProps,
     segments,
+    segmentCollapsedLabels,
   } = props
   const a11yAttrs = pickA11yProps<ItineraryProps>(props)
 
@@ -221,7 +223,7 @@ export const Itinerary = (props: ItineraryProps) => {
                 {renderStopover({
                   isCollapsible,
                   intermediatePlaces: segmentIntermediatePlaces,
-                  collapsedLabel,
+                  collapsedLabel: segmentCollapsedLabels[index],
                   collapsedAriaProps,
                   small,
                   withTime,

--- a/src/itinerary/Itinerary.unit.tsx
+++ b/src/itinerary/Itinerary.unit.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
+import { render, screen } from '@testing-library/react'
+
 import { ItineraryCollapsible } from '../_internals/itineraryCollapsible'
 import { ItineraryLocation } from '../_internals/itineraryLocation'
 import { Proximity } from '../proximity'
@@ -151,6 +153,28 @@ describe('Itinerary component', () => {
 
       const itinerary = shallow(<Itinerary places={placesWithMultipleStopover} isCollapsible />)
       expect(itinerary.find(ItineraryCollapsible).exists()).toBe(true)
+    })
+
+    it('should render ItineraryCollapsible when more than 1 stopover', () => {
+      const placesWithMultipleStopover = [
+        ...places,
+        {
+          time: '12:00',
+          isoDate: '2017-12-11T12:00',
+          stepAriaLabel: 'Pick up/drop off location',
+          mainLabel: 'Tours',
+        },
+      ]
+
+      render(
+        <Itinerary
+          segments={[placesWithMultipleStopover, placesWithMultipleStopover]}
+          segmentCollapsedLabels={['2 stops', '3 stops']}
+          isCollapsible
+        />,
+      )
+      expect(screen.getByText('2 stops')).toBeInTheDocument()
+      expect(screen.getByText('3 stops')).toBeInTheDocument()
     })
   })
 })

--- a/src/itinerary/story.tsx
+++ b/src/itinerary/story.tsx
@@ -20,6 +20,20 @@ const places = [
     href: '#',
   },
   {
+    time: '10:00',
+    isoDate: '2017-12-11T10:00',
+    stepAriaLabel: 'Stopover',
+    mainLabel: 'Poitiers',
+    subLabel: 'Poitiers',
+  },
+  {
+    time: '11:00',
+    isoDate: '2017-12-11T10:00',
+    stepAriaLabel: 'Stopover',
+    mainLabel: 'Angouleme',
+    subLabel: 'Angouleme',
+  },
+  {
     time: '15:00',
     isoDate: '2017-12-11T15:00',
     stepAriaLabel: 'Dropoff location',
@@ -42,8 +56,29 @@ const places2 = [
     time: '16:00',
     isoDate: '2017-12-11T12:00',
     stepAriaLabel: 'Stopover',
-    mainLabel: "Gare d'Agen",
-    subLabel: 'Agen',
+    mainLabel: 'Agen',
+    subLabel: "Gare d'Agen",
+  },
+  {
+    time: '16:00',
+    isoDate: '2017-12-11T12:00',
+    stepAriaLabel: 'Stopover',
+    mainLabel: 'Agen',
+    subLabel: "Hotel de ville d'Agen",
+  },
+  {
+    time: '17:00',
+    isoDate: '2017-12-11T12:00',
+    stepAriaLabel: 'Stopover',
+    mainLabel: 'Langon',
+    subLabel: 'Langon Hotel de ville',
+  },
+  {
+    time: '16:00',
+    isoDate: '2017-12-11T12:00',
+    stepAriaLabel: 'Stopover',
+    mainLabel: 'Langon',
+    subLabel: 'Gare de Langon',
   },
   {
     time: '19:00',
@@ -251,6 +286,7 @@ stories.add('with segments and stopovers', () => {
         toAddon={toAddon}
         toAddonAriaLabel={toAddonLabel}
         places={[]}
+        segmentCollapsedLabels={['2 stops', '4 stops']}
         segments={[places, places2]}
         small={boolean('small', false)}
         headline={headline}


### PR DESCRIPTION
## Description

- Added new prop `segmentCollapsedLabel` so that we can display the correct number of stopover

See an example of usage here: https://github.com/blablacar/kairos/pull/4368/files

## Things to consider

I went for the easiest solution without having to change the whole `Itinerary` component. 
We plan to do a bigger refacto to handle segments better in `Itinerary` I should be able to work on that next week.
 
## How it was tested

In SPA through a canary version
