### PR TITLE
[boyscout] Update SubHeader stories to play with `text`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [...]
 
+- **[UPDATE]** Typographic elmements get `pre` formating
+
 # v47.1.0 (05/02/2021)
 
 - **[NEW]** Add `Marquee`

--- a/src/layout/section/mediaContentSection/__snapshots__/MediaContentSection.unit.tsx.snap
+++ b/src/layout/section/mediaContentSection/__snapshots__/MediaContentSection.unit.tsx.snap
@@ -321,6 +321,7 @@ exports[`MediaContentSection should render default MediaContentSection section 1
 }
 
 .c4 {
+  white-space: pre-line;
   color: #054752;
   font-size: 30px;
   line-height: 1.06;
@@ -773,6 +774,7 @@ exports[`MediaContentSection should render flipped MediaContentSection section 1
 }
 
 .c4 {
+  white-space: pre-line;
   color: #054752;
   font-size: 30px;
   line-height: 1.06;

--- a/src/review/__snapshots__/Review.unit.tsx.snap
+++ b/src/review/__snapshots__/Review.unit.tsx.snap
@@ -129,6 +129,7 @@ Array [
 }
 
 .c2 {
+  white-space: pre-line;
   color: #054752;
   font-size: 18px;
   font-weight: 400;
@@ -350,6 +351,7 @@ Array [
 }
 
 .c2 {
+  white-space: pre-line;
   color: #054752;
   font-size: 18px;
   font-weight: 400;

--- a/src/subHeader/SubHeader.story.mdx
+++ b/src/subHeader/SubHeader.story.mdx
@@ -1,4 +1,5 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks'
+import { text } from '@storybook/addon-knobs'
 
 import { SubHeader } from './index'
 
@@ -8,7 +9,7 @@ import { SubHeader } from './index'
 
 <Canvas>
   <Story name="Default">
-    <SubHeader>SubHeader Title</SubHeader>
+    <SubHeader>{text('children', 'SubHeader Title')}</SubHeader>
   </Story>
 </Canvas>
 
@@ -19,9 +20,9 @@ import { SubHeader } from './index'
 Use it to categorize groups of information.
 Also used to give existing rides and bookings a date and chronological context.
 
- - Max 2 lines of text
- - Not clickable
- - Can be a sticky header
+- Max 2 lines of text
+- Not clickable
+- Can be a sticky header
 
 This component can appear as a sticky date separator on search results feed.
 
@@ -36,7 +37,7 @@ In which case it should stick to the top of the page while scrolling.
 ```jsx
 import { SubHeader } from '@blablacar/ui-library/build/subHeader'
 
-<SubHeader>SubHeader Title</SubHeader>
+;<SubHeader>SubHeader Title</SubHeader>
 ```
 
 <ArgsTable of={SubHeader} />

--- a/src/typography/Text.tsx
+++ b/src/typography/Text.tsx
@@ -5,9 +5,18 @@ import { replaceNewLineWithBR } from '../_utils'
 export type TextProps = Readonly<{
   className?: string
   children: string | ReactNode
-  isInverted?: boolean // Switch colors based on backgournd
-  isDisabled?: boolean // Ligthen the text color to emphasis on disabled state
-  itemProp?: string // Allows microdata annotation on Text
+  /**
+   * Switch colors based on backgournd
+   */
+  isInverted?: boolean
+  /**
+   * Ligthen the text color to emphasis on disabled state
+   * */
+  isDisabled?: boolean
+  /**
+   * Allows microdata annotation on Text
+   */
+  itemProp?: string
 }>
 
 export const Text = ({ children, className, isInverted, isDisabled, ...props }: TextProps) => {

--- a/src/typography/index.tsx
+++ b/src/typography/index.tsx
@@ -4,6 +4,8 @@ import { color } from '../_utils/branding'
 import { Text } from './Text'
 
 const StyledText = styled(Text)`
+  white-space: pre-line;
+
   & {
     color: ${props => (props.isInverted ? color.white : '')};
   }

--- a/src/typography/subHeader/SubHeader.story.mdx
+++ b/src/typography/subHeader/SubHeader.story.mdx
@@ -1,24 +1,28 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks'
+import { text } from '@storybook/addon-knobs'
 
 import { color } from '../../_utils/branding'
 import { TextSubHeader } from '.'
 
-<Meta title="Design Tokens/Typography" />
+<Meta title="Design Tokens/Typography/TextSubHeader" />
 
 # **TextSubHeader**
 
 <Canvas>
-  <Story name="TextSubHeader">
-    <React.Fragment>
-      <h1>
-        <TextSubHeader isInverted={false}>
-          {'The quick\n brown fox jumps\n over the lazy\n dog'}
-        </TextSubHeader>
-      </h1>
-      <h1 style={{ backgroundColor: color.blue }}>
-        <TextSubHeader isInverted>The quick brown fox jumps over the lazy dog</TextSubHeader>
-      </h1>
-    </React.Fragment>
+  <Story name="Default">
+    <TextSubHeader isInverted={false} as="h1">
+      {text('children', 'The quick\n brown fox jumps\n over the lazy\n dog')}
+    </TextSubHeader>
+  </Story>
+</Canvas>
+
+### **isInverted**
+
+<Canvas>
+  <Story name="isInverted">
+    <h1 style={{ backgroundColor: color.blue }}>
+      <TextSubHeader isInverted>The quick brown fox jumps over the lazy dog</TextSubHeader>
+    </h1>
   </Story>
 </Canvas>
 


### PR DESCRIPTION
## Description

<!-- Give some context of this PR. Illustrate with screenshots or a video (gif, loom, etc.) -->

![Screenshot 2021-02-05 at 16 15 56](https://user-images.githubusercontent.com/2952998/107057625-f7e9ff00-67d3-11eb-949a-a7fe040b6a6f.png)

![Screenshot 2021-02-05 at 16 15 45](https://user-images.githubusercontent.com/2952998/107057646-fcaeb300-67d3-11eb-9389-31d9ff7d85a1.png)


## What has been done

<!-- How do you solve the problem? -->
- use knobs `text`
- split stories

## Things to consider

<!-- Explain your changes. What are you expecting for the reviewers? -->
-  Update text components to take `\n` into account

## How it was tested

<!-- Local environment with ui-library only, integrated within the main project, on which browsers, etc. -->
- SB
