### PR TITLE
Use click event to select an item in AutoCompleteList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[UPDATE]** Use click event to select an item in `AutoCompleteList`
 - [...]
 
 # v41.10.2 (02/12/2020)
@@ -9,7 +10,6 @@
 # v41.10.1 (01/12/2020)
 
 - **[FIX]** Remove `title` attribute from `A11yProps`
-
 
 # v41.10.0 (30/11/2020)
 

--- a/src/autoComplete/AutoComplete.unit.tsx
+++ b/src/autoComplete/AutoComplete.unit.tsx
@@ -78,7 +78,7 @@ describe('AutoComplete', () => {
     wrapper
       .find(ItemChoice)
       .first()
-      .simulate('mousedown')
+      .simulate('click')
 
     expect(event).not.toBeCalled()
     jest.advanceTimersByTime(3000)
@@ -266,7 +266,7 @@ describe('AutoComplete', () => {
       wrapper
         .find(ItemChoice)
         .first()
-        .simulate('mousedown')
+        .simulate('click')
       expect(onSelectSpy).toHaveBeenCalledWith({
         name: defaultProps.name,
         value: items[0].label,
@@ -300,7 +300,7 @@ describe('AutoComplete', () => {
       wrapper
         .find('ItemChoice')
         .first()
-        .simulate('mousedown')
+        .simulate('click')
       expect(onSelectSpy).toHaveBeenCalledWith({
         name: defaultProps.name,
         value: items[0].id,
@@ -323,7 +323,7 @@ describe('AutoComplete', () => {
       wrapper
         .find('ItemChoice')
         .first()
-        .simulate('mousedown')
+        .simulate('click')
       expect(wrapper.find('TextField').prop('defaultValue')).toBe(items[0].id)
     })
   })

--- a/src/autoComplete/AutoCompleteList.tsx
+++ b/src/autoComplete/AutoCompleteList.tsx
@@ -159,7 +159,7 @@ export class AutoCompleteList extends Component<AutoCompleteListProps, AutoCompl
                 className={this.props.itemClassName}
                 style={isHighlighted ? ItemChoiceStyle.RECOMMENDED : ItemChoiceStyle.PRIMARY}
                 status={status}
-                onMouseDown={() => {
+                onClick={() => {
                   this.onSelect(index, item)
                 }}
                 onDoneAnimationEnd={this.props.onDoneAnimationEnd}


### PR DESCRIPTION
## Description

Use click event instead of mousedown to select an item in `AutoCompleteList`.

## What has been done

See ☝️

## Things to consider

None.

## How it was tested

- Storybook
- Unit tests
