### PR TITLE
Releases/46.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Unreleased
 
+[...]
+
+# v46.0.0 (26/01/2021)
+
 - **[BREAKING CHANGE]** Remove default exports
 - **[FIX]** Fix `leftAddon` and `rightAddon` types on `ItemChoice` to allow strings
-[...]
 
 # v45.2.0 (21/01/2021)
 - **[FIX]** Fix `MediaSizeProvider` first render state

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "45.2.0",
+  "version": "46.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "45.2.0",
+  "version": "46.0.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# v46.0.0 (26/01/2021)

- **[BREAKING CHANGE]** Remove default exports
- **[FIX]** Fix `leftAddon` and `rightAddon` types on `ItemChoice` to allow strings
