### PR TITLE
[BBC-11002] (chore): fix build warnings

### DIFF
--- a/src/_internals/itineraryCollapsible/index.tsx
+++ b/src/_internals/itineraryCollapsible/index.tsx
@@ -94,6 +94,6 @@ const StyledItineraryCollapsible = styled(ItineraryCollapsible)`
     padding: 0;
   }
 `
-export { ItineraryCollapsibleProps } from './ItineraryCollapsible'
+export type ItineraryCollapsibleProps = ItineraryCollapsibleProps
 export { StyledItineraryCollapsible as ItineraryCollapsible }
 export default StyledItineraryCollapsible

--- a/src/_internals/itineraryLocation/index.tsx
+++ b/src/_internals/itineraryLocation/index.tsx
@@ -101,6 +101,7 @@ const StyledItineraryLocation = styled(ItineraryLocation)`
   }
 `
 
-export { ItineraryLocationProps, computeKeyFromPlace } from './ItineraryLocation'
+export { computeKeyFromPlace } from './ItineraryLocation'
+export type ItineraryLocationProps = ItineraryLocationProps
 export { StyledItineraryLocation as ItineraryLocation }
 export default StyledItineraryLocation

--- a/src/_utils/rideAxis/index.tsx
+++ b/src/_utils/rideAxis/index.tsx
@@ -1,2 +1,3 @@
-export { RideAxis, RideAxisProps } from './RideAxis'
+export { RideAxis } from './RideAxis'
+export type RideAxisProps = RideAxisProps
 export { RideAxis as default } from './RideAxis'

--- a/src/autoComplete/AutoComplete.tsx
+++ b/src/autoComplete/AutoComplete.tsx
@@ -12,11 +12,9 @@ import { ItemInfo } from '../itemInfo'
 import { Loader } from '../loader'
 import { inputTypes, TextField } from '../textField'
 import { StyledAutoComplete } from './AutoComplete.style'
-import { AutocompleteItem, AutoCompleteList } from './AutoCompleteListStyle'
+import { AutoCompleteList } from './AutoCompleteListStyle'
 
 type query = string | number | boolean
-
-export { AutocompleteItem }
 
 export interface AutocompleteOnChange {
   readonly name: string

--- a/src/autoComplete/index.tsx
+++ b/src/autoComplete/index.tsx
@@ -1,7 +1,5 @@
-export {
-  AutoComplete,
-  AutoCompleteProps,
-  AutocompleteOnChange,
-  AutocompleteItem,
-} from './AutoComplete'
+export { AutoComplete } from './AutoComplete'
+export type AutoCompleteProps = AutoCompleteProps
+export type AutocompleteOnChange = AutocompleteOnChange
+export type AutocompleteItem = AutocompleteItem
 export { AutoComplete as default } from './AutoComplete'

--- a/src/avatar/index.tsx
+++ b/src/avatar/index.tsx
@@ -1,2 +1,3 @@
-export { Avatar, AvatarProps } from './Avatar'
+export { Avatar } from './Avatar'
+export type AvatarProps = AvatarProps
 export { Avatar as default } from './Avatar'

--- a/src/badge/index.tsx
+++ b/src/badge/index.tsx
@@ -1,2 +1,3 @@
-export { Badge, BadgeProps } from './Badge'
+export { Badge } from './Badge'
+export type BadgeProps = BadgeProps
 export { Badge as default } from './Badge'

--- a/src/breadcrumb/index.tsx
+++ b/src/breadcrumb/index.tsx
@@ -1,2 +1,4 @@
-export { Breadcrumb, BreadcrumbProps, CrumbProps } from './Breadcrumb'
+export { Breadcrumb } from './Breadcrumb'
+export type BreadcrumbProps = BreadcrumbProps
+export type CrumbProps = CrumbProps
 export { Breadcrumb as default } from './Breadcrumb'

--- a/src/bullet/index.tsx
+++ b/src/bullet/index.tsx
@@ -1,2 +1,3 @@
-export { Bullet, BulletProps, BulletTypes } from './Bullet'
+export { Bullet, BulletTypes } from './Bullet'
+export type BulletProps = BulletProps
 export { Bullet as default } from './Bullet'

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -1,6 +1,7 @@
 // Note: can't use styled components the same way we do for all other components,
 // as buttons are created dynamically with React.createElement (and can be a "a", "button" or
 // even every other React component => SlugLink for instance).
-export { ButtonStatus, ButtonProps } from './Button'
+export { ButtonStatus } from './Button'
+export type ButtonProps = ButtonProps
 export { StyledButton as Button } from './Button.style'
 export { StyledButton as default } from './Button.style'

--- a/src/buttonGroup/index.tsx
+++ b/src/buttonGroup/index.tsx
@@ -1,2 +1,3 @@
-export { ButtonGroup, ButtonGroupProps } from './ButtonGroup'
+export { ButtonGroup } from './ButtonGroup'
+export type ButtonGroupProps = ButtonGroupProps
 export { ButtonGroup as default } from './ButtonGroup'

--- a/src/caption/index.tsx
+++ b/src/caption/index.tsx
@@ -1,2 +1,3 @@
-export { Caption, CaptionProps } from './Caption'
+export { Caption } from './Caption'
+export type CaptionProps = CaptionProps
 export { Caption as default } from './Caption'

--- a/src/confirmationModal/index.tsx
+++ b/src/confirmationModal/index.tsx
@@ -1,6 +1,3 @@
-export {
-  ConfirmationModal,
-  ConfirmationModalProps,
-  ConfirmationModalStatus,
-} from './ConfirmationModal'
+export { ConfirmationModal, ConfirmationModalStatus } from './ConfirmationModal'
+export type ConfirmationModalProps = ConfirmationModalProps
 export { ConfirmationModal as default } from './ConfirmationModal'

--- a/src/datePicker/index.tsx
+++ b/src/datePicker/index.tsx
@@ -1,2 +1,3 @@
-export { DatePicker, DatePickerProps, DatePickerOrientation } from './DatePicker'
+export { DatePicker, DatePickerOrientation } from './DatePicker'
+export type DatePickerProps = DatePickerProps
 export { DatePicker as default } from './DatePicker'

--- a/src/disclaimer/index.tsx
+++ b/src/disclaimer/index.tsx
@@ -1,2 +1,3 @@
-export { Disclaimer, DisclaimerProps } from './Disclaimer'
+export { Disclaimer } from './Disclaimer'
+export type DisclaimerProps = DisclaimerProps
 export { Disclaimer as default } from './Disclaimer'

--- a/src/divider/spacingDivider/index.tsx
+++ b/src/divider/spacingDivider/index.tsx
@@ -1,1 +1,3 @@
-export { SpacingDivider, SpacingDividerProps, SpacingDividerSize } from './SpacingDivider'
+export { SpacingDivider, SpacingDividerSize } from './SpacingDivider'
+
+export type SpacingDividerProps = SpacingDividerProps

--- a/src/drawer/index.tsx
+++ b/src/drawer/index.tsx
@@ -1,2 +1,3 @@
-export { Drawer, DrawerProps } from './Drawer'
+export { Drawer } from './Drawer'
+export type DrawerProps = DrawerProps
 export { Drawer as default } from './Drawer'

--- a/src/dropdownButton/index.tsx
+++ b/src/dropdownButton/index.tsx
@@ -1,2 +1,3 @@
-export { DropdownButton, DropdownButtonProps } from './DropdownButton'
+export { DropdownButton } from './DropdownButton'
+export type DropdownButtonProps = DropdownButtonProps
 export { DropdownButton as default } from './DropdownButton'

--- a/src/emptyState/index.tsx
+++ b/src/emptyState/index.tsx
@@ -1,2 +1,3 @@
-export { EmptyState, EmptyStateProps } from './EmptyState'
+export { EmptyState } from './EmptyState'
+export type EmptyStateProps = EmptyStateProps
 export { EmptyState as default } from './EmptyState'

--- a/src/filterBar/index.tsx
+++ b/src/filterBar/index.tsx
@@ -1,2 +1,3 @@
-export { FilterBar, FilterBarProps } from './FilterBar'
+export { FilterBar } from './FilterBar'
+export type FilterBarProps = FilterBarProps
 export { FilterBar as default } from './FilterBar'

--- a/src/grip/index.tsx
+++ b/src/grip/index.tsx
@@ -1,1 +1,2 @@
-export { GripProps, Grip } from './Grip'
+export { Grip } from './Grip'
+export type GripProps = GripProps

--- a/src/hamburgerButton/index.tsx
+++ b/src/hamburgerButton/index.tsx
@@ -1,2 +1,3 @@
-export { HamburgerButton, HamburgerButtonProps } from './HamburgerButton'
+export { HamburgerButton } from './HamburgerButton'
+export type HamburgerButtonProps = HamburgerButtonProps
 export { HamburgerButton as default } from './HamburgerButton'

--- a/src/hint/index.ts
+++ b/src/hint/index.ts
@@ -1,3 +1,4 @@
-export { Hint, HintProps } from './Hint'
+export { Hint } from './Hint'
+export type HintProps = HintProps
 export { HintBubblePosition } from './HintBubble'
 export { Hint as default } from './Hint'

--- a/src/itemAction/index.tsx
+++ b/src/itemAction/index.tsx
@@ -1,2 +1,3 @@
-export { ItemAction, ItemActionProps } from './ItemAction'
+export { ItemAction } from './ItemAction'
+export type ItemActionProps = ItemActionProps
 export { ItemAction as default } from './ItemAction'

--- a/src/itemBigData/index.tsx
+++ b/src/itemBigData/index.tsx
@@ -1,2 +1,3 @@
-export { ItemBigData, ItemBigDataProps } from './ItemBigData'
+export { ItemBigData } from './ItemBigData'
+export type ItemBigDataProps = ItemBigDataProps
 export { ItemBigData as default } from './ItemBigData'

--- a/src/itemCheckbox/index.tsx
+++ b/src/itemCheckbox/index.tsx
@@ -1,2 +1,3 @@
-export { ItemCheckbox, ItemCheckboxProps, ItemCheckboxStatus } from './ItemCheckbox'
+export { ItemCheckbox, ItemCheckboxStatus } from './ItemCheckbox'
+export type ItemCheckboxProps = ItemCheckboxProps
 export { ItemCheckbox as default } from './ItemCheckbox'

--- a/src/itemChoice/index.tsx
+++ b/src/itemChoice/index.tsx
@@ -1,2 +1,3 @@
-export { ItemChoice, ItemChoiceProps, ItemChoiceStatus, ItemChoiceStyle } from './ItemChoice'
+export { ItemChoice, ItemChoiceStatus, ItemChoiceStyle } from './ItemChoice'
+export type ItemChoiceProps = ItemChoiceProps
 export { ItemChoice as default } from './ItemChoice'

--- a/src/itemData/index.tsx
+++ b/src/itemData/index.tsx
@@ -1,2 +1,3 @@
-export { ItemData, ItemDataProps } from './ItemData'
+export { ItemData } from './ItemData'
+export type ItemDataProps = ItemDataProps
 export { ItemData as default } from './ItemData'

--- a/src/itemEditableInfo/index.tsx
+++ b/src/itemEditableInfo/index.tsx
@@ -1,2 +1,3 @@
-export { ItemEditableInfo, ItemEditableInfoProps } from './itemEditableInfo'
-export { ItemEditableInfo as default } from './itemEditableInfo'
+export { ItemEditableInfo } from './ItemEditableInfo'
+export type ItemEditableInfoProps = ItemEditableInfoProps
+export { ItemEditableInfo as default } from './ItemEditableInfo'

--- a/src/itemInfo/index.tsx
+++ b/src/itemInfo/index.tsx
@@ -1,2 +1,3 @@
-export { ItemInfo, ItemInfoProps } from './ItemInfo'
+export { ItemInfo } from './ItemInfo'
+export type ItemInfoProps = ItemInfoProps
 export { ItemInfo as default } from './ItemInfo'

--- a/src/itemRadio/index.tsx
+++ b/src/itemRadio/index.tsx
@@ -1,2 +1,3 @@
-export { ItemRadio, ItemRadioProps, ItemRadioStatus } from './ItemRadio'
+export { ItemRadio, ItemRadioStatus } from './ItemRadio'
+export type ItemRadioProps = ItemRadioProps
 export { ItemRadio as default } from './ItemRadio'

--- a/src/itemsList/index.ts
+++ b/src/itemsList/index.ts
@@ -1,2 +1,4 @@
-export { ItemsList, ItemsListProps, ItemsListDivider, ItemsListChild } from './ItemsList'
+export { ItemsList, ItemsListDivider } from './ItemsList'
+export type ItemsListProps = ItemsListProps
+export type ItemsListChild = ItemsListChild
 export { ItemsList as default } from './ItemsList'

--- a/src/itinerary/Itinerary.style.tsx
+++ b/src/itinerary/Itinerary.style.tsx
@@ -109,6 +109,6 @@ export const StyledItinerary = styled.div`
   }
 `
 
-export { ItineraryProps } from './Itinerary'
+export type ItineraryProps = ItineraryProps
 export { StyledItinerary as Itinerary }
 export default StyledItinerary

--- a/src/itinerary/index.tsx
+++ b/src/itinerary/index.tsx
@@ -1,2 +1,3 @@
-export { Itinerary, ItineraryProps } from './Itinerary'
+export { Itinerary } from './Itinerary'
+export type ItineraryProps = ItineraryProps
 export { Itinerary as default } from './Itinerary'

--- a/src/layout/column/index.tsx
+++ b/src/layout/column/index.tsx
@@ -11,6 +11,6 @@ const StyledColumn = styled(Column)`
   }
 `
 
-export { ColumnProps } from './column'
+export type ColumnProps = ColumnProps
 export { StyledColumn as Column }
 export default StyledColumn

--- a/src/layout/columns/index.tsx
+++ b/src/layout/columns/index.tsx
@@ -21,6 +21,6 @@ const StyledColumns = styled(Columns)`
   }
 `
 
-export { ColumnsProps } from './columns'
+export type ColumnsProps = ColumnsProps
 export { StyledColumns as Columns }
 export default StyledColumns

--- a/src/layout/content/index.tsx
+++ b/src/layout/content/index.tsx
@@ -1,5 +1,5 @@
-import { MainContentProps } from './Content'
 import { BottomContent, Content, StyledMainContent } from './Content.style'
 
-export { StyledMainContent as MainContent, BottomContent, Content, MainContentProps }
+export { StyledMainContent as MainContent, BottomContent, Content }
+export type MainContentProps = MainContentProps
 export default StyledMainContent

--- a/src/layout/section/baseSection/index.tsx
+++ b/src/layout/section/baseSection/index.tsx
@@ -1,2 +1,4 @@
-export { BaseSection, BaseSectionProps, SectionContentSize } from './BaseSection'
+export { BaseSection, SectionContentSize } from './BaseSection'
+export type BaseSectionProps = BaseSectionProps
+
 export { BaseSection as default } from './BaseSection'

--- a/src/layout/section/cardsSection/index.tsx
+++ b/src/layout/section/cardsSection/index.tsx
@@ -1,2 +1,3 @@
-export { CardsSection, CardsSectionProps } from './CardsSection'
+export { CardsSection } from './CardsSection'
+export type CardsSectionProps = CardsSectionProps
 export { CardsSection as default } from './CardsSection'

--- a/src/layout/section/columnedContentSection/index.tsx
+++ b/src/layout/section/columnedContentSection/index.tsx
@@ -1,6 +1,4 @@
-export {
-  ColumnedContentSection,
-  ColumnedContentSectionProps,
-  ColumnedSectionContentMediaKind,
-} from './ColumnedContentSection'
+export { ColumnedContentSection, ColumnedSectionContentMediaKind } from './ColumnedContentSection'
+
+export type ColumnedContentSectionProps = ColumnedContentSectionProps
 export { ColumnedContentSection as default } from './ColumnedContentSection'

--- a/src/layout/section/heroSection/index.tsx
+++ b/src/layout/section/heroSection/index.tsx
@@ -1,2 +1,3 @@
-export { HeroSection, HeroSectionProps } from './HeroSection'
+export { HeroSection } from './HeroSection'
+export type HeroSectionProps = HeroSectionProps
 export { HeroSection as default } from './HeroSection'

--- a/src/layout/section/highlightSection/index.tsx
+++ b/src/layout/section/highlightSection/index.tsx
@@ -1,2 +1,3 @@
-export { HighlightSection, HighlightSectionProps } from './HighlightSection'
+export { HighlightSection } from './HighlightSection'
+export type HighlightSectionProps = HighlightSectionProps
 export { HighlightSection as default } from './HighlightSection'

--- a/src/layout/section/illustratedSection/index.tsx
+++ b/src/layout/section/illustratedSection/index.tsx
@@ -1,2 +1,3 @@
-export { IllustratedSection, IllustratedSectionProps } from './IllustratedSection'
+export { IllustratedSection } from './IllustratedSection'
+export type IllustratedSectionProps = IllustratedSectionProps
 export { IllustratedSection as default } from './IllustratedSection'

--- a/src/layout/section/itemsSection/index.tsx
+++ b/src/layout/section/itemsSection/index.tsx
@@ -1,2 +1,3 @@
-export { ItemsSection, ItemsSectionProps } from './ItemsSection'
+export { ItemsSection } from './ItemsSection'
+export type ItemsSectionProps = ItemsSectionProps
 export { ItemsSection as default } from './ItemsSection'

--- a/src/layout/section/mediaContentSection/index.tsx
+++ b/src/layout/section/mediaContentSection/index.tsx
@@ -1,2 +1,3 @@
-export { MediaContentSection, MediaContentSectionProps } from './MediaContentSection'
+export { MediaContentSection } from './MediaContentSection'
+export type MediaContentSectionProps = MediaContentSectionProps
 export { MediaContentSection as default } from './MediaContentSection'

--- a/src/layout/section/mediaSection/index.tsx
+++ b/src/layout/section/mediaSection/index.tsx
@@ -1,2 +1,3 @@
-export { MediaSection, MediaSectionProps } from './MediaSection'
+export { MediaSection } from './MediaSection'
+export type MediaSectionProps = MediaSectionProps
 export { MediaSection as default } from './MediaSection'

--- a/src/layout/section/slideSection/index.ts
+++ b/src/layout/section/slideSection/index.ts
@@ -1,1 +1,2 @@
-export { SlideSectionProps, SlideSectionPosition, SlideSection } from './SlideSection'
+export { SlideSectionPosition, SlideSection } from './SlideSection'
+export type SlideSectionProps = SlideSectionProps

--- a/src/layout/section/tabsSection/index.tsx
+++ b/src/layout/section/tabsSection/index.tsx
@@ -1,2 +1,3 @@
-export { TabsSection, TabsSectionProps } from './TabsSection'
+export { TabsSection } from './TabsSection'
+export type TabsSectionProps = TabsSectionProps
 export { TabsSection as default } from './TabsSection'

--- a/src/layout/section/textFieldsSection/index.tsx
+++ b/src/layout/section/textFieldsSection/index.tsx
@@ -1,2 +1,3 @@
-export { TextFieldsSection, TextFieldsSectionProps } from './TextFieldsSection'
+export { TextFieldsSection } from './TextFieldsSection'
+export type TextFieldsSectionProps = TextFieldsSectionProps
 export { TextFieldsSection as default } from './TextFieldsSection'

--- a/src/loader/index.tsx
+++ b/src/loader/index.tsx
@@ -1,2 +1,3 @@
-export { Loader, LoaderProps, LoaderLayoutMode } from './Loader'
+export { Loader, LoaderLayoutMode } from './Loader'
+export type LoaderProps = LoaderProps
 export { Loader as default } from './Loader'

--- a/src/loadingPage/index.tsx
+++ b/src/loadingPage/index.tsx
@@ -1,2 +1,3 @@
-export { LoadingPage, LoadingPageProps } from './LoadingPage'
+export { LoadingPage } from './LoadingPage'
+export type LoadingPageProps = LoadingPageProps
 export { LoadingPage as default } from './LoadingPage'

--- a/src/marketingMessage/index.tsx
+++ b/src/marketingMessage/index.tsx
@@ -1,2 +1,3 @@
-export { MarketingMessage, MarketingMessageProps } from './MarketingMessage'
+export { MarketingMessage } from './MarketingMessage'
+export type MarketingMessageProps = MarketingMessageProps
 export { MarketingMessage as default } from './MarketingMessage'

--- a/src/menu/index.tsx
+++ b/src/menu/index.tsx
@@ -1,2 +1,3 @@
-export { Menu, MenuProps } from './Menu'
+export { Menu } from './Menu'
+export type MenuProps = MenuProps
 export { Menu as default } from './Menu'

--- a/src/message/index.tsx
+++ b/src/message/index.tsx
@@ -1,2 +1,3 @@
-export { Message, MessageProps } from './Message'
+export { Message } from './Message'
+export type MessageProps = MessageProps
 export { Message as default } from './Message'

--- a/src/messagingSummaryItem/index.tsx
+++ b/src/messagingSummaryItem/index.tsx
@@ -1,2 +1,3 @@
-export { MessagingSummaryItem, MessagingSummaryItemProps } from './MessagingSummaryItem'
+export { MessagingSummaryItem } from './MessagingSummaryItem'
+export type MessagingSummaryItemProps = MessagingSummaryItemProps
 export { MessagingSummaryItem as default } from './MessagingSummaryItem'

--- a/src/modal/index.tsx
+++ b/src/modal/index.tsx
@@ -1,3 +1,4 @@
-export { Modal, ModalSize, ModalProps } from './Modal'
+export { Modal, ModalSize } from './Modal'
+export type ModalProps = ModalProps
 export { ModalBody, ModalFooter, ModalFog } from './Modal.style'
 export { Modal as default } from './Modal'

--- a/src/paragraph/index.tsx
+++ b/src/paragraph/index.tsx
@@ -1,2 +1,3 @@
-export { Paragraph, ParagraphProps } from './Paragraph'
+export { Paragraph } from './Paragraph'
+export type ParagraphProps = ParagraphProps
 export { Paragraph as default } from './Paragraph'

--- a/src/phoneField/index.tsx
+++ b/src/phoneField/index.tsx
@@ -1,2 +1,3 @@
-export { PhoneField, PhoneFieldProps } from './PhoneField'
+export { PhoneField } from './PhoneField'
+export type PhoneFieldProps = PhoneFieldProps
 export { PhoneField as default } from './PhoneField'

--- a/src/profile/index.tsx
+++ b/src/profile/index.tsx
@@ -1,2 +1,3 @@
-export { Profile, ProfileProps } from './Profile'
+export { Profile } from './Profile'
+export type ProfileProps = ProfileProps
 export { Profile as default } from './Profile'

--- a/src/proximity/index.tsx
+++ b/src/proximity/index.tsx
@@ -1,2 +1,4 @@
-export { Proximity, ProximityProps, Distances } from './Proximity'
+export { Proximity, Distances } from './Proximity'
+export type ProximityProps = ProximityProps
+
 export { Proximity as default } from './Proximity'

--- a/src/pushInfo/index.tsx
+++ b/src/pushInfo/index.tsx
@@ -1,2 +1,3 @@
-export { PushInfo, PushInfoProps } from './PushInfo'
+export { PushInfo } from './PushInfo'
+export type PushInfoProps = PushInfoProps
 export { PushInfo as default } from './PushInfo'

--- a/src/qrCard/index.tsx
+++ b/src/qrCard/index.tsx
@@ -1,2 +1,3 @@
-export { QrCard, QrCardProps } from './QrCard'
+export { QrCard } from './QrCard'
+export type QrCardProps = QrCardProps
 export { QrCard as default } from './QrCard'

--- a/src/rating/index.tsx
+++ b/src/rating/index.tsx
@@ -1,2 +1,3 @@
-export { Rating, RatingProps } from './Rating'
+export { Rating } from './Rating'
+export type RatingProps = RatingProps
 export { Rating as default } from './Rating'

--- a/src/review/index.tsx
+++ b/src/review/index.tsx
@@ -1,2 +1,3 @@
-export { Review, ReviewProps } from './Review'
+export { Review } from './Review'
+export type ReviewProps = ReviewProps
 export { Review as default } from './Review'

--- a/src/searchForm/autoComplete/overlay/index.tsx
+++ b/src/searchForm/autoComplete/overlay/index.tsx
@@ -25,7 +25,7 @@ const StyledAutoComplete = styled(AutoCompleteOverlay)`
   }
 `
 
-export { AutoCompleteOverlayProps } from './AutoCompleteOverlay'
+export type AutoCompleteOverlayProps = AutoCompleteOverlayProps
 
 export { StyledAutoComplete as AutoCompleteOverlay }
 export default StyledAutoComplete

--- a/src/searchForm/datePicker/overlay/index.tsx
+++ b/src/searchForm/datePicker/overlay/index.tsx
@@ -18,6 +18,6 @@ const StyledDatePickerOverlay = styled(DatePickerOverlay)`
   }
 `
 
-export { DatePickerOverlayProps } from './DatePickerOverlay'
+export type DatePickerOverlayProps = DatePickerOverlayProps
 export { StyledDatePickerOverlay as DatePickerOverlay }
 export default StyledDatePickerOverlay

--- a/src/searchForm/index.tsx
+++ b/src/searchForm/index.tsx
@@ -1,9 +1,6 @@
-export {
-  SearchFormProps,
-  SearchFormDatePickerProps,
-  SearchFormStepperProps,
-  SearchFormElements,
-  SearchFormValues,
-  SearchForm,
-} from './SearchForm'
+export { SearchForm, SearchFormElements } from './SearchForm'
+export type SearchFormProps = SearchFormProps
+export type SearchFormDatePickerProps = SearchFormDatePickerProps
+export type SearchFormStepperProps = SearchFormStepperProps
+export type SearchFormValues = SearchFormStepperProps
 export { SearchForm as default } from './SearchForm'

--- a/src/searchRecap/index.tsx
+++ b/src/searchRecap/index.tsx
@@ -1,2 +1,3 @@
-export { SearchRecap, SearchRecapProps } from './SearchRecap'
+export { SearchRecap } from './SearchRecap'
+export type SearchRecapProps = SearchRecapProps
 export { SearchRecap as default } from './SearchRecap'

--- a/src/selectField/index.tsx
+++ b/src/selectField/index.tsx
@@ -1,2 +1,3 @@
-export { SelectField, SelectFieldProps } from './SelectField'
+export { SelectField } from './SelectField'
+export type SelectFieldProps = SelectFieldProps
 export { SelectField as default } from './SelectField'

--- a/src/snackbar/index.tsx
+++ b/src/snackbar/index.tsx
@@ -1,2 +1,3 @@
-export { Snackbar, SnackbarProps } from './Snackbar'
+export { Snackbar } from './Snackbar'
+export type SnackbarProps = SnackbarProps
 export { Snackbar as default } from './Snackbar'

--- a/src/stars/index.tsx
+++ b/src/stars/index.tsx
@@ -1,2 +1,3 @@
-export { Stars, StarsProps } from './Stars'
+export { Stars } from './Stars'
+export type StarsProps = StarsProps
 export { Stars as default } from './Stars'

--- a/src/stepper/index.tsx
+++ b/src/stepper/index.tsx
@@ -1,3 +1,4 @@
 export { StepperDisplay } from './constants'
-export { Stepper, StepperProps } from './Stepper'
+export { Stepper } from './Stepper'
+export type StepperProps = StepperProps
 export { Stepper as default } from './Stepper'

--- a/src/subHeader/index.tsx
+++ b/src/subHeader/index.tsx
@@ -1,2 +1,3 @@
-export { SubHeader, SubHeaderProps } from './SubHeader'
+export { SubHeader } from './SubHeader'
+export type SubHeaderProps = SubHeaderProps
 export { SubHeader as default } from './SubHeader'

--- a/src/successModal/index.tsx
+++ b/src/successModal/index.tsx
@@ -1,4 +1,5 @@
-export { SuccessModal, SuccessModalProps } from './SuccessModal'
+export { SuccessModal } from './SuccessModal'
+export type SuccessModalProps = SuccessModalProps
 /** @Todo Only used in SPA test should be removed when SPA stop using this import */
 export { SuccessModalElements } from './SuccessModal.style'
 export { SuccessModal as default } from './SuccessModal'

--- a/src/tabs/index.tsx
+++ b/src/tabs/index.tsx
@@ -1,2 +1,3 @@
-export { Tabs, TabsProps, TabStatus } from './Tabs'
+export { Tabs, TabStatus } from './Tabs'
+export type TabsProps = TabsProps
 export { Tabs as default } from './Tabs'

--- a/src/text/index.tsx
+++ b/src/text/index.tsx
@@ -1,3 +1,4 @@
-export { TextProps, TextDisplayType, TextTagType } from './Text'
+export { TextDisplayType, TextTagType } from './Text'
+export type TextProps = TextProps
 export { StyledText as Text } from './Text.style'
 export { StyledText as default } from './Text.style'

--- a/src/textField/index.tsx
+++ b/src/textField/index.tsx
@@ -1,2 +1,3 @@
-export { TextField, TextFieldProps, inputModes, inputTypes } from './TextField'
+export { TextField, inputModes, inputTypes } from './TextField'
+export type TextFieldProps = TextFieldProps
 export { TextField as default } from './TextField'

--- a/src/textarea/index.tsx
+++ b/src/textarea/index.tsx
@@ -1,2 +1,3 @@
-export { Textarea, TextareaProps } from './Textarea'
+export { Textarea } from './Textarea'
+export type TextareaProps = TextareaProps
 export { Textarea as default } from './Textarea'

--- a/src/theVoice/index.tsx
+++ b/src/theVoice/index.tsx
@@ -1,2 +1,3 @@
-export { TheVoice, TheVoiceProps } from './TheVoice'
+export { TheVoice } from './TheVoice'
+export type TheVoiceProps = TheVoiceProps
 export { TheVoice as default } from './TheVoice'

--- a/src/timePicker/index.tsx
+++ b/src/timePicker/index.tsx
@@ -1,2 +1,3 @@
-export { TimePicker, TimePickerProps } from './TimePicker'
+export { TimePicker } from './TimePicker'
+export type TimePickerProps = TimePickerProps
 export { TimePicker as default } from './TimePicker'

--- a/src/title/index.tsx
+++ b/src/title/index.tsx
@@ -1,2 +1,3 @@
-export { Title, TitleProps } from './Title'
+export { Title } from './Title'
+export type TitleProps = TitleProps
 export { Title as default } from './Title'

--- a/src/toggleButton/index.tsx
+++ b/src/toggleButton/index.tsx
@@ -1,2 +1,3 @@
-export { ToggleButton, ToggleButtonProps, ToggleButtonStatus } from './ToggleButton'
+export { ToggleButton, ToggleButtonStatus } from './ToggleButton'
+export type ToggleButtonProps = ToggleButtonProps
 export { ToggleButton as default } from './ToggleButton'

--- a/src/topBar/index.tsx
+++ b/src/topBar/index.tsx
@@ -1,2 +1,3 @@
-export { TopBar, TopBarProps } from './TopBar'
+export { TopBar } from './TopBar'
+export type TopBarProps = TopBarProps
 export { TopBar as default } from './TopBar'

--- a/src/transitions/index.tsx
+++ b/src/transitions/index.tsx
@@ -41,6 +41,8 @@ const StyledTransitions = styled(Transitions)`
   }
 `
 
-export { AnimationType, TransitionsProps } from './Transitions'
+export { AnimationType } from './Transitions'
+export type TransitionsProps = TransitionsProps
+
 export { StyledTransitions as Transitions }
 export default StyledTransitions

--- a/src/tripCard/index.tsx
+++ b/src/tripCard/index.tsx
@@ -1,2 +1,3 @@
-export { TripCard, TripCardProps } from './TripCard'
+export { TripCard } from './TripCard'
+export type TripCardProps = TripCardProps
 export { TripCard as default } from './TripCard'

--- a/src/uneditableTextField/index.tsx
+++ b/src/uneditableTextField/index.tsx
@@ -1,2 +1,3 @@
-export { UneditableTextField, UneditableTextFieldProps } from './UneditableTextField'
+export { UneditableTextField } from './UneditableTextField'
+export type UneditableTextFieldProps = UneditableTextFieldProps
 export { UneditableTextField as default } from './UneditableTextField'

--- a/src/why/Why.tsx
+++ b/src/why/Why.tsx
@@ -5,7 +5,7 @@ import { useFocusVisible } from '../_utils/focusVisibleProvider/useFocusVisible'
 import { QuestionIcon } from '../icon/questionIcon'
 import { StyledWhy } from './Why.style'
 
-export type WhyProps = Readonly<{
+type WhyProps = Readonly<{
   children: string
   title: string
   className?: string

--- a/src/why/index.tsx
+++ b/src/why/index.tsx
@@ -1,2 +1,4 @@
-export { Why, WhyProps } from './Why'
+export { Why } from './Why'
+export type WhyProps = WhyProps
+
 export { Why as default } from './Why'

--- a/tools/component/index.tsx
+++ b/tools/component/index.tsx
@@ -1,2 +1,4 @@
-export { __COMPONENT_NAME__, __COMPONENT_NAME__Props } from './__COMPONENT_NAME__'
+export { __COMPONENT_NAME__ } from './__COMPONENT_NAME__'
+// eslint-disable-next-line camelcase
+export type __COMPONENT_NAME__Props = __COMPONENT_NAME__Props
 export { __COMPONENT_NAME__ as default } from './__COMPONENT_NAME__'


### PR DESCRIPTION
## Description

<!-- Give some context of this PR. Illustrate with screenshots or a video (gif, loom, etc.) -->

All components have had missing properties on building

## What has been done

<!-- How do you solve the problem? -->

- Export type from index

// Before
`export { ActionNames, ActionTypes } from "./ActionTypes";`

// Above line resulted in warning
`// > "export 'ActionPayload' was not found in './ActionTypes'`

// Changed the code to the following for the warning to disappear
```
export { ActionNames } from "./ActionTypes";
export type ActionPayload = ActionPayload;
```

## Things to consider

<!-- Explain your changes. What are you expecting for the reviewers? -->

- Now we have a lint issue on circularly references

```
src/topBar/index.tsx:2:13 - error TS2456: Type alias 'TopBarProps' circularly references itself.

2 export type TopBarProps = TopBarProps
```

Need help from ts experts @simonrelet @mcellier 

## How it was tested

<!-- Local environment with ui-library only, integrated within the main project, on which browsers, etc. -->
- Storybook compiling (npm start)

