### PR TITLE
update title props & layout for ColumnedContentSection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[UPDATE]** Optional title prop and layout changes for `ColumnedContentSection`
 - **[UPDATE]** Use click event to select an item in `AutoCompleteList`
 - [...]
 

--- a/src/layout/section/columnedContentSection/ColumnedContentSection.story.mdx
+++ b/src/layout/section/columnedContentSection/ColumnedContentSection.story.mdx
@@ -1,4 +1,4 @@
-import { ArgsTable, Canvas, Meta } from '@storybook/addon-docs/blocks'
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks'
 
 import { CheckShieldIcon } from '../../../icon/checkShieldIcon'
 import { DirectionIcon } from '../../../icon/directionIcon'
@@ -9,9 +9,36 @@ import { ColumnedContentSection, ColumnedSectionContentMediaKind } from './index
 
 # **ColumnedContentSection**
 
-### Simple
+### Default
 
 <Canvas>
+  <Story name="Default">
+    <ColumnedContentSection
+      columnContentList={[
+        {
+          title: 'Pratique',
+          content:
+            'Trouvez rapidement un covoiturage ou un bus à proximité parmi les millions de trajets proposés.',
+        },
+        {
+          title: 'Facile',
+          content:
+            'Trouvez le trajet parfait ! Il vous suffit d’entrer votre adresse exacte, de choisir le voyage qui vous convient le mieux, et de réserver.',
+        },
+        {
+          title: 'Direct',
+          content:
+            'Que vous prévoyiez à l’avance ou réserviez en dernière minute, vous trouverez toujours un tarif avantageux.',
+        },
+      ]}
+    />
+  </Story>
+</Canvas>
+
+### With top link
+
+<Canvas>
+  <Story name="With top link">
     <ColumnedContentSection
       title="Allez où vous voulez. D'où vous voulez."
       topLinkLabel="En savoir plus"
@@ -34,11 +61,13 @@ import { ColumnedContentSection, ColumnedSectionContentMediaKind } from './index
         },
       ]}
     />
+  </Story>
 </Canvas>
 
-### Blog section
+### With media cover (blog)
 
 <Canvas>
+  <Story name="With media cover (blog)">
     <ColumnedContentSection
       title="Allez où vous voulez. D'où vous voulez."
       topLinkLabel="En savoir plus"
@@ -91,11 +120,13 @@ import { ColumnedContentSection, ColumnedSectionContentMediaKind } from './index
         },
       ]}
     />
+  </Story>
 </Canvas>
 
-### Pro section
+### With media fit (pro)
 
 <Canvas>
+  <Story name="With media fit (pro)">
     <ColumnedContentSection
       title="Gain access to more than 20 million travellers across the whole country"
       columnContentList={[
@@ -105,7 +136,7 @@ import { ColumnedContentSection, ColumnedSectionContentMediaKind } from './index
           media: {
             kind: ColumnedSectionContentMediaKind.FIT,
             pictureUrl:
-              'https://cdn.blablacar.com/kairos/assets/build/images/item_presentation_1-b0786829cd9fdc76581d2ca07d4e9357.svg',
+              'https://cdn.blablacar.com/kairos/assets/build/images/presentation_item_1-b0786829cd9fdc76581d2ca07d4e9357.svg',
           },
         },
         {
@@ -115,7 +146,7 @@ import { ColumnedContentSection, ColumnedSectionContentMediaKind } from './index
           media: {
             kind: ColumnedSectionContentMediaKind.FIT,
             pictureUrl:
-              'https://cdn.blablacar.com/kairos/assets/build/images/item_presentation_2-1a58d466645859b86d9bef6e454c7e9b.svg',
+              'https://cdn.blablacar.com/kairos/assets/build/images/presentation_item_2-1a58d466645859b86d9bef6e454c7e9b.svg',
           },
         },
         {
@@ -125,23 +156,25 @@ import { ColumnedContentSection, ColumnedSectionContentMediaKind } from './index
           media: {
             kind: ColumnedSectionContentMediaKind.FIT,
             pictureUrl:
-              'https://cdn.blablacar.com/kairos/assets/build/images/item_presentation_3-28b79c781e8f536d800aa31254286333.svg',
+              'https://cdn.blablacar.com/kairos/assets/build/images/presentation_item_3-28b79c781e8f536d800aa31254286333.svg',
           },
         },
       ]}
     />
+  </Story>
 </Canvas>
 
-### Simple with icons
+### With media element
 
 <Canvas>
+  <Story name="With media element">
     <ColumnedContentSection
       title="Ce qui va vous plaire"
       columnContentList={[
         {
           media: {
             kind: ColumnedSectionContentMediaKind.ELEMENT,
-            element: <DirectionIcon size={90} />,
+            element: <DirectionIcon size={40} />,
           },
           title: 'Avoir le choix',
           content:
@@ -150,7 +183,7 @@ import { ColumnedContentSection, ColumnedSectionContentMediaKind } from './index
         {
           media: {
             kind: ColumnedSectionContentMediaKind.ELEMENT,
-            element: <IdCardVerifiedIcon size={90} />,
+            element: <IdCardVerifiedIcon size={40} />,
           },
           title: 'Communauté',
           content:
@@ -159,7 +192,7 @@ import { ColumnedContentSection, ColumnedSectionContentMediaKind } from './index
         {
           media: {
             kind: ColumnedSectionContentMediaKind.ELEMENT,
-            element: <CheckShieldIcon size={90} />,
+            element: <CheckShieldIcon size={40} />,
           },
           title: 'Assurance',
           content:
@@ -176,6 +209,75 @@ import { ColumnedContentSection, ColumnedSectionContentMediaKind } from './index
         },
       ]}
     />
+  </Story>
+</Canvas>
+
+### One column
+
+<Canvas>
+  <Story name="One column">
+    <ColumnedContentSection
+      columnContentList={[
+        {
+          title: 'Pratique',
+          content:
+            'Trouvez rapidement un covoiturage ou un bus à proximité parmi les millions de trajets proposés.',
+        },
+      ]}
+    />
+  </Story>
+</Canvas>
+
+### Two columns
+
+<Canvas>
+  <Story name="Two columns">
+    <ColumnedContentSection
+      columnContentList={[
+        {
+          title: 'Pratique',
+          content:
+            'Trouvez rapidement un covoiturage ou un bus à proximité parmi les millions de trajets proposés.',
+        },
+        {
+          title: 'Facile',
+          content:
+            'Trouvez le trajet parfait ! Il vous suffit d’entrer votre adresse exacte, de choisir le voyage qui vous convient le mieux, et de réserver.',
+        },
+      ]}
+    />
+  </Story>
+</Canvas>
+
+### Four columns
+
+<Canvas>
+  <Story name="Four columns">
+    <ColumnedContentSection
+      columnContentList={[
+        {
+          title: 'Pratique',
+          content:
+            'Trouvez rapidement un covoiturage ou un bus à proximité parmi les millions de trajets proposés.',
+        },
+        {
+          title: 'Facile',
+          content:
+            'Trouvez le trajet parfait ! Il vous suffit d’entrer votre adresse exacte, de choisir le voyage qui vous convient le mieux, et de réserver.',
+        },
+        {
+          title: 'Direct',
+          content:
+            'Que vous prévoyiez à l’avance ou réserviez en dernière minute, vous trouverez toujours un tarif avantageux.',
+        },
+        {
+          title: 'Pratique',
+          content:
+            'Trouvez rapidement un covoiturage ou un bus à proximité parmi les millions de trajets proposés.',
+        },
+      ]}
+    />
+  </Story>
 </Canvas>
 
 ## Specifications

--- a/src/layout/section/columnedContentSection/ColumnedContentSection.style.tsx
+++ b/src/layout/section/columnedContentSection/ColumnedContentSection.style.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-import { font, radius, responsiveBreakpoints, space } from '../../../_utils/branding'
+import { font, fontWeight, radius, responsiveBreakpoints, space } from '../../../_utils/branding'
 import { BaseSection } from '../baseSection'
 
 export const StyledColumnedContentSection = styled(BaseSection)`
@@ -24,10 +24,16 @@ export const StyledColumnedContentSection = styled(BaseSection)`
   }
 
   & .kirk-columned-content-section-subtitle {
-    font-size: ${font.m.size};
-    line-height: ${font.m.lineHeight};
     padding-top: ${space.m};
     padding-bottom: ${space.s};
+    margin: 0;
+  }
+
+  & .kirk-columned-content-section-subtitle span {
+    font-weight: ${fontWeight.medium};
+  }
+
+  & .kirk-columned-content-section-subcontent {
     margin: 0;
   }
 
@@ -45,16 +51,19 @@ export const StyledColumnedContentSection = styled(BaseSection)`
   }
 
   & .kirk-columned-content-section-media-element {
-    text-align: center;
+    text-align: left;
+    margin-bottom: ${space.m};
   }
 
   & .kirk-columned-content-section-media-fit {
     text-align: center;
+    margin-bottom: ${space.m};
   }
 
   & .kirk-columned-content-section-media-fit img {
     width: 60%;
     border-radius: ${radius.s};
+    margin-bottom: ${space.m};
   }
 
   @media (${responsiveBreakpoints.isMediaSmall}) {
@@ -74,11 +83,14 @@ export const StyledColumnedContentSection = styled(BaseSection)`
     & .kirk-columned-content-section-column {
       text-align: center;
     }
+
+    & .kirk-columned-content-section-media-element {
+      text-align: center;
+    }
   }
 
   @media (${responsiveBreakpoints.isMediaLarge}) {
-    & .kirk-columned-content-section-column:not(:first-child):not(:last-child) {
-      margin-left: ${space.xxl};
+    & .kirk-columned-content-section-column:not(:last-child) {
       margin-right: ${space.xxl};
     }
   }

--- a/src/layout/section/columnedContentSection/ColumnedContentSection.tsx
+++ b/src/layout/section/columnedContentSection/ColumnedContentSection.tsx
@@ -4,13 +4,14 @@ import { Button, ButtonStatus } from '../../../button'
 import { Column } from '../../../layout/column'
 import { Columns } from '../../../layout/columns'
 import { SectionContentSize } from '../../../layout/section/baseSection'
-import { Text, TextTagType } from '../../../text'
-import { Title } from '../../../title'
+import { TextBody } from '../../../typography/body'
+import { TextDisplay1 } from '../../../typography/display1'
+import { TextTitle } from '../../../typography/title'
 import { StyledColumnedContentSection } from './ColumnedContentSection.style'
 
 export type ColumnedContentSectionProps = Readonly<{
   className?: string
-  title: string
+  title?: string
   topLinkLabel?: string
   topLinkHref?: string | JSX.Element
   columnContentList: ColumnContent[]
@@ -106,12 +107,13 @@ const renderColumnContent = (columnContent: ColumnContent, index: string): JSX.E
   return (
     <Column className="kirk-columned-content-section-column" key={index}>
       {media && renderMedia(media)}
+      <p className="kirk-columned-content-section-subtitle">
+        <TextTitle>{title}</TextTitle>
+      </p>
+      <p className="kirk-columned-content-section-subcontent">
+        <TextBody>{content}</TextBody>
+      </p>
 
-      <Title className="kirk-columned-content-section-subtitle" headingLevel={3}>
-        {title}
-      </Title>
-
-      <Text tag={TextTagType.PARAGRAPH}>{content}</Text>
       {showFooterLink && (
         <span>
           <Button
@@ -123,6 +125,7 @@ const renderColumnContent = (columnContent: ColumnContent, index: string): JSX.E
           </Button>
         </span>
       )}
+
       {deprecatedExtraFooter}
     </Column>
   )
@@ -142,9 +145,11 @@ export const ColumnedContentSection = (props: ColumnedContentSectionProps) => {
       className={className}
       contentSize={SectionContentSize.LARGE}
     >
-      <Title headingLevel={2} className="kirk-columned-content-section-title">
-        {title}
-      </Title>
+      {title && (
+        <h2 className="kirk-columned-content-section-title">
+          <TextDisplay1>{title}</TextDisplay1>
+        </h2>
+      )}
       {showTopLink && (
         <Button
           className="kirk-columned-content-section-top-link"

--- a/src/layout/section/columnedContentSection/ColumnedContentSection.unit.tsx
+++ b/src/layout/section/columnedContentSection/ColumnedContentSection.unit.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { mount } from 'enzyme'
 
+import { render, screen } from '@testing-library/react'
+
 import {
   ColumnedContentSection,
   ColumnedContentSectionProps,
@@ -45,18 +47,25 @@ describe('MediaContentSection', () => {
   })
 
   it('should render title', () => {
-    const wrapper = mount(<ColumnedContentSection {...defaultProps} />)
-    expect(wrapper.find('Title.kirk-columned-content-section-title').exists()).toBe(true)
+    render(<ColumnedContentSection {...defaultProps} />)
+    expect(screen.getByRole('heading', { level: 2, name: 'section title' })).toBeInTheDocument()
   })
 
-  it('should render basic columns', () => {
-    const wrapper = mount(<ColumnedContentSection {...defaultProps} />)
-    const columns = wrapper.find('li.kirk-columned-content-section-column')
-    expect(columns.length).toBe(3)
+  it('should not render title', () => {
+    render(<ColumnedContentSection {...defaultProps} title={null} />)
+    expect(
+      screen.queryByRole('heading', { level: 2, name: 'section title' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('should render 3 basic columns', () => {
+    render(<ColumnedContentSection {...defaultProps} />)
+    const columns = screen.getAllByRole('listitem')
+    expect(columns).toHaveLength(3)
 
     columns.forEach(column => {
-      expect(column.find('Title.kirk-columned-content-section-subtitle').text()).toBe('title')
-      expect(column.find('p').text()).toBe('content')
+      expect(column).toHaveTextContent('title')
+      expect(column).toHaveTextContent('content')
     })
   })
 


### PR DESCRIPTION
We're adding a "USP" block on Bus landing pages that is basically the same as what we have on the homepage (a section with 3 columns, each with an icon/image and text).

I ask and we can change the Homepage block with these adjustments too.

Changes:
- icon is smaller (but that's not defined in ui-library), positioned on the left rather than in the center (except on small devices), all media have an added margin-bottom
- subtitle is now a paragraph instead of a heading (seo optimization)
- now using typography instead of Text/Title
- fixed columns gap when displaying less or more than 3 columns (not used but illustrated in the specs)

![Screen Shot 2020-12-04 at 11 42 24](https://user-images.githubusercontent.com/373381/101171070-91aff700-363f-11eb-8a1f-042369284cad.png)
![Screen Shot 2020-12-04 at 11 42 40](https://user-images.githubusercontent.com/373381/101171079-9379ba80-363f-11eb-8c54-6b95ceaef05e.png)


Tested on Firefox Macos, with canary release