### PR TITLE
Release/v41.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+[...]
+
+# v41.6.3 (09/11/2020)
+
 - **[FIX]** Removed `cursor: not-allowed` from `UneditableTextField`
 
 # v41.6.2 (06/11/2020)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "41.6.2",
+  "version": "41.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "41.6.2",
+  "version": "41.6.3",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Description

- **[FIX]** Removed `cursor: not-allowed` from `UneditableTextField`
