### PR TITLE
New BrandedVoice component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- **[NEW]** Add `BlueGradient` in colors
+- **[NEW]** Add `Brand` in typography
+- **[NEW]** Add `BrandedVoice` component
 [...]
 
 - **[FIX]** Remove background from `SEA Pages`

--- a/src/_internals/colors.story.mdx
+++ b/src/_internals/colors.story.mdx
@@ -4,7 +4,7 @@ import { color, gradientColors } from '../_utils/branding'
 
 <Meta title="Design Tokens/Colors" />
 
-# Fixed colors
+# Flat colors
 
 <ColorPalette>
   {Object.keys(color).map(hue => (

--- a/src/_internals/colors.story.mdx
+++ b/src/_internals/colors.story.mdx
@@ -1,13 +1,21 @@
 import { ColorItem, ColorPalette, Meta } from '@storybook/addon-docs/blocks'
 
-import { color } from '../_utils/branding'
+import { color, gradientColors } from '../_utils/branding'
 
 <Meta title="Design Tokens/Colors" />
 
-# Colors
+# Fixed colors
 
 <ColorPalette>
   {Object.keys(color).map(hue => (
     <ColorItem title={hue} subtitle={`color.${hue}`} colors={[color[hue]]} />
+  ))}
+</ColorPalette>
+
+# Gradient colors
+
+<ColorPalette>
+  {Object.keys(gradientColors).map(hue => (
+    <ColorItem title={hue} subtitle={`gradientColors.${hue}`} colors={[gradientColors[hue]]} />
   ))}
 </ColorPalette>

--- a/src/_utils/branding.ts
+++ b/src/_utils/branding.ts
@@ -22,6 +22,10 @@ export const color: Color = {
   tapHighlight: 'rgba(221, 221, 221, .4)', // gray, 40%
 }
 
+export const gradientColors = {
+  blueGradient: `linear-gradient(80.19deg, ${color.boostBlue} 4.92%, ${color.blue} 95.98%)`,
+}
+
 type Font = {
   [key: string]: {
     size: string
@@ -55,6 +59,10 @@ export const font: Font = {
   xl: {
     size: '30px',
     lineHeight: String(Math.floor((32 / 30) * 100) / 100),
+  },
+  brand: {
+    size: '56px',
+    lineHeight: '56px',
   },
   xxl: {
     size: '82px',

--- a/src/brandedVoice/BrandedVoice.story.mdx
+++ b/src/brandedVoice/BrandedVoice.story.mdx
@@ -1,0 +1,27 @@
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks'
+
+import { BoostIcon } from '../icon/boostIcon'
+import { BrandedVoice } from './index'
+
+<Meta title="widgets/BrandedVoice" />
+
+# **BrandedVoice**
+
+<Canvas>
+  <Story name="Default">
+    <BrandedVoice label="Main text" subLabel="SubText" icon={<BoostIcon noBackground />} />
+  </Story>
+</Canvas>
+
+## Specifications
+
+## Usage
+
+```jsx
+import { BrandedVoice } from '@blablacar/ui-library/build/brandedVoice'
+import { BoostIcon } from '@blablacar/ui-library/build/icon/boostIcon'
+
+<BrandedVoice label="Main text" subLabel="SubText" icon={<BoostIcon />}/>
+```
+
+<ArgsTable of={BrandedVoice} />

--- a/src/brandedVoice/BrandedVoice.style.tsx
+++ b/src/brandedVoice/BrandedVoice.style.tsx
@@ -1,0 +1,30 @@
+import styled from 'styled-components'
+
+import { componentSizes, gradientColors, responsiveBreakpoints, space } from '../_utils/branding'
+import { normalizeHorizontally } from '../layout/layoutNormalizer'
+
+export const StyledBrandedVoice = styled.div`
+  ${normalizeHorizontally};
+  background: ${gradientColors.blueGradient};
+  padding-top: ${space.l};
+  padding-bottom: ${space.xl};
+`
+
+export const StyledWrapper = styled.div`
+  display: flex;
+
+  @media (${responsiveBreakpoints.isMediaLarge}) {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: ${componentSizes.smallSectionWidth};
+  }
+`
+
+export const StyledIcon = styled.div`
+  margin: ${space.s} ${space.s} 0 0;
+`
+
+export const StyledContent = styled.div`
+  display: flex;
+  flex-direction: column;
+`

--- a/src/brandedVoice/BrandedVoice.tsx
+++ b/src/brandedVoice/BrandedVoice.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+
+import { TextBrand } from '../typography/brand'
+import { TextSubHeader } from '../typography/subHeader'
+import { StyledBrandedVoice, StyledContent, StyledIcon, StyledWrapper } from './BrandedVoice.style'
+
+// Should we consider having icon sizes in branding?
+const BRANDED_VOICE_ICON_SIZE = 40
+
+export type BrandedVoiceProps = Readonly<{
+  label: string
+  subLabel: string
+  icon: JSX.Element
+}>
+
+export const BrandedVoice = ({ label, subLabel, icon }: BrandedVoiceProps) => (
+  <StyledBrandedVoice>
+    <StyledWrapper>
+      <StyledIcon>
+        {React.cloneElement(icon, { ...icon.props, size: BRANDED_VOICE_ICON_SIZE })}
+      </StyledIcon>
+      <StyledContent>
+        <TextBrand isInverted>{label}</TextBrand>
+        <TextSubHeader>{subLabel}</TextSubHeader>
+      </StyledContent>
+    </StyledWrapper>
+  </StyledBrandedVoice>
+)

--- a/src/brandedVoice/BrandedVoice.unit.tsx
+++ b/src/brandedVoice/BrandedVoice.unit.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+import { render, screen } from '@testing-library/react'
+
+import { BoostIcon } from '../icon/boostIcon'
+import { BrandedVoice } from './BrandedVoice'
+
+describe('BrandedVoice', () => {
+  it('should render the content', () => {
+    render(
+      <BrandedVoice label="Main label" subLabel="Sub label" icon={<BoostIcon title="Boost" />} />,
+    )
+
+    expect(screen.getByText('Main label')).toBeInTheDocument()
+    expect(screen.getByText('Sub label')).toBeInTheDocument()
+    expect(screen.getByText('Boost')).toBeInTheDocument()
+  })
+})

--- a/src/brandedVoice/index.tsx
+++ b/src/brandedVoice/index.tsx
@@ -1,0 +1,1 @@
+export { BrandedVoice, BrandedVoiceProps } from './BrandedVoice'

--- a/src/icon/boostIcon.tsx
+++ b/src/icon/boostIcon.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
+import styled from 'styled-components'
 
-import { color } from '../_utils/branding'
+import { color, gradientColors } from '../_utils/branding'
 import { BaseIcon, BaseIconDefaultProps, Icon } from '../_utils/icon'
 
 export type BoostIconProps = Icon &
@@ -8,31 +9,20 @@ export type BoostIconProps = Icon &
     noBackground?: boolean
   }>
 
-export const BoostIcon = ({ noBackground, ...props }: BoostIconProps) => (
+export const BaseBoostIcon = ({ noBackground, ...props }: BoostIconProps) => (
   <BaseIcon {...props}>
-    <g>
-      <circle cx="12" cy="12" r="11" fill={noBackground ? 'transparent' : 'url(#paint0_linear)'} />
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M18.105 5.407a.402.402 0 01.367.12.392.392 0 01.121.367 13.196 13.196 0 01-2.896 7.59 3.019 3.019 0 01-.427 3.777L12.832 19.7l-2.122-2.102H6.83a.417.417 0 01-.428-.428v-3.898l-2.101-2.107 2.438-2.419a2.97 2.97 0 013.75-.397 12.72 12.72 0 017.616-2.942zm-4.936 5.421a1.734 1.734 0 00-2.438 0L9.514 12.05a1.726 1.726 0 002.433 2.44l1.222-1.217a1.736 1.736 0 000-2.445z"
-        fill={color.white}
-      />
-      <defs>
-        <linearGradient
-          id="paint0_linear"
-          x1="1"
-          y1="23"
-          x2="26.084"
-          y2="18.606"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop offset=".049" stopColor={color.boostBlue} />
-          <stop offset=".96" stopColor={color.blue} />
-        </linearGradient>
-      </defs>
-    </g>
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M18.105 5.407a.402.402 0 01.367.12.392.392 0 01.121.367 13.196 13.196 0 01-2.896 7.59 3.019 3.019 0 01-.427 3.777L12.832 19.7l-2.122-2.102H6.83a.417.417 0 01-.428-.428v-3.898l-2.101-2.107 2.438-2.419a2.97 2.97 0 013.75-.397 12.72 12.72 0 017.616-2.942zm-4.936 5.421a1.734 1.734 0 00-2.438 0L9.514 12.05a1.726 1.726 0 002.433 2.44l1.222-1.217a1.736 1.736 0 000-2.445z"
+      fill={color.white}
+    />
   </BaseIcon>
 )
 
-BoostIcon.defaultProps = BaseIconDefaultProps
+BaseBoostIcon.defaultProps = BaseIconDefaultProps
+
+export const BoostIcon = styled(BaseBoostIcon)`
+  background: ${props => (props.noBackground ? '' : gradientColors.blueGradient)};
+  border-radius: 50%;
+`

--- a/src/icon/boostIcon.tsx
+++ b/src/icon/boostIcon.tsx
@@ -3,10 +3,15 @@ import React from 'react'
 import { color } from '../_utils/branding'
 import { BaseIcon, BaseIconDefaultProps, Icon } from '../_utils/icon'
 
-export const BoostIcon = (props: Icon) => (
+export type BoostIconProps = Icon &
+  Readonly<{
+    noBackground?: boolean
+  }>
+
+export const BoostIcon = ({ noBackground, ...props }: BoostIconProps) => (
   <BaseIcon {...props}>
     <g>
-      <circle cx="12" cy="12" r="11" fill="url(#paint0_linear)" />
+      <circle cx="12" cy="12" r="11" fill={noBackground ? 'transparent' : 'url(#paint0_linear)'} />
       <path
         fillRule="evenodd"
         clipRule="evenodd"

--- a/src/typography/brand/Brand.story.mdx
+++ b/src/typography/brand/Brand.story.mdx
@@ -1,24 +1,28 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks'
+import { text } from '@storybook/addon-knobs'
 
 import { color } from '../../_utils/branding'
 import { TextBrand } from '.'
 
-<Meta title="Design Tokens/Typography" />
+<Meta title="Design Tokens/Typography/TextBrand" />
 
 # **TextBrand**
 
 <Canvas>
-  <Story name="TextBrand">
-    <React.Fragment>
-      <h1>
-        <TextBrand isInverted={false}>
-          {'The quick\n brown fox jumps\n over the lazy\n dog'}
-        </TextBrand>
-      </h1>
-      <h1 style={{ backgroundColor: color.blue }}>
-        <TextBrand isInverted>The quick brown fox jumps over the lazy dog</TextBrand>
-      </h1>
-    </React.Fragment>
+  <Story name="Default">
+    <TextBrand isInverted={false} as="h1">
+      {text('children', 'The quick\n brown fox jumps\n over the lazy\n dog')}
+    </TextBrand>
+  </Story>
+</Canvas>
+
+### **isInverted**
+
+<Canvas>
+  <Story name="isInverted">
+    <h1 style={{ backgroundColor: color.blue }}>
+      <TextBrand isInverted>{text('children', 'The quick brown fox jumps over the lazy dog')}</TextBrand>
+    </h1>
   </Story>
 </Canvas>
 

--- a/src/typography/brand/Brand.story.mdx
+++ b/src/typography/brand/Brand.story.mdx
@@ -1,0 +1,33 @@
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks'
+
+import { color } from '../../_utils/branding'
+import { TextBrand } from '.'
+
+<Meta title="Design Tokens/Typography" />
+
+# **TextBrand**
+
+<Canvas>
+  <Story name="TextBrand">
+    <React.Fragment>
+      <h1>
+        <TextBrand isInverted={false}>
+          {'The quick\n brown fox jumps\n over the lazy\n dog'}
+        </TextBrand>
+      </h1>
+      <h1 style={{ backgroundColor: color.blue }}>
+        <TextBrand isInverted>The quick brown fox jumps over the lazy dog</TextBrand>
+      </h1>
+    </React.Fragment>
+  </Story>
+</Canvas>
+
+## Usage
+
+```jsx
+import { TextBrand } from '@blablacar/ui-library/build/typography/brand'
+
+<TextBrand>The quick brown fox jumps over the lazy dog</TextBrand>
+```
+
+<ArgsTable of={TextBrand} />

--- a/src/typography/brand/Brand.style.tsx
+++ b/src/typography/brand/Brand.style.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components'
+
+import { color, font, fontWeight } from '../../_utils/branding'
+import { Text } from '../index'
+
+export const TextBrand = styled(Text)`
+  color: ${color.midnightGreen};
+  font-size: ${font.brand.size};
+  font-weight: ${fontWeight.medium};
+  line-height: ${font.brand.lineHeight};
+`

--- a/src/typography/brand/index.tsx
+++ b/src/typography/brand/index.tsx
@@ -1,0 +1,1 @@
+export { TextBrand } from './Brand.style'

--- a/src/typography/typography.story.mdx
+++ b/src/typography/typography.story.mdx
@@ -3,6 +3,7 @@ import { Meta } from '@storybook/addon-docs/blocks'
 import { space } from '../_utils/branding'
 import { TextBody } from './body'
 import { TextBodyStrong } from './bodyStrong'
+import { TextBrand } from './brand'
 import { TextCaption } from './caption'
 import { TextDisplay1 } from './display1'
 import { TextDisplay2 } from './display2'
@@ -23,14 +24,22 @@ import { TextTitleStrong } from './titleStrong'
       Medium 82px <br /> Height 82px
     </TextDisplay2>
 </h1>
-  <h2 style={{ marginBottom: space.xxl }}>
+<h1 style={{ marginBottom: space.xxl }}>
+   <p style={{ marginBottom: space.s }}>
+     <TextBody>Brand</TextBody>
+   </p>
+   <TextBrand>
+     Medium 56px <br /> Height 56px
+   </TextBrand>
+</h1>
+  <h1 style={{ marginBottom: space.xxl }}>
     <p style={{ marginBottom: space.s }}>
       <TextBody>Display1</TextBody>
     </p>
     <TextDisplay1>
       Medium 30px <br /> Height 32px
     </TextDisplay1>
-</h2>
+</h1>
   <h3 style={{ marginBottom: space.xxl }}>
     <p style={{ marginBottom: space.s }}>
       <TextBody>SubHeader</TextBody>
@@ -99,6 +108,11 @@ _Text Components_ are text based components.
 ```js
 import { TextBody } from './typography/body'
 <TextBody>The quick brown fox jumps over the lazy dog</TextBody>
+```
+
+```js
+import { TextBrand } from './typography/brand'
+<TextBrand>The quick brown fox jumps over the lazy dog</TextBrand>
 ```
 
 ```js


### PR DESCRIPTION
## Description

- **[NEW]** Add `BrandedVoice` component
- **[NEW]** Add `BlueGradient` in colors
- **[NEW]** Add `Brand` in typography

On small media:
<img width="377" alt="Capture d’écran 2021-02-16 à 13 38 43" src="https://user-images.githubusercontent.com/729186/108064177-97bd4d80-705c-11eb-8f2c-690346ce411f.png">

On large media:
<img width="1123" alt="Capture d’écran 2021-02-16 à 13 38 30" src="https://user-images.githubusercontent.com/729186/108064138-8aa05e80-705c-11eb-9394-cb6f40ec1c30.png">

## What has been done

- Added `gradientColors` 

![screencapture-192-168-0-101-4000-iframe-html-2021-02-16-13_35_23](https://user-images.githubusercontent.com/729186/108064282-bae7fd00-705c-11eb-9453-d2f4bb7c3847.jpg)

- Added new `TextBrand` display in typography

![screencapture-192-168-0-101-4000-iframe-html-2021-02-16-13_37_49](https://user-images.githubusercontent.com/729186/108064341-d18e5400-705c-11eb-942b-efe609388e8f.jpg)

## Things to consider

- I couldn't find a way to introduce a size between XL & XXL for our font sizes, so I just called it `brand`. Seems like we already had the case with `base`.

```
export const font: Font = {
  s: {
    size: '13px',
    lineHeight: '16px',
  },
  base: {
    size: '16px',
    lineHeight: '20px',
  },
  m: {
    size: '18px',
    lineHeight: '20px',
  },
  l: {
    size: '22px',
    lineHeight: '24px',
  },
  xl: {
    size: '30px',
    lineHeight: String(Math.floor((32 / 30) * 100) / 100),
  },
  brand: {
    size: '56px',
    lineHeight: '56px',
  },
  xxl: {
    size: '82px',
    lineHeight: '82px',
  },
}
```

- I'll like to use the `gradientColor` inside the `BoostIcon` SVG icon... Is it possible?
- We don't have written specs for now.

## How it was tested

Storybook
