### PR TITLE
Release/41.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Unreleased
 
-- **[FIX]** Fix bad parameters on `MessagingSummaryItem` widget
 - [...]
+
+# v41.9.4 (30/11/2020)
+
+- **[FIX]** Fix bad parameters on `MessagingSummaryItem` widget
 
 # v41.9.3 (27/11/2020)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "41.9.3",
+  "version": "41.9.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "41.9.3",
+  "version": "41.9.4",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# v41.9.4 (30/11/2020)

- **[FIX]** Fix bad parameters on `MessagingSummaryItem` widget