### PR TITLE
Fixed autocomplete keyboard navigation

### DIFF
--- a/src/autoComplete/AutoCompleteList.tsx
+++ b/src/autoComplete/AutoCompleteList.tsx
@@ -6,7 +6,7 @@ import isEqual from 'lodash.isequal'
 
 import { ItemStatus } from '../_internals/item'
 import { prefix } from '../_utils'
-import { ItemChoice, ItemChoiceStyle } from '../itemChoice'
+import { ItemChoice } from '../itemChoice'
 import { ItemsList } from '../itemsList'
 
 export interface AutocompleteItem {
@@ -48,14 +48,13 @@ export class AutoCompleteList extends Component<AutoCompleteListProps, AutoCompl
     selectedIndex: null,
   }
 
-  componentDidUpdate(prevProps: AutoCompleteListProps) {
-    if (canUseEventListeners && prevProps.visible !== this.props.visible) {
-      if (this.props.visible) {
-        document.addEventListener('keydown', this.handleKeydown)
-      } else {
-        document.removeEventListener('keydown', this.handleKeydown)
-      }
+  componentDidMount() {
+    if (canUseEventListeners) {
+      document.addEventListener('keydown', this.handleKeydown)
     }
+  }
+
+  componentDidUpdate(prevProps: AutoCompleteListProps) {
     if (!isEqual(prevProps.items, this.props.items)) {
       this.setState({
         highlightedIndex: null,
@@ -64,7 +63,7 @@ export class AutoCompleteList extends Component<AutoCompleteListProps, AutoCompl
   }
 
   componentWillUnmount() {
-    if (this.props.visible && canUseEventListeners) {
+    if (canUseEventListeners) {
       document.removeEventListener('keydown', this.handleKeydown)
     }
   }
@@ -156,14 +155,14 @@ export class AutoCompleteList extends Component<AutoCompleteListProps, AutoCompl
             return (
               <ItemChoice
                 {...itemChoiceProps}
-                className={this.props.itemClassName}
-                style={isHighlighted ? ItemChoiceStyle.RECOMMENDED : ItemChoiceStyle.PRIMARY}
+                className={cc([this.props.itemClassName, { highlight: isHighlighted }])}
                 status={status}
                 onClick={() => {
                   this.onSelect(index, item)
                 }}
                 onDoneAnimationEnd={this.props.onDoneAnimationEnd}
                 key={this.props.itemKey(item)}
+                tabIndex={-1}
               />
             )
           })}

--- a/src/autoComplete/AutoCompleteListStyle.ts
+++ b/src/autoComplete/AutoCompleteListStyle.ts
@@ -28,7 +28,8 @@ const StyledAutoCompleteList = styled(AutoCompleteList)`
   }
 
   & .kirk-item-choice:hover,
-  & .kirk-item-choice[aria-selected='true'] {
+  & .kirk-item-choice[aria-selected='true'],
+  & .kirk-item-choice.highlight {
     background-color: ${color.lightGray};
   }
 `

--- a/src/itemChoice/ItemChoice.tsx
+++ b/src/itemChoice/ItemChoice.tsx
@@ -36,6 +36,7 @@ export type ItemChoiceProps = A11yProps &
     onFocus?: (event: React.FocusEventHandler<HTMLElement>) => void
     onMouseDown?: (event: React.MouseEvent<HTMLElement>) => void
     onDoneAnimationEnd?: () => void
+    tabIndex?: number
   }>
 
 export class ItemChoice extends PureComponent<ItemChoiceProps> {
@@ -49,6 +50,7 @@ export class ItemChoice extends PureComponent<ItemChoiceProps> {
     status: ItemStatus.DEFAULT,
     style: ItemChoiceStyle.PRIMARY,
     disabled: false,
+    tabIndex: null,
   }
 
   get rightAddon() {
@@ -93,6 +95,7 @@ export class ItemChoice extends PureComponent<ItemChoiceProps> {
       disabled,
       className,
       hasHorizontalSpacing = false,
+      tabIndex,
     } = this.props
     const a11yAttrs = pickA11yProps<ItemChoiceProps>(this.props)
     const isRecommended = style === ItemChoiceStyle.RECOMMENDED
@@ -121,7 +124,7 @@ export class ItemChoice extends PureComponent<ItemChoiceProps> {
             leftAddon={leftAddon}
             rightAddon={this.rightAddon}
             href={!disabled ? href : ''}
-            tag={<button type="button" disabled={disabled} />}
+            tag={<button type="button" disabled={disabled} tabIndex={tabIndex} />}
             onClick={!disabled ? onClick : null}
             onFocus={!disabled ? onFocus : null}
             onBlur={!disabled ? onBlur : null}

--- a/src/itemChoice/__snapshots__/index.unit.tsx.snap
+++ b/src/itemChoice/__snapshots__/index.unit.tsx.snap
@@ -380,6 +380,7 @@ button:focus:not(.focus-visible).c0 {
   disabled={false}
   href="#"
   onClick={[Function]}
+  tabIndex={null}
   type="button"
 >
   <span
@@ -885,6 +886,7 @@ button:focus:not(.focus-visible).c0 {
   disabled={false}
   href="#"
   onClick={[Function]}
+  tabIndex={null}
   type="button"
 >
   <span
@@ -1278,6 +1280,7 @@ button:focus:not(.focus-visible).c0 {
   disabled={false}
   href="#"
   onClick={[Function]}
+  tabIndex={null}
   type="button"
 >
   <span
@@ -1702,6 +1705,7 @@ button:focus:not(.focus-visible).c0 {
   onClick={null}
   onFocus={null}
   onMouseDown={null}
+  tabIndex={null}
   type="button"
 >
   <span
@@ -2103,6 +2107,7 @@ button:focus:not(.focus-visible).c0 {
   className="kirk-item kirk-item--clickable kirk-item-choice custom-class-name c0"
   disabled={false}
   onClick={[Function]}
+  tabIndex={null}
   type="button"
 >
   <span


### PR DESCRIPTION
## Description

- Fixed autocomplete keyboard navigation
- Removed non-Pixar style when list item gets highlighter with the keyboard
- Fixed tabbing issue

![Kapture 2021-01-15 at 16 58 07](https://user-images.githubusercontent.com/1606624/104749627-541cae80-5753-11eb-9726-fe38e5f9d665.gif)

## What has been done

- Added `tabIndex` 0 on autocomplete list so we can't tab in the list, we can go through the list only using arrow up and down
- Simplified  `eventListener` on keyboard
- Used same style as hover on autocomplete list when navigating through the list with keyboard

## How it was tested

Storybook + canary in Kairos
