### PR TITLE
Releases/45.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Unreleased
 
+- [...]
+
+# v45.0.0 (12/01/2021)
+
 - **[BREAKING CHANGE]** Remove `title` prop from `HighlightSection`
 - **[UPDATE]** Normalize `SubHeader`
-- [...]
 
 # v44.0.0 (11/01/2021)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "44.0.0",
+  "version": "45.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "44.0.0",
+  "version": "45.0.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# v45.0.0 (12/01/2021)

- **[BREAKING CHANGE]** Remove `title` prop from `HighlightSection`
- **[UPDATE]** Normalize `SubHeader`