### PR TITLE
Fix SearchForm autocomplete styles

### DIFF
--- a/src/searchForm/baseStyles.tsx
+++ b/src/searchForm/baseStyles.tsx
@@ -32,9 +32,9 @@ export const sectionBaseStyle = `
 
 export const autoCompleteBaseStyle = `
   .kirk-textField-wrapper {
-    background: transparent;
-    border-radius: 0;
-    border: 0;
+    background: transparent !important;
+    border-radius: 0 !important;
+    border: 0 !important;
 
     input {
       font-size: ${font.m.size};


### PR DESCRIPTION
## Description

Fix style override in `SearchForm`.
The issue only appears in production mode.

## What has been done

Use `!important` as quick fix, better fix would be not to use nested selectors for styles override, it breaks components isolation and introduce these kinds of errors.

Before | After
------ | ------
<img width="368" alt="Screenshot 2020-11-25 at 13 23 00" src="https://user-images.githubusercontent.com/17502801/100227395-60d61080-2f21-11eb-9fb7-32f446d856de.png"> | <img width="369" alt="Screenshot 2020-11-25 at 13 22 43" src="https://user-images.githubusercontent.com/17502801/100227419-6895b500-2f21-11eb-8033-64c21081cdb0.png">


## Things to consider

Nothing.

## How it was tested

- Locally
