### PR TITLE
Removed cursor: not-allowed from UneditableTextField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- **[FIX]** Removed `cursor: not-allowed` from `UneditableTextField`
+
 # v41.6.2 (06/11/2020)
 
 - **[UPDATE]** Migrate [all stories](https://github.com/blablacar/ui-library/milestones) to MDX (PR #938)

--- a/src/searchRecap/__snapshots__/SearchRecap.unit.tsx.snap
+++ b/src/searchRecap/__snapshots__/SearchRecap.unit.tsx.snap
@@ -119,7 +119,6 @@ exports[`SearchRecap Should display searchRecap component 1`] = `
   line-height: 54px;
   -webkit-text-decoration: none;
   text-decoration: none;
-  cursor: not-allowed;
 }
 
 .c1 .kirk-uneditableTextField-label:not(:first-child) {

--- a/src/uneditableTextField/UneditableTextField.style.tsx
+++ b/src/uneditableTextField/UneditableTextField.style.tsx
@@ -16,7 +16,6 @@ export const StyledUneditableTextField = styled.div`
     font-size: ${font.base.size};
     line-height: ${inputHeight};
     text-decoration: none;
-    cursor: not-allowed;
   }
 
   & .kirk-uneditableTextField-label:not(:first-child) {


### PR DESCRIPTION
## Description

Removed `cursor: not-allowed` from `UneditableTextField`

## How it was tested

Storybook
