### PR TITLE
Release/v42.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Unreleased
 
-- **[BREAKING CHANGE]** Rename `ItemActionTitle` to `ItemActionLabel`
 - [...]
+
+# v42.0.0 (14/12/2020)
+
+- **[BREAKING CHANGE]** Rename `ItemActionTitle` to `ItemActionLabel`
 
 # v41.13.0 (10/12/2020)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "41.13.0",
+  "version": "42.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "41.13.0",
+  "version": "42.0.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Description

**v42.0.0 (14/12/2020)**
- **[BREAKING CHANGE]** Rename `ItemActionTitle` to `ItemActionLabel`
