### PR TITLE
[BOYSCOUT] Fix itinerary headline display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Fix `headline` display in `Itinerary`
 - [...]
 
 # v45.0.0 (12/01/2021)

--- a/src/itinerary/Itinerary.style.tsx
+++ b/src/itinerary/Itinerary.style.tsx
@@ -20,6 +20,11 @@ export const StyledItinerary = styled.div`
     padding-top: ${space.m};
   }
 
+  & .kirk-itinerary--headline {
+    padding-top: ${space.xl};
+    padding-bottom: ${space.m};
+  }
+
   & .kirk-itinerary--highlightRoad .kirk-itineraryLocation-road {
     background-color: ${color.midnightGreen};
   }

--- a/src/itinerary/Itinerary.tsx
+++ b/src/itinerary/Itinerary.tsx
@@ -10,8 +10,8 @@ import { A11yProps, pickA11yProps } from '../_utils/interfaces'
 import { Place } from '../_utils/place'
 import { Bullet, BulletTypes } from '../bullet'
 import { SpacingDivider } from '../divider/spacingDivider'
-import { SubHeader } from '../subHeader'
 import { Text, TextDisplayType, TextTagType } from '../text'
+import { TextSubHeaderStrong } from '../typography/subHeaderStrong'
 import { StyledItinerary } from './Itinerary.style'
 
 export type ItineraryProps = A11yProps &
@@ -188,7 +188,9 @@ export const Itinerary = (props: ItineraryProps) => {
     <StyledItinerary className={cc(['kirk-itinerary-root', className])} {...rootA11yProps}>
       {isNonEmptyString(headline) && (
         <Fragment>
-          <SubHeader>{headline}</SubHeader>
+          <h2 className="kirk-itinerary--headline">
+            <TextSubHeaderStrong>{headline}</TextSubHeaderStrong>
+          </h2>
           <SpacingDivider />
         </Fragment>
       )}


### PR DESCRIPTION
## Description

Fix itinerary headline broken since `SubHeader` has been normalized

## What has been done

Stop using `SubHeader` as it comes with its default margin/padding that'll have to be overriden in this component.
Used `typography/SubHeaderStrong` instead, to keep consistent on the typography side. Added a h2 to keep the layout similar without breaking SEO, and re-added margins.

## Things to consider

We should use typography components over "exposed" components to avoid these issues

## How it was tested

storybook
