### PR TITLE
[BBC-11573] Add placeholder prop to UneditableTextField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - **[BREAKING CHANGE]** Remove `ToggleButton`. Use `ItemCheckbox` instead.
+- **[UPDATE]** Add `isPlaceholder` prop to `UneditableTextField`.
 - [...]
 
 # v42.1.0 (17/12/2020)

--- a/src/searchRecap/__snapshots__/SearchRecap.unit.tsx.snap
+++ b/src/searchRecap/__snapshots__/SearchRecap.unit.tsx.snap
@@ -131,6 +131,10 @@ exports[`SearchRecap Should display searchRecap component 1`] = `
   overflow: hidden;
 }
 
+.c1 .kirk-uneditableTextField-label--placeholder {
+  color: #708C91;
+}
+
 .c0 .kirk-uneditableTextField {
   width: 100%;
   padding: 8px 16px;

--- a/src/uneditableTextField/UneditableTextField.story.mdx
+++ b/src/uneditableTextField/UneditableTextField.story.mdx
@@ -35,6 +35,16 @@ import { UneditableTextField } from './index'
   </Story>
 </Canvas>
 
+### As a placeholder
+
+<Canvas>
+  <Story name="As placeholder">
+    <UneditableTextField isPlaceholder>
+      Placeholder
+    </UneditableTextField>
+  </Story>
+</Canvas>
+
 
 ## Specifications
 

--- a/src/uneditableTextField/UneditableTextField.style.tsx
+++ b/src/uneditableTextField/UneditableTextField.style.tsx
@@ -27,4 +27,8 @@ export const StyledUneditableTextField = styled.div`
     text-overflow: ellipsis;
     overflow: hidden;
   }
+
+  & .kirk-uneditableTextField-label--placeholder {
+    color: ${color.lightMidnightGreen};
+  }
 `

--- a/src/uneditableTextField/UneditableTextField.tsx
+++ b/src/uneditableTextField/UneditableTextField.tsx
@@ -10,6 +10,7 @@ export type UneditableTextFieldProps = Readonly<{
   addOn?: JSX.Element
   href?: JSX.Element | string
   ellipsis?: boolean
+  isPlaceholder?: boolean
 }>
 
 export const UneditableTextField = ({
@@ -17,6 +18,7 @@ export const UneditableTextField = ({
   className = '',
   addOn = null,
   ellipsis = false,
+  isPlaceholder = false,
   href,
 }: UneditableTextFieldProps) => {
   let componentType
@@ -43,6 +45,7 @@ export const UneditableTextField = ({
         className={cc([
           'kirk-uneditableTextField-label',
           { 'kirk-uneditableTextField-label--ellipsis': ellipsis },
+          { 'kirk-uneditableTextField-label--placeholder': isPlaceholder },
         ])}
       >
         {children}

--- a/src/uneditableTextField/UneditableTextField.unit.tsx
+++ b/src/uneditableTextField/UneditableTextField.unit.tsx
@@ -24,7 +24,7 @@ describe('UneditableTextField', () => {
     expect(screen.getByText(props.children as string)).toHaveClass('kirk-uneditableTextField-label')
   })
 
-  it('Should not add CSS class for text ellipsis by default', () => {
+  it('should not add CSS class for text ellipsis by default', () => {
     const props = createProps()
     render(<UneditableTextField {...props} />)
 
@@ -33,12 +33,30 @@ describe('UneditableTextField', () => {
     )
   })
 
-  it('Should add CSS class for text ellipsis', () => {
+  it('should add CSS class for text ellipsis', () => {
     const props = createProps({ ellipsis: true })
     render(<UneditableTextField {...props} />)
 
     expect(screen.getByText(props.children as string)).toHaveClass(
       'kirk-uneditableTextField-label--ellipsis',
+    )
+  })
+
+  it('should not add CSS class for grey text by default', () => {
+    const props = createProps()
+    render(<UneditableTextField {...props} />)
+
+    expect(screen.getByText(props.children as string)).not.toHaveClass(
+      'kirk-uneditableTextField-label--placeholder',
+    )
+  })
+
+  it('should add CSS class for grey text with isPlaceholder prop', () => {
+    const props = createProps({ isPlaceholder: true })
+    render(<UneditableTextField {...props} />)
+
+    expect(screen.getByText(props.children as string)).toHaveClass(
+      'kirk-uneditableTextField-label--placeholder',
     )
   })
 
@@ -62,7 +80,7 @@ describe('UneditableTextField', () => {
     expect(link).toHaveTextContent(props.children as string)
   })
 
-  it('Should support component links', () => {
+  it('should support component links', () => {
     const props = createProps({ href: <a href="#bar" /> })
     render(<UneditableTextField {...props} />)
 


### PR DESCRIPTION
## Description

This prop makes the text light grey.
The idea is to remove custom CSS from Kairos that does that.

## What has been done

Add placeholder prop to UneditableTextField

<img width="977" alt="Capture d’écran 2020-12-21 à 14 53 17" src="https://user-images.githubusercontent.com/7479808/102784202-567e2980-439c-11eb-837b-2bcf69fe9033.png">

## How it was tested

Locally + UT
