### PR TITLE
Normalized Hint

### DIFF
--- a/src/hint/Hint.story.mdx
+++ b/src/hint/Hint.story.mdx
@@ -12,7 +12,7 @@ import { Hint } from './index'
 
 <Preview>
   <Story name="Default">
-    <BaseSection>
+    <BaseSection noHorizontalSpacing>
       <ItemsList>
         <ItemChoice label="Itinerary, date and time" href="#" />
         <ItemChoice label="Seats and options" href="#" />
@@ -50,7 +50,6 @@ Use it to show the member there’s a new action they can take on this page. Onl
 
 ```jsx
 import { Hint } from '@blablacar/ui-library/build/Hint'
-
 ;<Hint
   title="New settings"
   description="Take more control of your ride!"

--- a/src/hint/HintBubble.tsx
+++ b/src/hint/HintBubble.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import cc from 'classcat'
 import styled from 'styled-components'
 
-import { color, fontWeight, radius, shadow, space } from '../_utils/branding'
+import { color, fontWeight, horizontalSpace, radius, shadow, space } from '../_utils/branding'
 import { A11yProps, pickA11yProps } from '../_utils/interfaces'
 import { Button, ButtonStatus } from '../button'
 import { CrossIcon } from '../icon/crossIcon'
@@ -55,6 +55,9 @@ const StyledHintBubble = styled(HintBubble)`
     color: ${color.white};
     border-radius: ${radius.l};
     box-shadow: ${shadow.icon};
+    /* Normalization */
+    margin-left: ${horizontalSpace.global};
+    margin-right: ${horizontalSpace.global};
   }
 
   & strong {

--- a/src/hint/__snapshots__/Hint.unit.tsx.snap
+++ b/src/hint/__snapshots__/Hint.unit.tsx.snap
@@ -218,6 +218,8 @@ exports[`Hint Default rendering (above) 1`] = `
   color: #FFF;
   border-radius: 16px;
   box-shadow: 0 0 2px rgba(0,0,0,.3);
+  margin-left: 24px;
+  margin-right: 24px;
 }
 
 .c2 strong {
@@ -570,6 +572,8 @@ exports[`Hint Default rendering (below) 1`] = `
   color: #FFF;
   border-radius: 16px;
   box-shadow: 0 0 2px rgba(0,0,0,.3);
+  margin-left: 24px;
+  margin-right: 24px;
 }
 
 .c2 strong {


### PR DESCRIPTION
## Description

Normalized `Hint`
![image](https://user-images.githubusercontent.com/1606624/98144349-99f30600-1eca-11eb-8b89-4b3ca1b07671.png)


## What has been done

Added missing horizontal margin on Hint component so that it has the correct outer spacing. 
Padding was already correct.

## Things to consider

I couldn't use the `normalizeHorizontally` because it's only handling 2 cases: 
1. Components like Items that we can stack
2. Components like TripCard that will contain other components

This `Hint` component is a third case where the padding should be 16px (as stackable component) but also needs 24px margin.
 
## How it was tested

Locally in storybook.