### PR TITLE
Release/v47.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [...]
 
+# v47.1.0 (07/02/2021)
+
 - **[NEW]** `SeaPage` holds SEA Page layout
 - **[UPDATE]** Typographic elmements get `pre` formating
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 [...]
 
-# v47.1.0 (07/02/2021)
+# v47.2.0 (08/02/2021)
 
 - **[NEW]** `SeaPage` holds SEA Page layout
 - **[UPDATE]** Typographic elmements get `pre` formating

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "47.1.0",
+  "version": "47.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "47.1.0",
+  "version": "47.2.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Description

<!-- Give some context of this PR. Illustrate with screenshots or a video (gif, loom, etc.) -->

## v47.1.0 (07/02/2021)

- **[NEW]** `SeaPage` holds SEA Page layout
- **[UPDATE]** Typographic elmements get `pre` formating


