### PR TITLE
Add media size hooks and test set-up helper prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
 
+- **[UPDATE]** New hooks for `MediaSizeProvider` and add a `mediaSizeForTestsOnly` override for test setup.
 - **[FIX]** Make `OnChangeParameters` part of the public API.
-  [...]
+[...]
 
 # v41.6.3 (09/11/2020)
 

--- a/src/_utils/mediaSizeProvider/index.tsx
+++ b/src/_utils/mediaSizeProvider/index.tsx
@@ -10,14 +10,26 @@ export enum MediaSize {
 
 export type MediaSizeProviderProps = Readonly<{
   children: ReactNode
+  mediaSizeForTestsOnly?: MediaSize
 }>
 
-export const MediaSizeContext = React.createContext(MediaSize.SMALL)
+const DEFAULT_MEDIA_SIZE = MediaSize.SMALL
+export const MediaSizeContext = React.createContext(DEFAULT_MEDIA_SIZE)
 
 const DEBOUNCE_VALUE = 500
 
-export const MediaSizeProvider = ({ children }: MediaSizeProviderProps) => {
-  const [mediaSize, setMediaSize] = useState(MediaSize.SMALL)
+export const useIsSmallMediaSize = (): boolean => {
+  const mediaSize = React.useContext(MediaSizeContext)
+  return mediaSize === MediaSize.SMALL
+}
+
+export const useIsLargeMediaSize = (): boolean => {
+  const mediaSize = React.useContext(MediaSizeContext)
+  return mediaSize === MediaSize.LARGE
+}
+
+export const MediaSizeProvider = ({ children, mediaSizeForTestsOnly }: MediaSizeProviderProps) => {
+  const [mediaSize, setMediaSize] = useState(DEFAULT_MEDIA_SIZE)
 
   const handleResize = () => {
     const isSmall = window.innerWidth <= parseInt(responsiveBreakpoints.small, 10)
@@ -29,6 +41,14 @@ export const MediaSizeProvider = ({ children }: MediaSizeProviderProps) => {
     window.addEventListener('resize', debounce(handleResize, DEBOUNCE_VALUE))
     return () => window.removeEventListener('resize', handleResize)
   }, [])
+
+  if (mediaSizeForTestsOnly) {
+    return (
+      <MediaSizeContext.Provider value={mediaSizeForTestsOnly}>
+        {children}
+      </MediaSizeContext.Provider>
+    )
+  }
 
   return <MediaSizeContext.Provider value={mediaSize}>{children}</MediaSizeContext.Provider>
 }

--- a/src/_utils/mediaSizeProvider/index.unit.tsx
+++ b/src/_utils/mediaSizeProvider/index.unit.tsx
@@ -1,9 +1,15 @@
 import React, { useContext } from 'react'
 import { mount } from 'enzyme'
 
-import { MediaSizeContext, MediaSizeProvider } from './index'
+import {
+  MediaSize,
+  MediaSizeContext,
+  MediaSizeProvider,
+  useIsLargeMediaSize,
+  useIsSmallMediaSize,
+} from './index'
 
-const mockWindowInnerWidth = value => {
+const mockWindowInnerWidth = (value: number): void => {
   Object.defineProperty(window, 'innerWidth', {
     writable: true,
     configurable: true,
@@ -11,12 +17,19 @@ const mockWindowInnerWidth = value => {
   })
 }
 
-let ChildComponent
 describe('MediaSizeProvider', () => {
+  let ChildComponent: any
+
   beforeEach(() => {
     ChildComponent = () => {
-      const value = useContext(MediaSizeContext)
-      return <div>{value}</div>
+      const valueFromContext = useContext(MediaSizeContext)
+      const isSmall = useIsSmallMediaSize().toString()
+      const isLarge = useIsLargeMediaSize().toString()
+      return (
+        <div>
+          context: {valueFromContext} | isSmall: {isSmall} | isLarge: {isLarge}
+        </div>
+      )
     }
   })
   it('Should provide "small" value when screen is under `responsiveBreakpoints.small`', () => {
@@ -27,7 +40,8 @@ describe('MediaSizeProvider', () => {
       </MediaSizeProvider>,
     )
 
-    expect(wrapper.find('div').text()).toEqual('small')
+    const expected = 'context: small | isSmall: true | isLarge: false'
+    expect(wrapper.find('div').text()).toEqual(expected)
   })
 
   it('Should provide "large" value when screen is above `responsiveBreakpoints.small`', () => {
@@ -38,6 +52,27 @@ describe('MediaSizeProvider', () => {
       </MediaSizeProvider>,
     )
 
-    expect(wrapper.find('div').text()).toEqual('large')
+    const expected = 'context: large | isSmall: false | isLarge: true'
+    expect(wrapper.find('div').text()).toEqual(expected)
+  })
+
+  it('Should provide "small" when no provider', () => {
+    mockWindowInnerWidth(900)
+    const wrapper = mount(<ChildComponent />)
+
+    const expected = 'context: small | isSmall: true | isLarge: false'
+    expect(wrapper.find('div').text()).toEqual(expected)
+  })
+
+  it('Should respect the mediaSizeForTestsOnly override`', () => {
+    mockWindowInnerWidth(300)
+    const wrapper = mount(
+      <MediaSizeProvider mediaSizeForTestsOnly={MediaSize.LARGE}>
+        <ChildComponent />
+      </MediaSizeProvider>,
+    )
+
+    const expected = 'context: large | isSmall: false | isLarge: true'
+    expect(wrapper.find('div').text()).toEqual(expected)
   })
 })


### PR DESCRIPTION
## Description

- Add new useIsSmallMediaSize and useIsLargeMediaSize custom hooks
- Add new mediaSizeForTestsOnly to set up the MediaSizeProvider in tests

## TESTED

Unit tests
