### PR TITLE
Fix `ItemChoice` addons types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Fix `leftAddon` and `rightAddon` types on `ItemChoice` to allow strings
 [...]
 
 # v45.1.0 (20/01/2021)

--- a/src/itemChoice/ItemChoice.tsx
+++ b/src/itemChoice/ItemChoice.tsx
@@ -24,8 +24,8 @@ export type ItemChoiceProps = A11yProps &
     labelInfo?: React.ReactNode
     data?: string
     dataInfo?: string
-    leftAddon?: JSX.Element
-    rightAddon?: JSX.Element
+    leftAddon?: React.ReactNode
+    rightAddon?: React.ReactNode
     className?: string
     href?: string | JSX.Element
     status?: ItemStatus


### PR DESCRIPTION
## Description

Now matching `Item` types and allow strings
