### PR TITLE
Releases/43.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Unreleased
 
+- [...]
+
+# v43.0.0 (28/12/2020)
+
 - **[BREAKING CHANGE]** Remove `ToggleButton`. Use `ItemCheckbox` instead.
 - **[UPDATE]** Add `isPlaceholder` prop to `UneditableTextField`.
 - **[UPDATE]** Add `A11yProps` to `Menu`.
-- [...]
 
 # v42.1.0 (17/12/2020)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "42.1.0",
+  "version": "43.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "42.1.0",
+  "version": "43.0.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
- **[BREAKING CHANGE]** Remove `ToggleButton`. Use `ItemCheckbox` instead.
- **[UPDATE]** Add `isPlaceholder` prop to `UneditableTextField`.
- **[UPDATE]** Add `A11yProps` to `Menu`.