### PR TITLE
[BOYSCOUT] Fix MediaSizeProvider first render state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- **[FIX]** Fix `MediaSizeProvider` first render state
+- **[NEW]** New serverSideMediaSize attribute for `MediaSizeProvider`
 [...]
 
 # v45.1.0 (20/01/2021)

--- a/src/_utils/mediaSizeProvider/index.tsx
+++ b/src/_utils/mediaSizeProvider/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useState } from 'react'
+import React, { ReactNode, useLayoutEffect, useState } from 'react'
 import debounce from 'lodash.debounce'
 
 import { responsiveBreakpoints } from '../branding'
@@ -8,12 +8,14 @@ export enum MediaSize {
   LARGE = 'large',
 }
 
+const DEFAULT_MEDIA_SIZE = MediaSize.SMALL
+
 export type MediaSizeProviderProps = Readonly<{
   children: ReactNode
+  serverSideMediaSize?: MediaSize
   mediaSizeForTestsOnly?: MediaSize
 }>
 
-const DEFAULT_MEDIA_SIZE = MediaSize.SMALL
 export const MediaSizeContext = React.createContext(DEFAULT_MEDIA_SIZE)
 
 const DEBOUNCE_VALUE = 500
@@ -28,28 +30,48 @@ export const useIsLargeMediaSize = (): boolean => {
   return mediaSize === MediaSize.LARGE
 }
 
-export const MediaSizeProvider = ({ children, mediaSizeForTestsOnly }: MediaSizeProviderProps) => {
-  const [mediaSize, setMediaSize] = useState(DEFAULT_MEDIA_SIZE)
+const computeMediaSizeFromViewport = (): MediaSize => {
+  const isSmall = window.innerWidth <= parseInt(responsiveBreakpoints.small, 10)
+  return isSmall ? MediaSize.SMALL : MediaSize.LARGE
+}
 
-  const handleResize = () => {
-    const isSmall = window.innerWidth <= parseInt(responsiveBreakpoints.small, 10)
-    setMediaSize(isSmall ? MediaSize.SMALL : MediaSize.LARGE)
+// Provides a media size based on the client viewport size to nested components.
+// Use dedicated hooks useIsSmallMediaSize and/or useIsLargeMediaSize to get this media size.
+// If the MediaSizeProvider is rendered server side, no viewport is available and a default media
+// size will be sent. This default server side media size can be changed with serverSideMediaSize
+// props.
+export const MediaSizeProvider = (props: MediaSizeProviderProps) => {
+  const { children, serverSideMediaSize, mediaSizeForTestsOnly } = props
+  const [mediaSize, setMediaSize] = useState(serverSideMediaSize || DEFAULT_MEDIA_SIZE)
+
+  const updateMediaSize = () => {
+    setMediaSize(computeMediaSizeFromViewport())
   }
 
-  useEffect(() => {
-    handleResize()
-    window.addEventListener('resize', debounce(handleResize, DEBOUNCE_VALUE))
-    return () => window.removeEventListener('resize', handleResize)
+  useLayoutEffect(() => {
+    if (!window) {
+      // Server side rendering, no need to execute the client-side effects.
+      return () => {}
+    }
+    // Initial client-side update.
+    updateMediaSize()
+
+    // Register listener for screen resize events.
+    const debouncedHandleResize = debounce(updateMediaSize, DEBOUNCE_VALUE)
+    window.addEventListener('resize', debouncedHandleResize)
+    return () => {
+      window.removeEventListener('resize', debouncedHandleResize)
+    }
   }, [])
 
   if (mediaSizeForTestsOnly) {
+    // When mediaSizeForTestsOnly is set for tests, override any previous logic.
     return (
       <MediaSizeContext.Provider value={mediaSizeForTestsOnly}>
         {children}
       </MediaSizeContext.Provider>
     )
   }
-
   return <MediaSizeContext.Provider value={mediaSize}>{children}</MediaSizeContext.Provider>
 }
 

--- a/src/_utils/mediaSizeProvider/index.unit.tsx
+++ b/src/_utils/mediaSizeProvider/index.unit.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react'
-import { mount } from 'enzyme'
+
+import { render, screen } from '@testing-library/react'
 
 import {
   MediaSize,
@@ -32,47 +33,40 @@ describe('MediaSizeProvider', () => {
       )
     }
   })
+
   it('Should provide "small" value when screen is under `responsiveBreakpoints.small`', () => {
     mockWindowInnerWidth(300)
-    const wrapper = mount(
+    render(
       <MediaSizeProvider>
         <ChildComponent />
       </MediaSizeProvider>,
     )
-
-    const expected = 'context: small | isSmall: true | isLarge: false'
-    expect(wrapper.find('div').text()).toEqual(expected)
+    screen.getByText('context: small | isSmall: true | isLarge: false')
   })
 
   it('Should provide "large" value when screen is above `responsiveBreakpoints.small`', () => {
     mockWindowInnerWidth(900)
-    const wrapper = mount(
+    render(
       <MediaSizeProvider>
         <ChildComponent />
       </MediaSizeProvider>,
     )
-
-    const expected = 'context: large | isSmall: false | isLarge: true'
-    expect(wrapper.find('div').text()).toEqual(expected)
+    screen.getByText('context: large | isSmall: false | isLarge: true')
   })
 
   it('Should provide "small" when no provider', () => {
     mockWindowInnerWidth(900)
-    const wrapper = mount(<ChildComponent />)
-
-    const expected = 'context: small | isSmall: true | isLarge: false'
-    expect(wrapper.find('div').text()).toEqual(expected)
+    render(<ChildComponent />)
+    screen.getByText('context: small | isSmall: true | isLarge: false')
   })
 
   it('Should respect the mediaSizeForTestsOnly override`', () => {
     mockWindowInnerWidth(300)
-    const wrapper = mount(
+    render(
       <MediaSizeProvider mediaSizeForTestsOnly={MediaSize.LARGE}>
         <ChildComponent />
       </MediaSizeProvider>,
     )
-
-    const expected = 'context: large | isSmall: false | isLarge: true'
-    expect(wrapper.find('div').text()).toEqual(expected)
+    screen.getByText('context: large | isSmall: false | isLarge: true')
   })
 })


### PR DESCRIPTION
## Description

- Fix initial flickering using useLayoutEffect (sync before first render) instead of useEffect (async)
- Introduce new serverSideMediaSize attribute to have a better media size default for server side rendered cases.
- Fix unsubscribing from debounced listener
- RTL tests

## TESTED
Unit tests, locally in kairos