### PR TITLE
[PROPIM-609] Add prop divider with DividerPosition enum to Breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[UPDATE]** Add prop `divider` with `DividerPosition` enum to  `Breadcrumb` 
 - [...]
 
 # v41.9.1 (25/11/2020)

--- a/src/breadcrumb/Breadcrumb.story.mdx
+++ b/src/breadcrumb/Breadcrumb.story.mdx
@@ -1,7 +1,7 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks'
 import { withKnobs } from '@storybook/addon-knobs'
 
-import { Breadcrumb } from './index'
+import { Breadcrumb, DividerPosition } from './index'
 
 <Meta title="Widgets/Breadcrumb" decorators={[withKnobs({ escapeHTML: false })]} />
 
@@ -24,6 +24,46 @@ import { Breadcrumb } from './index'
   </Story>
 </Canvas>
 
+### With top divider
+
+<Canvas>
+  <Story name="With top divider">
+    <Breadcrumb
+      crumbs={[
+        {
+          url: 'http://www.goominet.com/unspeakable-vault/',
+          name: 'Fhtagn',
+        },
+        {
+          url: 'http://www.goominet.com/unspeakable-vault/vault/1/',
+          name: 'Cthulhu',
+        },
+      ]}
+      divider={DividerPosition.TOP}
+    />
+  </Story>
+</Canvas>
+
+### With bottom divider
+
+<Canvas>
+  <Story name="With bottom divider">
+    <Breadcrumb
+      crumbs={[
+        {
+          url: 'http://www.goominet.com/unspeakable-vault/',
+          name: 'Fhtagn',
+        },
+        {
+          url: 'http://www.goominet.com/unspeakable-vault/vault/1/',
+          name: 'Cthulhu',
+        },
+      ]}
+      divider={DividerPosition.BOTTOM}
+    />
+  </Story>
+</Canvas>
+
 ## Specifications
 
 The breadcrumb component uses structured data. It validates https://search.google.com/test/rich-results
@@ -31,8 +71,8 @@ The breadcrumb component uses structured data. It validates https://search.googl
 ## Usage
 
 ```jsx
-import { Breadcrumb } from '@blablacar/ui-library/build/breadcrumb'
-;<Breadcrumb />
+import { Breadcrumb, DividerPosition } from '@blablacar/ui-library/build/breadcrumb'
+<Breadcrumb crumbs={[{ name: string; url: string; }]} divider={DividerPosition} />
 ```
 
 <ArgsTable of={Breadcrumb} />

--- a/src/breadcrumb/Breadcrumb.style.tsx
+++ b/src/breadcrumb/Breadcrumb.style.tsx
@@ -1,9 +1,22 @@
 import styled from 'styled-components'
 
 import { color, space } from '../_utils/branding'
+import { DividerPosition } from './Breadcrumb'
 
-export const StyledBreadcrumb = styled.ol`
-  padding: ${space.l} ${space.xl} ${space.m};
+export const StyledBreadcrumb = styled.ol<{
+  divider: DividerPosition
+}>`
+  padding: ${props => {
+    if (props.divider === DividerPosition.TOP) {
+      return `${space.m} ${space.xl} ${space.l}`
+    }
+    if (props.divider === DividerPosition.BOTTOM) {
+      return `${space.l} ${space.xl} ${space.m}`
+    }
+
+    return `${space.l} ${space.xl} ${space.l}`
+  }};
+
   margin: 0;
   list-style: none;
 

--- a/src/breadcrumb/Breadcrumb.tsx
+++ b/src/breadcrumb/Breadcrumb.tsx
@@ -10,13 +10,22 @@ export type CrumbProps = Readonly<{
   url: string
 }>
 
-export type BreadcrumbProps = {
-  crumbs: Array<CrumbProps>
+export enum DividerPosition {
+  TOP = 'top',
+  BOTTOM = 'bottom',
+  NONE = 'none',
 }
 
-export const Breadcrumb = ({ crumbs }: BreadcrumbProps) => (
+export type BreadcrumbProps = {
+  crumbs: Array<CrumbProps>
+  divider?: DividerPosition
+}
+
+export const Breadcrumb = ({ crumbs, divider }: BreadcrumbProps) => (
   <Fragment>
-    <StyledBreadcrumb itemScope itemType="https://schema.org/BreadcrumbList">
+    {divider === DividerPosition.TOP && <ContentDivider />}
+
+    <StyledBreadcrumb divider={divider} itemScope itemType="https://schema.org/BreadcrumbList">
       {crumbs.map((crumb, index) => {
         const position = Number(index + 1)
 
@@ -50,6 +59,11 @@ export const Breadcrumb = ({ crumbs }: BreadcrumbProps) => (
         )
       })}
     </StyledBreadcrumb>
-    <ContentDivider />
+
+    {divider === DividerPosition.BOTTOM && <ContentDivider />}
   </Fragment>
 )
+
+Breadcrumb.defaultProps = {
+  divider: DividerPosition.NONE,
+}

--- a/src/breadcrumb/Breadcrumb.unit.tsx
+++ b/src/breadcrumb/Breadcrumb.unit.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { render, screen } from '@testing-library/react'
 
-import { Breadcrumb, CrumbProps } from './index'
+import { Breadcrumb, CrumbProps, DividerPosition } from './index'
 
 const crumb1: CrumbProps = {
   url: 'http://www.goominet.com/unspeakable-vault/',
@@ -20,9 +20,25 @@ describe('Breadcrumb', () => {
     expect(screen.getAllByRole('listitem')).toHaveLength(1)
     expect(screen.getByRole('list')).toHaveTextContent('Fhtagn')
   })
-  it('renders with 2 links and a separator', () => {
+  it('renders with 2 links and a separator between them', () => {
     render(<Breadcrumb crumbs={[crumb1, crumb2]} />)
     expect(screen.getAllByRole('listitem')).toHaveLength(2)
     expect(screen.getByRole('list')).toHaveTextContent('Fhtagn › Cthulhu')
+  })
+  it('renders with no divider ', () => {
+    render(<Breadcrumb crumbs={[crumb1]} />)
+    expect(screen.queryByRole('separator')).not.toBeInTheDocument()
+  })
+  it('renders with a divider before', () => {
+    const breadcrumb = render(<Breadcrumb crumbs={[crumb1]} divider={DividerPosition.TOP} />)
+      .container
+    expect(breadcrumb.querySelector('div')).toStrictEqual(breadcrumb.childNodes[0])
+    expect(breadcrumb.querySelector('ol')).toStrictEqual(breadcrumb.childNodes[1])
+  })
+  it('renders with a divider after', () => {
+    const breadcrumb = render(<Breadcrumb crumbs={[crumb1]} divider={DividerPosition.BOTTOM} />)
+      .container
+    expect(breadcrumb.querySelector('ol')).toStrictEqual(breadcrumb.childNodes[0])
+    expect(breadcrumb.querySelector('div')).toStrictEqual(breadcrumb.childNodes[1])
   })
 })

--- a/src/breadcrumb/index.tsx
+++ b/src/breadcrumb/index.tsx
@@ -1,2 +1,2 @@
-export { Breadcrumb, BreadcrumbProps, CrumbProps } from './Breadcrumb'
+export { Breadcrumb, BreadcrumbProps, CrumbProps, DividerPosition } from './Breadcrumb'
 export { Breadcrumb as default } from './Breadcrumb'


### PR DESCRIPTION
The Breadcrumb component on SEO pages will be moved from the top of the page to the bottom to make way for new content.
Hence, the ContentDivider that is included in Breadcrumb should shift from being below the actual breadcrumb to above. I also chose to create a case for no divider, which would be useful in the case of "directory pages" since the list of items ends with their own divider, so we wouldn't want to double that.

![Screen Shot 2020-11-24 at 17 06 00](https://user-images.githubusercontent.com/373381/100134172-1785b280-2e88-11eb-91f7-f40caf55fc41.png)

Tested locally on Firefox MacOs, with canary release