### PR TITLE
Release/v47.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Unreleased
 
+[...]
+
+# v47.6.1 (22/02/2021)
+
 - **[FIX]** `Icons` display on Storybook Canvas
 - **[FIX]** `SelectField` and `PhoneField` unclickable down arrow
-[...]
 
 # v47.6.0 (17/02/2021)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "47.6.0",
+  "version": "47.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "47.6.0",
+  "version": "47.6.1",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Description

Release v47.6.1 (22/02/2021)
- **[FIX]** `Icons` display on Storybook Canvas
- **[FIX]** `SelectField` and `PhoneField` unclickable down arrow
