### PR TITLE
Add dataEncryptedName prop on TextField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - **[UPDATE]** Don't deactivate/activate the trap in `useFocusTrap` each time `onClose` changes.
+- **[UPDATE]** Add `dataEncryptedName` prop on `TextField`
 - [...]
 
 # v41.7.1 (17/11/2020)

--- a/src/textField/TextField.tsx
+++ b/src/textField/TextField.tsx
@@ -72,6 +72,7 @@ export type TextFieldProps = CommonFormFields &
     focusBorder?: boolean
     loader?: JSX.Element
     inputAttributes: InputHTMLAttributes<HTMLInputElement>
+    dataEncryptedName?: string
   }>
 
 export type TextFieldState = {
@@ -237,11 +238,13 @@ export class TextField extends PureComponent<TextFieldProps, TextFieldState> {
       focusBorder,
       loader,
       inputAttributes,
+      dataEncryptedName,
     } = this.props
     const value = this.state.value ? format(this.state.value, this.state.previousValue) : ''
 
     const attrs: InputHTMLAttributes<HTMLInputElement> & {
       ref: any
+      'data-encrypted-name'?: string
     } = {
       ...inputAttributes,
       type,
@@ -270,6 +273,10 @@ export class TextField extends PureComponent<TextFieldProps, TextFieldState> {
 
     if (error) {
       attrs['aria-invalid'] = 'true'
+    }
+
+    if (dataEncryptedName) {
+      attrs['data-encrypted-name'] = dataEncryptedName
     }
 
     const iconProps = {


### PR DESCRIPTION
## Description

We've talked about this for a long time so now it's done 😄 

## What has been done

Added a `dataEncryptedName` prop on the text field so it can be passed directly instead of via `inputAttributes`

## How it was tested

Integrated in the main project
