### PR TITLE
Add missing SelectFieldItem type export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Add missing `SelectFieldItem` type export
 - [...]
 
 # v41.8.0 (20/11/2020)

--- a/src/selectField/index.tsx
+++ b/src/selectField/index.tsx
@@ -1,2 +1,2 @@
-export { SelectField, SelectFieldProps } from './SelectField'
+export { SelectField, SelectFieldProps, SelectFieldItem } from './SelectField'
 export { SelectField as default } from './SelectField'


### PR DESCRIPTION
## Description

Add missing`SelectFieldItem` type export

## How it was tested

On kairos
