### PR TITLE
Remove title attr from A11yProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Remove `title` attribute from `A11yProps`
 - [...]
 
 # v41.10.0 (30/11/2020)

--- a/src/_utils/interfaces.ts
+++ b/src/_utils/interfaces.ts
@@ -11,7 +11,6 @@ export interface CommonFieldsProps {
 export interface A11yProps {
   id?: string
   role?: string
-  title?: string
   'aria-label'?: string
   'aria-labelledby'?: string
   'aria-describedby'?: string
@@ -25,7 +24,6 @@ export function pickA11yProps<T extends A11yProps>(source: T): Pick<T, A11yKeys>
   const keys: A11yKeys[] = [
     'id',
     'role',
-    'title',
     'aria-label',
     'aria-labelledby',
     'aria-describedby',

--- a/src/hint/__snapshots__/Hint.unit.tsx.snap
+++ b/src/hint/__snapshots__/Hint.unit.tsx.snap
@@ -300,12 +300,10 @@ exports[`Hint Default rendering (above) 1`] = `
 <div
   aria-live="polite"
   className="c0"
-  title="Hint Title"
 >
   <aside
     className="c1 c2 bubble-arrow--above"
     id="kirk-hint-1"
-    title="Hint Title"
   >
     <p>
       <strong>
@@ -656,12 +654,10 @@ exports[`Hint Default rendering (below) 1`] = `
 <div
   aria-live="polite"
   className="c0"
-  title="Hint Title"
 >
   <aside
     className="c1 c2 bubble-arrow--below"
     id="kirk-hint-2"
-    title="Hint Title"
   >
     <p>
       <strong>

--- a/src/itemActionTitle/ItemActionTitle.unit.tsx
+++ b/src/itemActionTitle/ItemActionTitle.unit.tsx
@@ -40,17 +40,6 @@ describe('ItemActionTitle', () => {
       expect(screen.getByRole('button', { name: 'Screen reader content' })).toBeInTheDocument()
     })
 
-    it('Should have a complementary content', () => {
-      // Screen reader read it in addition
-      const props = createProps({
-        title: 'Screen reader complementary content',
-      })
-      render(<ItemActionTitle {...props} />)
-      expect(
-        screen.getByRole('button', { name: 'Screen reader complementary content' }),
-      ).toBeInTheDocument()
-    })
-
     it('Should pass aria props', () => {
       const props = createProps({
         'aria-controls': 'elem-ref',


### PR DESCRIPTION
## Description

Remove `title` attribute from `A11yProps` added in the previous release (v41.10.0).
Some components like `Profile` already use `title` prop but for something else.
So we can't provide the `title` attribute globally for now, it require a global refacto/fix.