### PR TITLE
Fixed aria props getting overriden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Unreleased
 
-- [...]
+- **[FIX]** Stopped `aria-*` props from getting overriden in `Item`
+
 # v41.9.2 (26/11/2020)
 
-- **[UPDATE]** Add prop `divider` with `DividerPosition` enum to  `Breadcrumb` 
+- **[UPDATE]** Add prop `divider` with `DividerPosition` enum to `Breadcrumb`
 
 # v41.9.1 (25/11/2020)
 

--- a/src/_internals/itineraryLocation/ItineraryLocation.tsx
+++ b/src/_internals/itineraryLocation/ItineraryLocation.tsx
@@ -153,7 +153,7 @@ export const ItineraryLocation = ({
       aria-label={place.stepAriaLabel}
     >
       {renderMeta(place.mainLabel, place.subLabel)}
-      <Component {...hrefProps} aria-label={place.actionAriaLabel}>
+      <Component aria-label={place.actionAriaLabel} {...hrefProps}>
         {hasTime && renderTime(place.isoDate, place.time)}
         <div className="kirk-itineraryLocation-roadContainer" aria-hidden="true">
           <Bullet

--- a/src/_internals/itineraryLocation/ItineraryLocation.unit.tsx
+++ b/src/_internals/itineraryLocation/ItineraryLocation.unit.tsx
@@ -23,14 +23,12 @@ const placeWithProximity: Place = {
 
 const placeWithLink: Place = {
   ...place,
-  actionAriaLabel: 'New page with a map',
-  href: '#test',
+  href: <a href="#" aria-label="New page with a map" />,
 }
 
 const placeWithButton: Place = {
   ...place,
-  actionAriaLabel: 'New page with a map',
-  href: <button type="button" />,
+  href: <button type="button" aria-label="New page with a map" />,
 }
 
 const placeWithKey: Place = {


### PR DESCRIPTION
## Description

Everytime we were trying to pass `aria-label` to `SlugLink` in `place.href` the prop was getting overriden by the `pickA11yProps`. See here for more context: https://github.com/blablacar/kairos/pull/4487#discussion_r529610375
~We also reproduced it with `ItemChoice` `href` prop.~

As a long term fix we might want to replace `a11yProps` with `React.AriaAttributes` instead

@PerrineBoissieres We need your input on this.

## What has been done

Moved a11y props first so it doesn't override the aria-label passed 

## Things to consider

This is a quick fix, I don't think other things will breaki

## How it was tested

~In storybook by passing a component with `aria-label` in `ItemChoice` `href` prop.~
Unit test + Storybook 