### PR TITLE
Release/43.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Unreleased
 
+- [...]
+
+# v43.1.0 (06/01/2021)
+
 - **[NEW]** Create new `ThemeProvider` with base app CSS reset/fonts and use it for all stories
 - **[UPDATE]** Update Storybook version to 6.11+ and run `npm audit fix`
 - **[UPDATE]** Add missing exports from `PhoneField`
 - **[FIX]** Add `inMotion` prop in `SlideSection` as sanity check to help define the default position
-- [...]
 
 # v43.0.0 (28/12/2020)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "43.0.0",
+  "version": "43.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "43.0.0",
+  "version": "43.1.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Description
# v43.1.0 (06/01/2021)

- **[NEW]** Create new `ThemeProvider` with base app CSS reset/fonts and use it for all stories
- **[UPDATE]** Update Storybook version to 6.11+ and run `npm audit fix`
- **[UPDATE]** Add missing exports from `PhoneField`
- **[FIX]** Add `inMotion` prop in `SlideSection` as sanity check to help define the default position