### PR TITLE
Release/v47.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [...]
 
+# v47.4.0 (11/02/2021)
+
 - **[UPDATE]** Add A11Y props to `DropdownButton` & `HamburgerButton`
 - **[FIX]** Adapt `SEAPage` to take header into account
 - **[UPDATE]** Update `SelectField` display used for `PhoneField` error state

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "47.3.0",
+  "version": "47.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "47.3.0",
+  "version": "47.4.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Description

**Release v47.3.0 to v47.4.0**
- **[UPDATE]** Add A11Y props to `DropdownButton` & `HamburgerButton`
- **[FIX]** Adapt `SEAPage` to take header into account
- **[UPDATE]** Update `SelectField` display used for `PhoneField` error state
- **[FIX]** Fix `PhoneField` error state display

## How it was tested

Canary release on Kairos
