### PR TITLE
make Avatar isSmall smaller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 [...]
+- **[UPDATE]** Change size of `<Avatar isSmall />`
 
 # v47.4.0 (11/02/2021)
 

--- a/src/avatar/Avatar.style.tsx
+++ b/src/avatar/Avatar.style.tsx
@@ -11,8 +11,8 @@ export const StyledAvatar = styled.div`
   height: 48px;
 
   &.kirk-avatar--small {
-    height: 40px;
-    width: 40px;
+    height: 24px;
+    width: 24px;
   }
 
   &.kirk-avatar--medium {

--- a/src/layout/section/illustratedSection/__snapshots__/IllustratedSection.unit.tsx.snap
+++ b/src/layout/section/illustratedSection/__snapshots__/IllustratedSection.unit.tsx.snap
@@ -11,8 +11,8 @@ exports[`IllustratedSection should render an IllustratedSection section with an 
 }
 
 .c2.kirk-avatar--small {
-  height: 40px;
-  width: 40px;
+  height: 24px;
+  width: 24px;
 }
 
 .c2.kirk-avatar--medium {

--- a/src/messagingSummaryItem/__snapshots__/MessagingSummaryItem.unit.tsx.snap
+++ b/src/messagingSummaryItem/__snapshots__/MessagingSummaryItem.unit.tsx.snap
@@ -31,8 +31,8 @@ exports[`Should render properly with read messages 1`] = `
 }
 
 .c2.kirk-avatar--small {
-  height: 40px;
-  width: 40px;
+  height: 24px;
+  width: 24px;
 }
 
 .c2.kirk-avatar--medium {
@@ -457,8 +457,8 @@ exports[`Should render properly with unread messages 1`] = `
 }
 
 .c2.kirk-avatar--small {
-  height: 40px;
-  width: 40px;
+  height: 24px;
+  width: 24px;
 }
 
 .c2.kirk-avatar--medium {


### PR DESCRIPTION
<Avatar isSmall /> made it 40x40px, slightly smaller than the normal size of 48x48px.
The "isSmall" variant is not used in the application so now I'm presented with an Avatar the size of an icon (24x24px) I simply changed the values.

Use case:
![Screen Shot 2021-02-10 at 15 23 48](https://user-images.githubusercontent.com/373381/107522483-0c534080-6bb4-11eb-998d-ace75f572150.png)

Note that it still works with the Badge:
![Screen Shot 2021-02-10 at 15 27 38](https://user-images.githubusercontent.com/373381/107522998-926f8700-6bb4-11eb-8998-ee4be496cda8.png)


Tested locally on Firefox MacOS and storybook.