### PR TITLE
Release/41.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Unreleased
 
+- [...]
+
+# v41.7.0 (16/11/2020)
+
 - **[UPDATE]** New hooks for `MediaSizeProvider` and add a `mediaSizeForTestsOnly` override for test setup.
 - **[FIX]** Make `OnChangeParameters` part of the public API.
 - **[NEW]** Add `SupportIcon`
-
 
 # v41.6.3 (09/11/2020)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "41.6.3",
+  "version": "41.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "41.6.3",
+  "version": "41.7.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# v41.7.0 (16/11/2020)

- **[UPDATE]** New hooks for `MediaSizeProvider` and add a `mediaSizeForTestsOnly` override for test setup.
- **[FIX]** Make `OnChangeParameters` part of the public API.
- **[NEW]** Add `SupportIcon`