### PR TITLE
Releases/41.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Unreleased
 
-- **[UPDATE]** Horizontal (and vertical) normalization for `ButtonGroup`
 - [...]
+
+# v41.7.1 (17/11/2020)
+
+- **[UPDATE]** Horizontal (and vertical) normalization for `ButtonGroup`
 
 # v41.7.0 (16/11/2020)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "41.7.0",
+  "version": "41.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "41.7.0",
+  "version": "41.7.1",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# v41.7.1 (17/11/2020)

- **[UPDATE]** Horizontal (and vertical) normalization for `ButtonGroup`