### PR TITLE
Horizontal normalization on SearchRecap & UneditableTextField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - **[FIX]** Use new `Itinerary` on `Stepper` component
 - **[UPDATE]** Normalize `TextArea`
 - **[UPDATE]** Update `ItemData` `data` prop to be nullable
-- **[UPDATE]** Horizontal Normalization on `UneditableTextField` and `SearchRecap`
+- **[UPDATE]** Horizontal Normalization on `SearchRecap`
+- **[BREAKING CHANGE]** Removed `href` prop on `UneditableTextField` and Horizontal Normalization
 
 # v48.0.0 (23/02/2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **[FIX]** Use new `Itinerary` on `Stepper` component
 - **[UPDATE]** Normalize `TextArea`
 - **[UPDATE]** Update `ItemData` `data` prop to be nullable
+- **[UPDATE]** Horizontal Normalization on `UneditableTextField` and `SearchRecap`
 
 # v48.0.0 (23/02/2021)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,7 @@
 {
   "name": "@blablacar/ui-library",
   "version": "48.1.0",
+  "version": "0.0.0-fe7e7d47",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/searchRecap/SearchRecap.style.tsx
+++ b/src/searchRecap/SearchRecap.style.tsx
@@ -7,7 +7,8 @@ const separatorWidthPx = '14px'
 export const StyledSearchRecap = styled.div`
   & .kirk-uneditableTextField {
     width: 100%;
-    padding: ${space.m} ${space.l};
+    padding-top: ${space.m};
+    padding-bottom: ${space.m};
   }
 
   & .kirk-uneditableTextField .kirk-icon {

--- a/src/searchRecap/__snapshots__/SearchRecap.unit.tsx.snap
+++ b/src/searchRecap/__snapshots__/SearchRecap.unit.tsx.snap
@@ -1,27 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SearchRecap Should display searchRecap component 1`] = `
-.c2 {
+.c3 {
   fill: #708C91;
 }
 
-.c2.kirk-icon-wrapper {
+.c3.kirk-icon-wrapper {
   display: inline-block;
   position: relative;
 }
 
-.c2.kirk-icon-shadowed {
+.c3.kirk-icon-shadowed {
   border-radius: 50%;
   box-shadow: 0 0 2px rgba(0,0,0,.3);
 }
 
-.c2 .kirk-icon-badge {
+.c3 .kirk-icon-badge {
   position: absolute;
   bottom: 12px;
   left: 12px;
 }
 
-.c4 {
+.c5 {
   display: inline-block;
   padding: 0.1em 0 0;
   margin: 0 8px;
@@ -36,72 +36,79 @@ exports[`SearchRecap Should display searchRecap component 1`] = `
   flex-grow: 0;
 }
 
-.c3 {
+.c4 {
   margin: 0;
   font-weight: 400;
 }
 
-.c3.kirk-text-button {
+.c4.kirk-text-button {
   color: #054752;
   font-size: 16px;
   line-height: 20px;
 }
 
-.c3.kirk-text-body,
-.c3.kirk-text-bodyStrong {
+.c4.kirk-text-body,
+.c4.kirk-text-bodyStrong {
   color: #708C91;
   font-size: 16px;
   line-height: 20px;
 }
 
-.c3.kirk-text-caption {
+.c4.kirk-text-caption {
   color: #708C91;
   font-size: 13px;
   line-height: 16px;
 }
 
-.c3.kirk-text-title,
-.c3.kirk-text-titleStrong {
+.c4.kirk-text-title,
+.c4.kirk-text-titleStrong {
   color: #054752;
   font-size: 18px;
   line-height: 20px;
 }
 
-.c3.kirk-text-display2 {
+.c4.kirk-text-display2 {
   color: #054752;
   font-size: 82px;
   line-height: 82px;
   font-weight: 500;
 }
 
-.c3.kirk-text-display1 {
+.c4.kirk-text-display1 {
   color: #054752;
   font-size: 30px;
   line-height: 1.06;
   font-weight: 500;
 }
 
-.c3.kirk-text-subheader,
-.c3.kirk-text-subheaderStrong {
+.c4.kirk-text-subheader,
+.c4.kirk-text-subheaderStrong {
   color: #054752;
   font-size: 22px;
   line-height: 24px;
 }
 
-.c3.kirk-text-title,
-.c3.kirk-text-titleStrong {
+.c4.kirk-text-title,
+.c4.kirk-text-titleStrong {
   color: #054752;
   font-size: 18px;
   line-height: 20px;
 }
 
-.c3.kirk-text-bodyStrong,
-.c3.kirk-text-subheaderStrong,
-.c3.kirk-text-titleStrong {
+.c4.kirk-text-bodyStrong,
+.c4.kirk-text-subheaderStrong,
+.c4.kirk-text-titleStrong {
   font-weight: 500;
 }
 
 .c1 {
+  padding-left: 24px !important;
+  padding-right: 24px !important;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -121,23 +128,24 @@ exports[`SearchRecap Should display searchRecap component 1`] = `
   text-decoration: none;
 }
 
-.c1 .kirk-uneditableTextField-label:not(:first-child) {
+.c2 .kirk-uneditableTextField-label:not(:first-child) {
   margin-left: 16px;
 }
 
-.c1 .kirk-uneditableTextField-label--ellipsis {
+.c2 .kirk-uneditableTextField-label--ellipsis {
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
 }
 
-.c1 .kirk-uneditableTextField-label--placeholder {
+.c2 .kirk-uneditableTextField-label--placeholder {
   color: #708C91;
 }
 
 .c0 .kirk-uneditableTextField {
   width: 100%;
-  padding: 8px 16px;
+  padding-top: 8px;
+  padding-bottom: 8px;
 }
 
 .c0 .kirk-uneditableTextField .kirk-icon {
@@ -201,14 +209,14 @@ exports[`SearchRecap Should display searchRecap component 1`] = `
   className="kirk-searchRecap c0"
 >
   <div
-    className="kirk-uneditableTextField"
+    className="kirk-uneditableTextField c1"
   >
     <div
-      className="c1"
+      className="c2"
     >
       <svg
         aria-hidden={true}
-        className="kirk-icon c2"
+        className="kirk-icon c3"
         height={24}
         viewBox="0 0 24 24"
         width={24}
@@ -240,7 +248,7 @@ exports[`SearchRecap Should display searchRecap component 1`] = `
         className="kirk-uneditableTextField-label kirk-uneditableTextField-label--ellipsis"
       >
         <p
-          className="kirk-text kirk-text-body kirk-requestRecap-route c3"
+          className="kirk-text kirk-text-body kirk-requestRecap-route c4"
           style={
             Object {
               "color": "#054752",
@@ -255,7 +263,7 @@ exports[`SearchRecap Should display searchRecap component 1`] = `
             </span>
             <svg
               aria-hidden={true}
-              className="kirk-icon c4 c2"
+              className="kirk-icon c5 c3"
               height={24}
               viewBox="0 0 24 24"
               width={24}
@@ -285,7 +293,7 @@ exports[`SearchRecap Should display searchRecap component 1`] = `
           </span>
         </p>
         <span
-          className="kirk-text kirk-text-body kirk-requestRecap-info c3"
+          className="kirk-text kirk-text-body kirk-requestRecap-info c4"
         >
           Today 2:30pm, 2 passengers
         </span>

--- a/src/uneditableTextField/UneditableTextField.style.tsx
+++ b/src/uneditableTextField/UneditableTextField.style.tsx
@@ -1,8 +1,20 @@
+import React from 'react'
+import cc from 'classcat'
 import styled from 'styled-components'
 
 import { color, font, radius, space } from '../_utils/branding'
+import { normalizeHorizontally } from '../layout/layoutNormalizer'
 
 const inputHeight = '54px'
+
+export const StyledUneditableContainer = styled(({ componentType, className, ...props }) =>
+  React.createElement(componentType, {
+    className: cc(['kirk-uneditableTextField', className]),
+    ...props,
+  }),
+)`
+  ${normalizeHorizontally}
+`
 
 export const StyledUneditableTextField = styled.div`
   & {

--- a/src/uneditableTextField/UneditableTextField.style.tsx
+++ b/src/uneditableTextField/UneditableTextField.style.tsx
@@ -1,19 +1,12 @@
-import React from 'react'
-import cc from 'classcat'
 import styled from 'styled-components'
 
 import { color, font, radius, space } from '../_utils/branding'
-import { normalizeHorizontally } from '../layout/layoutNormalizer'
+import { normalizeHorizontally, NormalizeProps } from '../layout/layoutNormalizer'
 
 const inputHeight = '54px'
 
-export const StyledUneditableContainer = styled(({ componentType, className, ...props }) =>
-  React.createElement(componentType, {
-    className: cc(['kirk-uneditableTextField', className]),
-    ...props,
-  }),
-)`
-  ${normalizeHorizontally}
+export const StyledUneditableContainer = styled.div<NormalizeProps>`
+  ${normalizeHorizontally};
 `
 
 export const StyledUneditableTextField = styled.div`

--- a/src/uneditableTextField/UneditableTextField.tsx
+++ b/src/uneditableTextField/UneditableTextField.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import cc from 'classcat'
-import isEmpty from 'lodash.isempty'
 
 import { StyledUneditableContainer, StyledUneditableTextField } from './UneditableTextField.style'
 
@@ -8,7 +7,6 @@ export type UneditableTextFieldProps = Readonly<{
   children: JSX.Element | string
   className?: string
   addOn?: JSX.Element
-  href?: JSX.Element | string
   ellipsis?: boolean
   isPlaceholder?: boolean
 }>
@@ -18,34 +16,20 @@ export const UneditableTextField = ({
   addOn = null,
   ellipsis = false,
   isPlaceholder = false,
-  href,
-}: UneditableTextFieldProps) => {
-  let componentType
-  let props: any = {}
-  if (href && typeof href !== 'string') {
-    componentType = href.type
-    props = href.props
-  } else if (typeof href === 'string' && !isEmpty(href)) {
-    componentType = 'a'
-    props = { href }
-  } else {
-    componentType = 'div'
-  }
-
-  return (
-    <StyledUneditableContainer componentType={componentType} {...props}>
-      <StyledUneditableTextField>
-        {addOn}
-        <div
-          className={cc([
-            'kirk-uneditableTextField-label',
-            { 'kirk-uneditableTextField-label--ellipsis': ellipsis },
-            { 'kirk-uneditableTextField-label--placeholder': isPlaceholder },
-          ])}
-        >
-          {children}
-        </div>
-      </StyledUneditableTextField>
-    </StyledUneditableContainer>
-  )
-}
+  className = '',
+}: UneditableTextFieldProps) => (
+  <StyledUneditableContainer className={cc(['kirk-uneditableTextField', className])}>
+    <StyledUneditableTextField>
+      {addOn}
+      <div
+        className={cc([
+          'kirk-uneditableTextField-label',
+          { 'kirk-uneditableTextField-label--ellipsis': ellipsis },
+          { 'kirk-uneditableTextField-label--placeholder': isPlaceholder },
+        ])}
+      >
+        {children}
+      </div>
+    </StyledUneditableTextField>
+  </StyledUneditableContainer>
+)

--- a/src/uneditableTextField/UneditableTextField.tsx
+++ b/src/uneditableTextField/UneditableTextField.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import cc from 'classcat'
 import isEmpty from 'lodash.isempty'
 
-import { StyledUneditableTextField } from './UneditableTextField.style'
+import { StyledUneditableContainer, StyledUneditableTextField } from './UneditableTextField.style'
 
 export type UneditableTextFieldProps = Readonly<{
   children: JSX.Element | string
@@ -15,7 +15,6 @@ export type UneditableTextFieldProps = Readonly<{
 
 export const UneditableTextField = ({
   children,
-  className = '',
   addOn = null,
   ellipsis = false,
   isPlaceholder = false,
@@ -33,23 +32,20 @@ export const UneditableTextField = ({
     componentType = 'div'
   }
 
-  return React.createElement(
-    componentType,
-    {
-      className: cc(['kirk-uneditableTextField', className]),
-      ...props,
-    },
-    <StyledUneditableTextField>
-      {addOn}
-      <div
-        className={cc([
-          'kirk-uneditableTextField-label',
-          { 'kirk-uneditableTextField-label--ellipsis': ellipsis },
-          { 'kirk-uneditableTextField-label--placeholder': isPlaceholder },
-        ])}
-      >
-        {children}
-      </div>
-    </StyledUneditableTextField>,
+  return (
+    <StyledUneditableContainer componentType={componentType} {...props}>
+      <StyledUneditableTextField>
+        {addOn}
+        <div
+          className={cc([
+            'kirk-uneditableTextField-label',
+            { 'kirk-uneditableTextField-label--ellipsis': ellipsis },
+            { 'kirk-uneditableTextField-label--placeholder': isPlaceholder },
+          ])}
+        >
+          {children}
+        </div>
+      </StyledUneditableTextField>
+    </StyledUneditableContainer>
   )
 }

--- a/src/uneditableTextField/UneditableTextField.unit.tsx
+++ b/src/uneditableTextField/UneditableTextField.unit.tsx
@@ -69,24 +69,4 @@ describe('UneditableTextField', () => {
 
     expect(screen.getByTestId(props.addOn.props['data-testid'])).toBeInTheDocument()
   })
-
-  it('should support simple links', () => {
-    const props = createProps({ href: '#foo' })
-    render(<UneditableTextField {...props} />)
-
-    const link = screen.getByRole('link')
-    expect(link).toBeInTheDocument()
-    expect(link).toHaveAttribute('href', props.href)
-    expect(link).toHaveTextContent(props.children as string)
-  })
-
-  it('should support component links', () => {
-    const props = createProps({ href: <a href="#bar" /> })
-    render(<UneditableTextField {...props} />)
-
-    const link = screen.getByRole('link')
-    expect(link).toBeInTheDocument()
-    expect(link).toHaveAttribute('href', (props.href as JSX.Element).props.href)
-    expect(link).toHaveTextContent(props.children as string)
-  })
 })


### PR DESCRIPTION
## Description

Horizontal normalization for `SearchRecap` & `UneditableTextField`

## What has been done

- Moved `UneditableTextField` React.createElement as a styled-component so that we can add styles to it.
- Removed horizontal padding from `SearchRecap`

![image](https://user-images.githubusercontent.com/1606624/108869258-4fbb9f00-75f7-11eb-9474-82ee73ff5185.png)


## Things to consider

Checking in Kairos now

## How it was tested

In storybook
