### PR TITLE
add a11y to DropdownButton and HamburgerButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - **[UPDATE]** Normalize `SelectField` vertically and horizontally
 - **[UPDATE]** Normalize `TextField` vertically and horizontally
 - **[UPDATE]** Export `FilterBarSupplyInfo` type from `FilterBar`
+- **[UPDATE]** Add A11Y props to `DropdownButton`
+[...]
 
 # v47.2.0 (08/02/2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - **[UPDATE]** Normalize `SelectField` vertically and horizontally
 - **[UPDATE]** Normalize `TextField` vertically and horizontally
 - **[UPDATE]** Export `FilterBarSupplyInfo` type from `FilterBar`
-- **[UPDATE]** Add A11Y props to `DropdownButton`
+- **[UPDATE]** Add A11Y props to `DropdownButton` & `HamburgerButton`
 [...]
 
 # v47.2.0 (08/02/2021)

--- a/src/dropdownButton/DropdownButton.story.mdx
+++ b/src/dropdownButton/DropdownButton.story.mdx
@@ -4,7 +4,7 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks'
 import { Avatar } from '../avatar'
 import { DropdownButton } from './index'
 
-<Meta title="Forms/DropdownButton" />
+<Meta title="Widgets/DropdownButton" />
 
 # **DropdownButton**
 

--- a/src/dropdownButton/DropdownButton.story.mdx
+++ b/src/dropdownButton/DropdownButton.story.mdx
@@ -4,7 +4,7 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks'
 import { Avatar } from '../avatar'
 import { DropdownButton } from './index'
 
-<Meta title="Widgets/DropdownButton" />
+<Meta title="Menu/DropdownButton" />
 
 # **DropdownButton**
 
@@ -23,9 +23,9 @@ import { DropdownButton } from './index'
 
 ```jsx
 import { DropdownButton } from '@blablacar/ui-library/build/DropdownButton'
-  <DropdownButton onClick={action('onClick')} open={false}>
-    <Avatar />
-  </DropdownButton>
+<DropdownButton onClick={action('onClick')} open={false}>
+  <Avatar />
+</DropdownButton>
 ```
 
 <ArgsTable of={DropdownButton} />

--- a/src/dropdownButton/DropdownButton.tsx
+++ b/src/dropdownButton/DropdownButton.tsx
@@ -9,7 +9,7 @@ import { StyledDropdownButton } from './DropdownButton.style'
 export type DropdownButtonProps = A11yProps &
   Readonly<{
     onClick: (event: React.MouseEvent<HTMLElement>) => void
-    children: JSX.Element | string
+    children: React.ReactNode
     open?: boolean
     className?: string
     iconPosition?: 'left' | 'right'

--- a/src/dropdownButton/DropdownButton.tsx
+++ b/src/dropdownButton/DropdownButton.tsx
@@ -2,37 +2,38 @@ import React from 'react'
 import cc from 'classcat'
 
 import { color } from '../_utils/branding'
+import { A11yProps, pickA11yProps } from '../_utils/interfaces'
 import { ChevronIcon } from '../icon/chevronIcon'
 import { StyledDropdownButton } from './DropdownButton.style'
 
-export type DropdownButtonProps = Readonly<{
-  onClick: (event: React.MouseEvent<HTMLElement>) => void
-  children: JSX.Element | string
-  open?: boolean
-  className?: string
-  iconPosition?: 'left' | 'right'
-}>
+export type DropdownButtonProps = A11yProps &
+  Readonly<{
+    onClick: (event: React.MouseEvent<HTMLElement>) => void
+    children: JSX.Element | string
+    open?: boolean
+    className?: string
+    iconPosition?: 'left' | 'right'
+  }>
 
-export const DropdownButton = ({
-  open = false,
-  children,
-  onClick,
-  className = '',
-  iconPosition = 'right',
-}: DropdownButtonProps) => (
-  <StyledDropdownButton
-    className={cc([
-      'kirk-dropdownButton',
-      {
-        'kirk-dropdownButton--open': open,
-      },
-      className,
-    ])}
-  >
-    <button aria-expanded={open} type="button" onClick={onClick}>
-      {iconPosition === 'left' && <ChevronIcon iconColor={color.lightMidnightGreen} down />}
-      {children}
-      {iconPosition === 'right' && <ChevronIcon iconColor={color.lightMidnightGreen} down />}
-    </button>
-  </StyledDropdownButton>
-)
+export const DropdownButton = (props: DropdownButtonProps) => {
+  const { open = false, children, onClick, className = '', iconPosition = 'right' } = props
+  const a11yAttrs = pickA11yProps<DropdownButtonProps>(props)
+
+  return (
+    <StyledDropdownButton
+      className={cc([
+        'kirk-dropdownButton',
+        {
+          'kirk-dropdownButton--open': open,
+        },
+        className,
+      ])}
+    >
+      <button {...a11yAttrs} aria-expanded={open} type="button" onClick={onClick}>
+        {iconPosition === 'left' && <ChevronIcon iconColor={color.lightMidnightGreen} down />}
+        {children}
+        {iconPosition === 'right' && <ChevronIcon iconColor={color.lightMidnightGreen} down />}
+      </button>
+    </StyledDropdownButton>
+  )
+}

--- a/src/hamburgerButton/HamburgerButton.story.mdx
+++ b/src/hamburgerButton/HamburgerButton.story.mdx
@@ -2,7 +2,7 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks'
 
 import { HamburgerButton } from './index'
 
-<Meta title="Widgets/HamburgerButton" />
+<Meta title="Menu/HamburgerButton" />
 
 # **HamburgerButton**
 
@@ -18,7 +18,6 @@ import { HamburgerButton } from './index'
 
 ```jsx
 import { HamburgerButton } from '@blablacar/ui-library/build/hamburgerButton'
-
 <HamburgerButton onClick={() => null} open={false} />
 ```
 

--- a/src/hamburgerButton/HamburgerButton.tsx
+++ b/src/hamburgerButton/HamburgerButton.tsx
@@ -1,16 +1,28 @@
 import React from 'react'
 import cc from 'classcat'
 
+import { A11yProps, pickA11yProps } from '../_utils/interfaces'
 import { StyledHamburgerButton } from './HamburgerButton.style'
 
-export type HamburgerButtonProps = Readonly<{
-  onClick: (event: React.MouseEvent<HTMLElement>) => void
-  open?: boolean
-  className?: string
-}>
+export type HamburgerButtonProps = A11yProps &
+  Readonly<{
+    onClick: (event: React.MouseEvent<HTMLElement>) => void
+    open?: boolean
+    className?: string
+  }>
 
-export const HamburgerButton = ({ open = false, onClick, className }: HamburgerButtonProps) => (
-  <StyledHamburgerButton className={cc([className])} aria-expanded={open} onClick={onClick}>
-    <i />
-  </StyledHamburgerButton>
-)
+export const HamburgerButton = (props: HamburgerButtonProps) => {
+  const { open = false, onClick, className } = props
+  const a11yAttrs = pickA11yProps<HamburgerButtonProps>(props)
+
+  return (
+    <StyledHamburgerButton
+      className={cc([className])}
+      {...a11yAttrs}
+      aria-expanded={open}
+      onClick={onClick}
+    >
+      <i />
+    </StyledHamburgerButton>
+  )
+}

--- a/src/menu/Menu.story.mdx
+++ b/src/menu/Menu.story.mdx
@@ -11,7 +11,7 @@ import { ItemChoice, ItemChoiceStatus } from '../itemChoice'
 import { Text } from '../text'
 import { Menu } from './index'
 
-<Meta title="Widgets/Menu" />
+<Meta title="Menu/Menu" />
 
 # **Menu**
 
@@ -71,7 +71,6 @@ import { Menu } from './index'
 
 ```jsx
 import { Menu } from '@blablacar/ui-library/build/menu'
-
 <Menu>
   <ItemChoice label="Rides booked" leftAddon={<TicketIcon />} href="#" />
   <ItemChoice label="Messages" leftAddon={<BubbleIcon />} href="#" />


### PR DESCRIPTION
Added A11Y props to DropdownButton. I will need to add a dropdown that toggle a menu with 2 items, Login & Signup.
I want this dropdown to read something like "Connect" with screen readers but right now the API doesn't allow for this.

I also moved the DropdownButton out of the "Forms" category back to "Widgets" as it feels more appropriate regarding the way we use it.

Tested locally on Firefox MacOS with VoiceOver and a canary release.