### PR TITLE
Fix CheckCircleIcon display when it has a title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Fix `CheckCircleIcon` display when it has a title
 [...]
 
 # v47.4.1 (11/02/2021)

--- a/src/icon/checkCircleIcon.tsx
+++ b/src/icon/checkCircleIcon.tsx
@@ -35,7 +35,7 @@ const StyledCheckCircleIcon = styled(CheckCircleIcon)`
     fill: ${props => (props.iconColor ? props.iconColor : color.green)};
   }
 
-  path:nth-child(2) {
+  path + path {
     fill: ${color.white};
   }
 `


### PR DESCRIPTION
## Description

`nth-child(2)` worked as long as we didn't had a title. Otherwise, the element we wanted to style is ... third.

## What has been done

Use adjacent selector instead

## How it was tested

Kairos
