### PR TITLE
Release/41.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Unreleased
 
-- **[UPDATE]** Add prop `divider` with `DividerPosition` enum to  `Breadcrumb` 
 - [...]
+# v41.9.2 (26/11/2020)
+
+- **[UPDATE]** Add prop `divider` with `DividerPosition` enum to  `Breadcrumb` 
 
 # v41.9.1 (25/11/2020)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "41.9.1",
+  "version": "41.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "41.9.1",
+  "version": "41.9.2",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# v41.9.2 (26/11/2020)

- **[UPDATE]** Add prop `divider` with `DividerPosition` enum to  `Breadcrumb` 