### PR TITLE
rename HighlightSection props for improved usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 [...]
+- **[BREAKING CHANGE]** rename `HighlightSection` props
 
 # v50.0.0 (02/03/2021)
 

--- a/src/layout/section/highlightSection/HighlightSection.story.mdx
+++ b/src/layout/section/highlightSection/HighlightSection.story.mdx
@@ -3,7 +3,7 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks'
 import { RideAxis } from '../../../_utils/rideAxis'
 import { HighlightSection } from './index'
 
-export const axes = [
+export const featured = [
   {
     id: '11',
     label: 'Toulouse',
@@ -48,57 +48,39 @@ export const axes = [
   },
 ]
 
-export const destinations = [
+export const optional = [
   {
     id: '1',
-    label: 'Lyon',
+    label: 'Madrid',
     href: '#',
     ariaLabel: 'Aria label',
   },
   {
     id: '2',
-    label: 'Cannes',
+    label: 'Barcelona',
     href: '#',
     ariaLabel: 'Aria label',
   },
   {
     id: '3',
-    label: 'Toulouse',
+    label: 'Guernica',
     href: '#',
     ariaLabel: 'Aria label',
   },
   {
     id: '4',
-    label: 'Paris',
+    label: 'Alicante',
     href: '#',
     ariaLabel: 'Aria label',
   },
   {
     id: '5',
-    label: 'Nantes',
+    label: 'Sevilla',
     href: '#',
     ariaLabel: 'Aria label',
   },
   {
     id: '6',
-    label: 'Bruxelles',
-    href: '#',
-    ariaLabel: 'Aria label',
-  },
-  {
-    id: '7',
-    label: 'Amsterdam',
-    href: '#',
-    ariaLabel: 'Aria label',
-  },
-  {
-    id: '8',
-    label: 'Amsterdam',
-    href: '#',
-    ariaLabel: 'Aria label',
-  },
-  {
-    id: '9',
     label: 'Tous les villes en bus',
     href: '#',
     ariaLabel: 'Aria label',
@@ -106,20 +88,22 @@ export const destinations = [
 ]
 
 export const highlights = {
-  axes: { heading: 'Top trajets en bus', items: axes },
-  destinations: { heading: 'Top villes en bus', items: destinations },
+  featured: { heading: 'Top trajets en bus', items: featured },
+  optional: { heading: 'Top villes en bus', items: optional },
 }
 
-export const axesOnly = {
-  axes: { heading: 'Top trajets en bus', items: axes },
+export const featuredOnly = {
+  featured: { heading: 'Top trajets en bus', items: featured },
 }
 
 <Meta title="Sections/HighlightSection" />
 
 # HighlightSection
 
+## Featured and optional items
+
 <Canvas>
-  <Story name="Default">
+  <Story name="with featured and optional items">
     <HighlightSection
       highlights={highlights}
       toggle={{
@@ -130,12 +114,12 @@ export const axesOnly = {
   </Story>
 </Canvas>
 
-## Axes
+## Featured items only
 
 <Canvas>
-  <Story name="with only Axes">
+  <Story name="with featured items only">
     <HighlightSection
-      highlights={axesOnly}
+      highlights={featuredOnly}
       toggle={{
         on: 'Show more',
         off: 'Show less',
@@ -146,8 +130,8 @@ export const axesOnly = {
 
 ## Specifications
 
-`HighlightSection` is applied mainly on Landing Pages to **highlight common axes**.
-It's divided on two main sections. It receives axes data and handles its display.
+`HighlightSection` is applied featuredly on Landing Pages to **highlight common axes and/or destinations**.
+It's divided on two sections. It receives data and handles its display.
 
 > _SEO_
 >
@@ -170,8 +154,8 @@ Action button/link for toggling collapse mode. It has on/off state
 ```jsx
 import { HighlightSection } from '@blablacar/ui-library/build/layout/section/highlightSection'
 
-const highlight = {
-  destinations: {
+const highlights = {
+  optional: {
     heading: 'Destinations heading'
     items: [ {
     id: '11',
@@ -181,7 +165,7 @@ const highlight = {
     ariaLabel: 'Aria label',
   }]
 },
-axes: {
+featured: {
    heading: 'Axes heading'
     items: [ {
     id: '11',

--- a/src/layout/section/highlightSection/HighlightSection.tsx
+++ b/src/layout/section/highlightSection/HighlightSection.tsx
@@ -35,11 +35,11 @@ const DEFAULT_ITEMS_SIZE = 3
 export type HighlightsType = { heading: string; items: Array<HighlightItemsType> }
 export type HighlightSectionProps = Readonly<{
   className?: string
-  highlights: { axes: HighlightsType; destinations?: HighlightsType }
+  highlights: { featured: HighlightsType; optional?: HighlightsType }
   toggle: { on: string; off: string }
 }>
 
-const setFocus = (collapsed: Boolean) => {
+const setFocus = (collapsed: boolean) => {
   const collapsibleRegionWrapper = useRef()
 
   const focusCollapsibleRegion = (): void => {
@@ -58,9 +58,9 @@ const setFocus = (collapsed: Boolean) => {
 
 export const HighlightSection = ({ highlights, toggle, className }: HighlightSectionProps) => {
   const [collapsed, setCollapsed] = useState(true)
-  const { axes, destinations } = highlights
+  const { featured, optional } = highlights
 
-  const displayedItems = axes.items.map((item, index) => ({
+  const displayedItems = featured.items.map((item, index) => ({
     ...item,
     hidden: collapsed && index >= DEFAULT_ITEMS_SIZE,
   }))
@@ -69,13 +69,13 @@ export const HighlightSection = ({ highlights, toggle, className }: HighlightSec
 
   // Set Focus
 
-  const collapsibleRegionWrapper = destinations ? setFocus(collapsed) : null
+  const collapsibleRegionWrapper = optional ? setFocus(collapsed) : null
 
   return (
     <HighlightSectionElements.Section className={className}>
       <HighlightSectionElements.Content>
-        <HighlightContentItems heading={axes.heading} items={displayedItems} />
-        {destinations && (
+        <HighlightContentItems heading={featured.heading} items={displayedItems} />
+        {optional && (
           <div
             id={collapsibleRegionId}
             ref={collapsibleRegionWrapper}
@@ -84,7 +84,7 @@ export const HighlightSection = ({ highlights, toggle, className }: HighlightSec
             role="region"
             tabIndex={-1}
           >
-            <HighlightContentItems heading={destinations.heading} items={destinations.items} />
+            <HighlightContentItems heading={optional.heading} items={optional.items} />
           </div>
         )}
         <HighlightSectionElements.Actions>

--- a/src/layout/section/highlightSection/HighlightSection.unit.tsx
+++ b/src/layout/section/highlightSection/HighlightSection.unit.tsx
@@ -5,7 +5,7 @@ import { fireEvent, render } from '@testing-library/react'
 import { RideAxis } from '../../../_utils/rideAxis'
 import { HighlightSection } from './index'
 
-export const axes = [
+export const featured = [
   {
     id: '11',
     label: 'Toulouse',
@@ -50,57 +50,39 @@ export const axes = [
   },
 ]
 
-export const destinations = [
+export const optional = [
   {
     id: '1',
-    label: 'Lyon',
+    label: 'Madrid',
     href: <a href="#" />,
     ariaLabel: 'Aria label',
   },
   {
     id: '2',
-    label: 'Cannes',
+    label: 'Barcelona',
     href: <a href="#" />,
     ariaLabel: 'Aria label',
   },
   {
     id: '3',
-    label: 'Toulouse',
+    label: 'Guernica',
     href: <a href="#" />,
     ariaLabel: 'Aria label',
   },
   {
     id: '4',
-    label: 'Paris',
+    label: 'Alicante',
     href: <a href="#" />,
     ariaLabel: 'Aria label',
   },
   {
     id: '5',
-    label: 'Nantes',
+    label: 'Sevilla',
     href: <a href="#" />,
     ariaLabel: 'Aria label',
   },
   {
     id: '6',
-    label: 'Bruxelles',
-    href: <a href="#" />,
-    ariaLabel: 'Aria label',
-  },
-  {
-    id: '7',
-    label: 'Amsterdam',
-    href: <a href="#" />,
-    ariaLabel: 'Aria label',
-  },
-  {
-    id: '8',
-    label: 'Amsterdam',
-    href: <a href="#" />,
-    ariaLabel: 'Aria label',
-  },
-  {
-    id: '9',
     label: 'Tous les villes en bus',
     href: <a href="#" />,
     ariaLabel: 'Aria label',
@@ -108,18 +90,18 @@ export const destinations = [
 ]
 
 export const highlights = {
-  axes: { heading: 'Top trajets en bus', items: axes },
-  destinations: { heading: 'Top villes en bus', items: destinations },
+  featured: { heading: 'Top trajets en bus', items: featured },
+  optional: { heading: 'Top villes en bus', items: optional },
 }
 
 describe('HighlightSection', () => {
-  describe('axes', () => {
-    it('should render ONLY highlighted items', () => {
+  describe('featured items', () => {
+    it('should render ONLY featured highlighted items', () => {
       const view = render(
         <HighlightSection
           highlights={{
-            axes: { heading: 'Top trajets en bus', items: axes },
-            destinations: { heading: 'Top villes en bus', items: [] },
+            featured: { heading: 'Top trajets en bus', items: featured },
+            optional: { heading: 'Top villes en bus', items: [] },
           }}
           toggle={{
             on: 'Show more',
@@ -136,8 +118,8 @@ describe('HighlightSection', () => {
       const view = render(
         <HighlightSection
           highlights={{
-            axes: { heading: 'Top trajets en bus', items: axes },
-            destinations: { heading: 'Top villes en bus', items: [] },
+            featured: { heading: 'Top trajets en bus', items: featured },
+            optional: { heading: 'Top villes en bus', items: [] },
           }}
           toggle={{
             on: 'Show more',
@@ -151,13 +133,13 @@ describe('HighlightSection', () => {
     })
   })
 
-  describe('destinations', () => {
-    it('should not render destinations by default', () => {
+  describe('optional items', () => {
+    it('should not render the "optional" items by default', () => {
       const view = render(
         <HighlightSection
           highlights={{
-            axes: { heading: 'Top trajets en bus', items: [] },
-            destinations: { heading: 'Top villes en bus', items: destinations },
+            featured: { heading: 'Top trajets en bus', items: [] },
+            optional: { heading: 'Top villes en bus', items: optional },
           }}
           toggle={{
             on: 'Show more',
@@ -166,15 +148,15 @@ describe('HighlightSection', () => {
         />,
       )
 
-      expect(view.getByText('Lyon')).not.toBeVisible()
+      expect(view.getByText('Tous les villes en bus')).not.toBeVisible()
     })
 
-    it('should render destinations when expanded', () => {
+    it('should render the "optional" items when expanded', () => {
       const view = render(
         <HighlightSection
           highlights={{
-            axes: { heading: 'Top trajets en bus', items: [] },
-            destinations: { heading: 'Top villes en bus', items: destinations },
+            featured: { heading: 'Top trajets en bus', items: [] },
+            optional: { heading: 'Top villes en bus', items: optional },
           }}
           toggle={{
             on: 'Show more',
@@ -184,7 +166,7 @@ describe('HighlightSection', () => {
       )
 
       fireEvent.click(view.getByRole('button'))
-      expect(view.getByText('Lyon')).toBeVisible()
+      expect(view.getByText('Tous les villes en bus')).toBeVisible()
     })
   })
 })


### PR DESCRIPTION
Changed the name of the highlighted items so it's less tied to product notions.

The highlights in HighlightSection were split in "axes" and "destinations", with "axes" being required.
It happens that the product now features blocks with only "destinations" so to make it less confusing, I'm renaming "axes => main" and "destinations = other" (you may suggest better names!)

I've also updated the data we use for tests and stories as it was confusing me a bit. Now test "destinations" are Spanish cities.

## How it was tested

Locally on Firefox MacOS