### PR TITLE
Autofocus next field in search form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[UPDATE]** Autofucs next field in `SearchForm` on large media
 - [...]
 
 # v41.11.0 (04/12/2020)


### PR DESCRIPTION
## Description

Automatically lead the user to the next field when he filled it.

## What has been done

- On large media, open the next field when it is empty after the user selected a value for the current one.

![Kapture 2020-12-07 at 10 58 37](https://user-images.githubusercontent.com/17502801/101336834-38340c00-387b-11eb-9eaa-9324680ff752.gif)

## Things to consider

We don't do this on a small media because the open/close animations of the _modal_ can be confusing for the user.

## How it was tested

- Locally
- With a canary release
