### PR TITLE
Release/43.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Unreleased
 
-- **[FIX]** Fix font base url for `ThemeProvider`
 - [...]
+
+# v43.1.1 (06/01/2021)
+- **[FIX]** Fix font base url for `ThemeProvider`
 
 # v43.1.0 (06/01/2021)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "43.1.0",
+  "version": "43.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "43.1.0",
+  "version": "43.1.1",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Description
# v43.1.1 (06/01/2021)
- **[FIX]** Fix font base url for `ThemeProvider`