### PR TITLE
update style and story to match use case

### DIFF
--- a/src/marquee/Marquee.story.mdx
+++ b/src/marquee/Marquee.story.mdx
@@ -1,6 +1,6 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks'
 
-import { Paragraph } from '../paragraph'
+import { TripCardSample } from '../tripCardSample'
 import { Marquee } from './index'
 
 <Meta title="Widgets/Marquee" />
@@ -10,11 +10,9 @@ import { Marquee } from './index'
 <Canvas>
   <Story name="Default">
     <Marquee>
-      <div>Lists and loops</div>
-      <div>through all children</div>
-      <div>regardless of their number</div>
-      <div>or their type</div>
-      <Paragraph>(here, a Paragraph)</Paragraph>
+      <TripCardSample departure="Ajaccio" arrival="Amsterdam" priceLabel="from" price="€90" />
+      <TripCardSample departure="London" arrival="Manchester" priceLabel="from" price="€10" />
+      <TripCardSample departure="London" arrival="Paris" priceLabel="from" price="€50" />
     </Marquee>
   </Story>
 </Canvas>
@@ -27,8 +25,8 @@ Simple component that loops through the children it is given and has them slide 
 ```jsx
 import { Marquee } from '@blablacar/ui-library/build/marquee'
 <Marquee className="optional">
-  <div>div</div>
-  <Paragraph>Paragraph</Paragraph>
+  <div>child</div>
+  <div>child</div>
 </Marquee>
 ```
 

--- a/src/marquee/Marquee.style.tsx
+++ b/src/marquee/Marquee.style.tsx
@@ -1,5 +1,7 @@
 import styled from 'styled-components'
 
+import { normalizeHorizontally, NormalizeProps } from '../layout/layoutNormalizer'
+
 // Total animation duration:
 // 3400ms fully visible + 320ms slideInOut
 const animationDuration = 3720
@@ -12,10 +14,13 @@ export const StyledMarquee = styled.ul`
   }
 `
 
-export const StyledMarqueeItem = styled.li<{
-  position: number
-  totalItems: number
-}>`
+type MarqueeItemProps = NormalizeProps &
+  Readonly<{
+    position: number
+    totalItems: number
+  }>
+
+export const StyledMarqueeItem = styled.li<MarqueeItemProps>`
   /* animation steps defined by how many items are passed */
   @keyframes slideInOutWait {
     0% {
@@ -54,4 +59,6 @@ export const StyledMarqueeItem = styled.li<{
   animation-duration: ${props => `${animationDuration * props.totalItems}ms`};
   animation-iteration-count: infinite;
   animation-delay: ${props => `${animationDuration * props.position}ms`};
+  width: 100%;
+  ${normalizeHorizontally};
 `


### PR DESCRIPTION

![Screen Shot 2021-02-04 at 17 39 06](https://user-images.githubusercontent.com/373381/106924980-efc88b80-670f-11eb-8b08-305e6040ab9c.png)


Fixed horizontal spacing to match Paragraph, SubHeader, etc.

## Things to consider
I had to paste the style for "normalizeHorizontally" cause it conflicted with the styled component's props

## How it was tested

Tested on Firefox MacOS, storybook and canary
