### PR TITLE
Release/45.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Unreleased
 
+[...]
+
+# v45.2.0 (21/01/2021)
 - **[FIX]** Fix `MediaSizeProvider` first render state
 - **[NEW]** New serverSideMediaSize attribute for `MediaSizeProvider`
-[...]
 
 # v45.1.0 (20/01/2021)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "45.1.0",
+  "version": "45.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "45.1.0",
+  "version": "45.2.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Description

# v45.2.0 (21/01/2021)
- **[FIX]** Fix `MediaSizeProvider` first render state
- **[NEW]** New serverSideMediaSize attribute for `MediaSizeProvider`