### PR TITLE
Releases/47.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Unreleased
 
+[...]
+
+# v47.0.0 (02/02/2021)
+
 - **[BREAKING CHANGE]** New `illustration` prop replacing `image` in `EmptyState`
 - **[BREAKING CHANGE]** New `illustration` prop replacing `imageSrc`, `imageText` in `SuccessModal`
 - **[BREAKING CHANGE]** New `illustration` prop replacing `illustrationUrl`, `illustrationAlt`, `isAvatar` in `IllustratedSection`
 - **[UPDATE]** `Storybook` version `6.1.15`
-[...]
 
 # v46.2.0 (01/02/2021)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "46.2.0",
+  "version": "47.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "46.2.0",
+  "version": "47.0.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# v47.0.0 (02/02/2021)

- **[BREAKING CHANGE]** New `illustration` prop replacing `image` in `EmptyState`
- **[BREAKING CHANGE]** New `illustration` prop replacing `imageSrc`, `imageText` in `SuccessModal`
- **[BREAKING CHANGE]** New `illustration` prop replacing `illustrationUrl`, `illustrationAlt`, `isAvatar` in `IllustratedSection`
- **[UPDATE]** `Storybook` version `6.1.15`