### PR TITLE
Release/v41.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+- [...]
+
+# v41.9.3 (27/11/2020)
 
 - **[FIX]** Stopped `aria-*` props from getting overriden in `Item`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "41.9.2",
+  "version": "41.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "41.9.2",
+  "version": "41.9.3",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Description

- **[FIX]** Stopped `aria-*` props from getting overriden in `Item`
