### PR TITLE
Release/41.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Unreleased
 
+- [...]
+
+# v41.8.0 (20/11/2020)
+
 - **[NEW]** Add `EditIcon`
 - **[UPDATE]** Don't deactivate/activate the trap in `useFocusTrap` each time `onClose` changes.
 - **[FIX]** The `SearchForm` no longer wobble on mount.
-- [...]
 
 # v41.7.1 (17/11/2020)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "41.7.1",
+  "version": "41.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "41.7.1",
+  "version": "41.8.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# v41.8.0 (20/11/2020)

- **[NEW]** Add `EditIcon`
- **[UPDATE]** Don't deactivate/activate the trap in `useFocusTrap` each time `onClose` changes.
- **[FIX]** The `SearchForm` no longer wobble on mount.