### PR TITLE
[BBC-11430] Handle `defaultValue` update in `SelectField`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[UPDATE]** Allow change of `defaultValue` in `SelectField`
 - [...]
 
 # v41.12.0 (08/12/2020)

--- a/src/phoneField/__snapshots__/PhoneField.unit.tsx.snap
+++ b/src/phoneField/__snapshots__/PhoneField.unit.tsx.snap
@@ -506,6 +506,7 @@ exports[`PhoneField should have the expected markup in the DOM with custom setti
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
+        value="ES"
       >
         <option
           value="ES"
@@ -917,6 +918,7 @@ exports[`PhoneField should have the expected markup in the DOM with default sett
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
+        value=""
       >
         <option
           value="FR"

--- a/src/selectField/SelectField.tsx
+++ b/src/selectField/SelectField.tsx
@@ -47,12 +47,21 @@ export const SelectField = React.forwardRef(
     const a11yAttrs = pickA11yProps<SelectFieldProps>(props)
     const baseClassName = 'kirk-selectField'
     const [hasFocus, setFocus] = useState(false)
+    const [previousDefaultValue, setPreviousDefaultValue] = useState(defaultValue)
+    const [currentValue, setCurrentValue] = useState(defaultValue)
 
     useEffect(() => {
       if (ref && !disabled && focus) {
         ref.current.focus()
       }
     }, [disabled, focus])
+
+    useEffect(() => {
+      if (defaultValue !== previousDefaultValue) {
+        setPreviousDefaultValue(defaultValue)
+        setCurrentValue(defaultValue)
+      }
+    }, [defaultValue])
 
     return (
       <StyledSelectField
@@ -64,7 +73,10 @@ export const SelectField = React.forwardRef(
       >
         <select
           name={name}
-          onChange={event => onChange({ name, value: event.target.value })}
+          onChange={event => {
+            setCurrentValue(event.target.value)
+            onChange({ name, value: event.target.value })
+          }}
           onFocus={event => {
             setFocus(true)
             onFocus(event)
@@ -74,6 +86,7 @@ export const SelectField = React.forwardRef(
             onBlur(event)
           }}
           defaultValue={defaultValue}
+          value={currentValue}
           disabled={disabled}
           required={required}
           autoFocus={autoFocus}

--- a/src/selectField/__snapshots__/SelectField.unit.tsx.snap
+++ b/src/selectField/__snapshots__/SelectField.unit.tsx.snap
@@ -91,6 +91,7 @@ exports[`SelectField should have the expected markup in the DOM 1`] = `
     onBlur={[Function]}
     onChange={[Function]}
     onFocus={[Function]}
+    value="1"
   >
     <option
       aria-label="value 1"


### PR DESCRIPTION
## Description

With OneAction & our kairos architecture, we can't be sure that the defaultValue will be correctly set a first render (race condition). Since defaultValue can't be updated after it's first rendering, we should use the `value`. We don't want to control this value from outside the component, so I just did as what we implemented in `TextArea` and `TextField`

## What has been done

Same as `TextArea` & `TextField`: use an internal state to handle value/default value

## Things to consider

We might want to have controlled components someday? But that might require bigger updates in all the codebase

## How it was tested

On kairos
