### PR TITLE
Fix SelectField and PhoneField down arrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[FIX]** Fix `SelectField` and `PhoneField` unclickable down arrow
 [...]
 
 - **[FIX]** `Icons` display on Storybook Canvas

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Unreleased
 
-- **[FIX]** Fix `SelectField` and `PhoneField` unclickable down arrow
-[...]
-
 - **[FIX]** `Icons` display on Storybook Canvas
+- **[FIX]** `SelectField` and `PhoneField` unclickable down arrow
+[...]
 
 # v47.6.0 (17/02/2021)
 

--- a/src/phoneField/PhoneField.style.tsx
+++ b/src/phoneField/PhoneField.style.tsx
@@ -62,7 +62,6 @@ export const StyledPhoneField = styled.div`
   }
 
   &.kirk-error .kirk-selectField-background,
-  &.kirk-error select,
   &.kirk-error .kirk-selectField-background .kirk-icon,
   &.kirk-error .kirk-textField-wrapper,
   &.kirk-error input {

--- a/src/phoneField/__snapshots__/PhoneField.unit.tsx.snap
+++ b/src/phoneField/__snapshots__/PhoneField.unit.tsx.snap
@@ -62,7 +62,7 @@ exports[`PhoneField should have the expected markup in the DOM with custom setti
   border: none;
   border-radius: 16px;
   cursor: pointer;
-  z-index: 0;
+  z-index: 1;
 }
 
 .c1 select::-ms-expand {
@@ -497,7 +497,6 @@ exports[`PhoneField should have the expected markup in the DOM with custom setti
 }
 
 .c0.kirk-error .kirk-selectField-background,
-.c0.kirk-error select,
 .c0.kirk-error .kirk-selectField-background .kirk-icon,
 .c0.kirk-error .kirk-textField-wrapper,
 .c0.kirk-error input {
@@ -700,7 +699,7 @@ exports[`PhoneField should have the expected markup in the DOM with default sett
   border: none;
   border-radius: 16px;
   cursor: pointer;
-  z-index: 0;
+  z-index: 1;
 }
 
 .c1 select::-ms-expand {
@@ -950,7 +949,6 @@ exports[`PhoneField should have the expected markup in the DOM with default sett
 }
 
 .c0.kirk-error .kirk-selectField-background,
-.c0.kirk-error select,
 .c0.kirk-error .kirk-selectField-background .kirk-icon,
 .c0.kirk-error .kirk-textField-wrapper,
 .c0.kirk-error input {

--- a/src/selectField/SelectField.style.tsx
+++ b/src/selectField/SelectField.style.tsx
@@ -38,7 +38,7 @@ export const StyledSelectField = styled.div`
     border: none;
     border-radius: ${radius.l};
     cursor: pointer;
-    z-index: 0;
+    z-index: 1;
   }
 
   /* Remove native select arrow on Internet Explorer 10 and 11  */

--- a/src/selectField/__snapshots__/SelectField.unit.tsx.snap
+++ b/src/selectField/__snapshots__/SelectField.unit.tsx.snap
@@ -62,7 +62,7 @@ exports[`SelectField should have the expected markup in the DOM 1`] = `
   border: none;
   border-radius: 16px;
   cursor: pointer;
-  z-index: 0;
+  z-index: 1;
 }
 
 .c0 select::-ms-expand {


### PR DESCRIPTION
## Description

Fix unclickable down arrow on `SelectField` & `PhoneField`

## Things to consider

- Keep the `<select>` tag above the `<svg>` tag (higher z-index)
- Keep the `<select>` tag transparent in case of error display to let the `<svg>` down arrow visible

## Demo
With the fix:
https://www.loom.com/share/a0333adb84af432d805beaa8d9984320

## How it was tested

Local environment with ui-library only (Chrome/FF/Safari)
