### PR TITLE
[BOYSCOUT] fix QrCard paddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Fix `QrCard` spacings issues due to normalization 
 - [...]
 
 # v45.0.0 (12/01/2021)

--- a/src/qrCard/QrCard.style.tsx
+++ b/src/qrCard/QrCard.style.tsx
@@ -7,7 +7,7 @@ const qrCardMaxWidth = '450px'
 export const StyledQrCard = styled.div`
   & .kirk-card {
     display: block;
-    padding: ${space.none} ${space.xl};
+    padding: ${space.none};
     max-width: ${qrCardMaxWidth};
   }
 


### PR DESCRIPTION
## Description

Normalization issues

Fixed:
<img width="478" alt="Capture d’écran 2021-01-12 à 17 51 07" src="https://user-images.githubusercontent.com/729186/104347065-78cd1800-5500-11eb-9dc3-039637a7fd2f.png">
Unfixed:
<img width="472" alt="Capture d’écran 2021-01-12 à 17 50 54" src="https://user-images.githubusercontent.com/729186/104347071-7a96db80-5500-11eb-9af5-ca99d4a17530.png">

## What has been done

Removed padding on QrCard as `SubHeader` & `ItemInfo` already handles it.

## How it was tested

storybook
