### PR TITLE
Boyscout/fix item action title alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Fix `ItemActionTitle` vertical alignment
 - [...]
 
 # v41.10.1 (01/12/2020)

--- a/src/_internals/item/__snapshots__/Item.unit.tsx.snap
+++ b/src/_internals/item/__snapshots__/Item.unit.tsx.snap
@@ -125,10 +125,12 @@ exports[`Item Should not have changed 1`] = `
   -webkit-flex-flow: wrap;
   -ms-flex-flow: wrap;
   flex-flow: wrap;
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
 .c0.kirk-item--wrappable .kirk-item-leftWrapper {
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 

--- a/src/_internals/item/index.tsx
+++ b/src/_internals/item/index.tsx
@@ -32,9 +32,11 @@ const StyledItem = styled(Item)`
 
   &.kirk-item--wrappable {
     flex-flow: wrap;
+    padding-top: ${space.m};
     padding-bottom: ${space.m};
 
     .kirk-item-leftWrapper {
+      padding-top: ${space.m};
       padding-bottom: ${space.m};
     }
 

--- a/src/itemChoice/__snapshots__/index.unit.tsx.snap
+++ b/src/itemChoice/__snapshots__/index.unit.tsx.snap
@@ -145,10 +145,12 @@ exports[`ItemChoice Should display a Loader when the component is in loading sta
   -webkit-flex-flow: wrap;
   -ms-flex-flow: wrap;
   flex-flow: wrap;
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
 .c0.kirk-item--wrappable .kirk-item-leftWrapper {
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
@@ -659,10 +661,12 @@ exports[`ItemChoice Should display a done Loader when the component is in checke
   -webkit-flex-flow: wrap;
   -ms-flex-flow: wrap;
   flex-flow: wrap;
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
 .c0.kirk-item--wrappable .kirk-item-leftWrapper {
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
@@ -1143,10 +1147,12 @@ exports[`ItemChoice Should forward its props to the Item component 1`] = `
   -webkit-flex-flow: wrap;
   -ms-flex-flow: wrap;
   flex-flow: wrap;
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
 .c0.kirk-item--wrappable .kirk-item-leftWrapper {
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
@@ -1563,10 +1569,12 @@ exports[`ItemChoice Should support a disabled state 1`] = `
   -webkit-flex-flow: wrap;
   -ms-flex-flow: wrap;
   flex-flow: wrap;
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
 .c0.kirk-item--wrappable .kirk-item-leftWrapper {
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
@@ -1965,10 +1973,12 @@ exports[`ItemChoice Should use a button tag if no href is given 1`] = `
   -webkit-flex-flow: wrap;
   -ms-flex-flow: wrap;
   flex-flow: wrap;
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
 .c0.kirk-item--wrappable .kirk-item-leftWrapper {
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 

--- a/src/itemsList/__snapshots__/ItemsList.unit.tsx.snap
+++ b/src/itemsList/__snapshots__/ItemsList.unit.tsx.snap
@@ -125,10 +125,12 @@ exports[`ItemsList Should render an unordered list 1`] = `
   -webkit-flex-flow: wrap;
   -ms-flex-flow: wrap;
   flex-flow: wrap;
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
 .c1.kirk-item--wrappable .kirk-item-leftWrapper {
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
@@ -547,10 +549,12 @@ exports[`ItemsList Should render an unordered list with some separators 1`] = `
   -webkit-flex-flow: wrap;
   -ms-flex-flow: wrap;
   flex-flow: wrap;
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
 .c1.kirk-item--wrappable .kirk-item-leftWrapper {
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
@@ -990,10 +994,12 @@ exports[`ItemsList Should render an unordered list with the separators classname
   -webkit-flex-flow: wrap;
   -ms-flex-flow: wrap;
   flex-flow: wrap;
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
 .c1.kirk-item--wrappable .kirk-item-leftWrapper {
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 

--- a/src/layout/section/itemsSection/__snapshots__/ItemsSection.unit.tsx.snap
+++ b/src/layout/section/itemsSection/__snapshots__/ItemsSection.unit.tsx.snap
@@ -105,10 +105,12 @@ exports[`ItemsSection should render default items section 1`] = `
   -webkit-flex-flow: wrap;
   -ms-flex-flow: wrap;
   flex-flow: wrap;
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
 .c2.kirk-item--wrappable .kirk-item-leftWrapper {
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
@@ -418,10 +420,12 @@ exports[`ItemsSection should render non-default items section 1`] = `
   -webkit-flex-flow: wrap;
   -ms-flex-flow: wrap;
   flex-flow: wrap;
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
 .c2.kirk-item--wrappable .kirk-item-leftWrapper {
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 

--- a/src/messagingSummaryItem/__snapshots__/MessagingSummaryItem.unit.tsx.snap
+++ b/src/messagingSummaryItem/__snapshots__/MessagingSummaryItem.unit.tsx.snap
@@ -211,10 +211,12 @@ exports[`Should render properly with read messages 1`] = `
   -webkit-flex-flow: wrap;
   -ms-flex-flow: wrap;
   flex-flow: wrap;
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
 .c0.kirk-item--wrappable .kirk-item-leftWrapper {
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
@@ -635,10 +637,12 @@ exports[`Should render properly with unread messages 1`] = `
   -webkit-flex-flow: wrap;
   -ms-flex-flow: wrap;
   flex-flow: wrap;
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 
 .c0.kirk-item--wrappable .kirk-item-leftWrapper {
+  padding-top: 8px;
   padding-bottom: 8px;
 }
 


### PR DESCRIPTION
## Description

Fix `ItemActionTitle` vertical alignment

**Bug demo**
<img width="503" alt="Capture d’écran 2020-12-01 à 17 40 22" src="https://user-images.githubusercontent.com/4067977/100843515-c3c42c00-347a-11eb-9fc4-1602935b51f7.png">


## How it was tested

Locally on Storybook

**Demo with all cases:**
<img width="472" alt="Capture d’écran 2020-12-02 à 08 32 46" src="https://user-images.githubusercontent.com/4067977/100843437-a5f6c700-347a-11eb-82b1-c0ff1426ff2d.png">
<img width="579" alt="Capture d’écran 2020-12-02 à 08 33 23" src="https://user-images.githubusercontent.com/4067977/100843440-a727f400-347a-11eb-8bcb-07bd8de5c191.png">
<img width="497" alt="Capture d’écran 2020-12-02 à 08 34 03" src="https://user-images.githubusercontent.com/4067977/100843444-a7c08a80-347a-11eb-94b3-360a2a0c66bf.png">
<img width="404" alt="Capture d’écran 2020-12-02 à 08 34 26" src="https://user-images.githubusercontent.com/4067977/100843446-a8592100-347a-11eb-9b81-bdfa776a81e9.png">
<img width="396" alt="Capture d’écran 2020-12-02 à 08 34 49" src="https://user-images.githubusercontent.com/4067977/100843448-a8f1b780-347a-11eb-9627-617df6ea4b96.png">
<img width="402" alt="Capture d’écran 2020-12-02 à 08 35 08" src="https://user-images.githubusercontent.com/4067977/100843450-a8f1b780-347a-11eb-8218-801e8b92231d.png">
