### PR TITLE
Export FilterBarSupplyInfo type from FilterBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 [...]
+- **[UPDATE]** Export `FilterBarSupplyInfo` type from `FilterBar`
 
 # v47.2.0 (08/02/2021)
 

--- a/src/filterBar/FilterBar.tsx
+++ b/src/filterBar/FilterBar.tsx
@@ -11,16 +11,18 @@ import {
   StyledSupplyInfoItem,
 } from './FilterBar.style'
 
+export type FilterBarSupplyInfo = {
+  icon: React.ElementType
+  iconTitle: string
+  liquidity: React.ReactNode
+  ariaLabel: string
+  isDisabled?: boolean
+}
+
 export type FilterBarProps = Readonly<{
   ctaText: string
   onClick: (event: React.MouseEvent<HTMLElement>) => void
-  supplyInfo: Array<{
-    icon: React.ElementType
-    iconTitle: string
-    liquidity: number
-    ariaLabel: string
-    isDisabled?: boolean
-  }>
+  supplyInfo: Array<FilterBarSupplyInfo>
   isLoading?: boolean
 }>
 


### PR DESCRIPTION
## Description

Export `FilterBarSupplyInfo` type and make `liquidity` more generic.