### PR TITLE
[BBC-12765] Paragraph should accept ReactNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [...]
 
+- **[UPDATE]** Allow `Paragraph` to receive `ReactNode`
+
 # v49.0.0 (25/02/2021)
 
 - **[UPDATE]** Horizontal Normalization on `SearchRecap`

--- a/src/paragraph/Paragraph.story.mdx
+++ b/src/paragraph/Paragraph.story.mdx
@@ -7,6 +7,14 @@ import { Paragraph } from './index'
 # **Paragraph**
 
 <Canvas>
+  <Story name="Simple usage">
+    <Paragraph>
+      Some text with a link, please go on <a href="http://blablacar.com">blablacar.com</a>
+    </Paragraph>
+  </Story>
+</Canvas>
+
+<Canvas>
   <Story name="Long text">
     <Paragraph isExpandable expandLabel="Expand">
       {`${'Long text (above max char) '.repeat(20)}`}

--- a/src/paragraph/Paragraph.style.tsx
+++ b/src/paragraph/Paragraph.style.tsx
@@ -9,8 +9,13 @@ export const StyledParagraph = styled.div`
   padding: ${space.m} 0;
   word-break: break-word;
   ${normalizeHorizontally};
+`
 
-  & .kirk-button {
-    align-self: flex-end;
+export const ButtonWrapper = styled.div`
+  margin-top: ${space.m};
+  text-align: right;
+
+  & > .kirk-button {
+    display: inline-block;
   }
 `

--- a/src/paragraph/Paragraph.tsx
+++ b/src/paragraph/Paragraph.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react'
+import React, { useState } from 'react'
 import cc from 'classcat'
 
 import { Button, ButtonStatus } from '../button'
@@ -7,59 +7,68 @@ import { StyledParagraph } from './Paragraph.style'
 
 const DEFAULT_MAX_CHAR_SIZE = 180
 
-export type ParagraphProps = Readonly<{
+type ParagraphBaseProps = Readonly<{
   className?: string
-  children: string
-  isExpandable?: boolean
-  expandLabel?: string
   itemProp?: string
 }>
 
-type ParagraphState = {
-  isExpanded: boolean
+export type ParagraphSimpleProps = ParagraphBaseProps &
+  Readonly<{
+    children: string
+  }>
+
+export type ParagraphExpandableProps = ParagraphBaseProps &
+  Readonly<{
+    isExpandable: true
+    expandLabel: string
+    children: string
+  }>
+
+export type ParagraphProps = ParagraphSimpleProps | ParagraphExpandableProps
+
+const truncateText = (text: string) => `${text.substring(0, DEFAULT_MAX_CHAR_SIZE)}…`
+
+function SimpleParagraph(props: ParagraphSimpleProps): JSX.Element {
+  const { className, itemProp, children } = props
+
+  return (
+    <StyledParagraph className={cc(className)} role="presentation">
+      <Text itemProp={itemProp} tag={TextTagType.PARAGRAPH} newlineToBr>
+        {children}
+      </Text>
+    </StyledParagraph>
+  )
 }
 
-export class Paragraph extends PureComponent<ParagraphProps> {
-  static defaultProps: Partial<ParagraphProps> = {
-    className: '',
-    isExpandable: false,
-    expandLabel: '',
-    itemProp: null,
+function ExpandableParagraph(props: ParagraphExpandableProps): JSX.Element {
+  const { className, itemProp, expandLabel, children: originalContent } = props
+
+  const [isExpanded, setIsExpanded] = useState(originalContent.length < DEFAULT_MAX_CHAR_SIZE)
+
+  const expandParagraph = () => {
+    setIsExpanded(true)
   }
 
-  state: ParagraphState = {
-    isExpanded: false,
+  const content = isExpanded ? originalContent : truncateText(originalContent)
+
+  return (
+    <StyledParagraph className={cc(className)} role="presentation">
+      <Text itemProp={itemProp} tag={TextTagType.PARAGRAPH} newlineToBr>
+        {content}
+      </Text>
+      {!isExpanded && (
+        <Button status={ButtonStatus.UNSTYLED} onClick={expandParagraph} className="mt-s">
+          {expandLabel}
+        </Button>
+      )}
+    </StyledParagraph>
+  )
+}
+
+export function Paragraph(props: ParagraphProps) {
+  if ('isExpandable' in props && props.isExpandable) {
+    return <ExpandableParagraph {...props} />
   }
 
-  expandParagraph = () => {
-    this.setState({ isExpanded: true })
-  }
-
-  getTruncatedText() {
-    return `${this.props.children.substring(0, DEFAULT_MAX_CHAR_SIZE)}…`
-  }
-
-  render() {
-    const { className, children: originalContent, isExpandable, expandLabel, itemProp } = this.props
-    const { isExpanded } = this.state
-
-    const isContentTruncated =
-      isExpandable && !isExpanded && originalContent.length > DEFAULT_MAX_CHAR_SIZE
-    const content = isContentTruncated ? this.getTruncatedText() : originalContent
-
-    const readMoreButton = isContentTruncated && (
-      <Button status={ButtonStatus.UNSTYLED} onClick={this.expandParagraph} className="mt-s">
-        {expandLabel}
-      </Button>
-    )
-
-    return (
-      <StyledParagraph className={cc(className)} role="presentation">
-        <Text {...(itemProp && { itemProp })} tag={TextTagType.PARAGRAPH} newlineToBr>
-          {content}
-        </Text>
-        {readMoreButton}
-      </StyledParagraph>
-    )
-  }
+  return <SimpleParagraph {...props} />
 }

--- a/src/paragraph/Paragraph.tsx
+++ b/src/paragraph/Paragraph.tsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react'
 import cc from 'classcat'
 
 import { Button, ButtonStatus } from '../button'
-import { Text, TextTagType } from '../text'
-import { StyledParagraph } from './Paragraph.style'
+import { TextBody } from '../typography/body'
+import { ButtonWrapper, StyledParagraph } from './Paragraph.style'
 
 const DEFAULT_MAX_CHAR_SIZE = 180
 
@@ -14,7 +14,7 @@ type ParagraphBaseProps = Readonly<{
 
 export type ParagraphSimpleProps = ParagraphBaseProps &
   Readonly<{
-    children: string
+    children: React.ReactNode
   }>
 
 export type ParagraphExpandableProps = ParagraphBaseProps &
@@ -33,9 +33,9 @@ function SimpleParagraph(props: ParagraphSimpleProps): JSX.Element {
 
   return (
     <StyledParagraph className={cc(className)} role="presentation">
-      <Text itemProp={itemProp} tag={TextTagType.PARAGRAPH} newlineToBr>
+      <TextBody as="p" itemProp={itemProp}>
         {children}
-      </Text>
+      </TextBody>
     </StyledParagraph>
   )
 }
@@ -53,13 +53,15 @@ function ExpandableParagraph(props: ParagraphExpandableProps): JSX.Element {
 
   return (
     <StyledParagraph className={cc(className)} role="presentation">
-      <Text itemProp={itemProp} tag={TextTagType.PARAGRAPH} newlineToBr>
+      <TextBody as="p" itemProp={itemProp}>
         {content}
-      </Text>
+      </TextBody>
       {!isExpanded && (
-        <Button status={ButtonStatus.UNSTYLED} onClick={expandParagraph} className="mt-s">
-          {expandLabel}
-        </Button>
+        <ButtonWrapper>
+          <Button status={ButtonStatus.UNSTYLED} onClick={expandParagraph}>
+            {expandLabel}
+          </Button>
+        </ButtonWrapper>
       )}
     </StyledParagraph>
   )

--- a/src/paragraph/Paragraph.unit.tsx
+++ b/src/paragraph/Paragraph.unit.tsx
@@ -59,3 +59,13 @@ it('should expand truncated long text', () => {
   // Verify button has been removed
   expect(screen.queryByRole('button')).not.toBeInTheDocument()
 })
+
+it('should allow JSX.Element as children for isExpandable=false version', () => {
+  render(
+    <Paragraph>
+      Hello <a href="http://blablacar.com">BBC</a>!
+    </Paragraph>,
+  )
+
+  expect(screen.getByRole('link')).toBeInTheDocument()
+})

--- a/src/paragraph/Paragraph.unit.tsx
+++ b/src/paragraph/Paragraph.unit.tsx
@@ -12,8 +12,10 @@ it('should truncate long text', () => {
   const props = {
     isExpandable: true,
     expandLabel: 'Read more',
-  }
+  } as const
+
   const paragraph = mount(<Paragraph {...props}>{longText}</Paragraph>)
+
   const expandButton = paragraph.find('Button')
   expect(expandButton.exists()).toBe(true)
   expect(expandButton.text()).toBe('Read more')
@@ -27,8 +29,10 @@ it('should never truncate short text', () => {
   const props = {
     isExpandable: true,
     expandLabel: 'Read more',
-  }
+  } as const
+
   const paragraph = mount(<Paragraph {...props}>{shortText}</Paragraph>)
+
   const expandButton = paragraph.find('Button')
   expect(expandButton.exists()).toBe(false)
 
@@ -41,7 +45,8 @@ it('should expand truncated long text', () => {
   const props = {
     isExpandable: true,
     expandLabel: 'Read more',
-  }
+  } as const
+
   const paragraph = mount(<Paragraph {...props}>{longText}</Paragraph>)
   const expandButton = paragraph.find('Button')
 

--- a/src/paragraph/Paragraph.unit.tsx
+++ b/src/paragraph/Paragraph.unit.tsx
@@ -1,63 +1,61 @@
 import React from 'react'
-import { mount } from 'enzyme'
+
+import { fireEvent, render, screen } from '@testing-library/react'
 
 import { Paragraph } from './index'
 
 const shortText = 'text'
-const longText = 'text '.repeat(100)
+const longText = 'text '.repeat(100).trim()
 const expectedTruncatedLongText =
   'text text text text text text text text text text text text text text text text text text text text text text text text text text text text text text text text text text text text …'
 
 it('should truncate long text', () => {
-  const props = {
-    isExpandable: true,
-    expandLabel: 'Read more',
-  } as const
+  const buttonLabel = 'Read more'
 
-  const paragraph = mount(<Paragraph {...props}>{longText}</Paragraph>)
+  render(
+    <Paragraph isExpandable expandLabel={buttonLabel}>
+      {longText}
+    </Paragraph>,
+  )
 
-  const expandButton = paragraph.find('Button')
-  expect(expandButton.exists()).toBe(true)
-  expect(expandButton.text()).toBe('Read more')
+  expect(screen.getByRole('button', { name: buttonLabel })).toBeInTheDocument()
 
-  const text = paragraph.find('Text')
-  expect(text.exists()).toBe(true)
-  expect(text.text()).toBe(expectedTruncatedLongText)
+  expect(screen.getByText(expectedTruncatedLongText)).toBeInTheDocument()
 })
 
 it('should never truncate short text', () => {
-  const props = {
-    isExpandable: true,
-    expandLabel: 'Read more',
-  } as const
+  const buttonLabel = 'Read more'
 
-  const paragraph = mount(<Paragraph {...props}>{shortText}</Paragraph>)
+  render(
+    <Paragraph isExpandable expandLabel={buttonLabel}>
+      {shortText}
+    </Paragraph>,
+  )
 
-  const expandButton = paragraph.find('Button')
-  expect(expandButton.exists()).toBe(false)
+  expect(screen.queryByText('button')).not.toBeInTheDocument()
 
-  const text = paragraph.find('Text')
-  expect(text.exists()).toBe(true)
-  expect(text.text()).toBe(shortText)
+  expect(screen.getByText(shortText)).toBeInTheDocument()
 })
 
 it('should expand truncated long text', () => {
-  const props = {
-    isExpandable: true,
-    expandLabel: 'Read more',
-  } as const
+  const buttonLabel = 'Read more'
 
-  const paragraph = mount(<Paragraph {...props}>{longText}</Paragraph>)
-  const expandButton = paragraph.find('Button')
+  render(
+    <Paragraph isExpandable expandLabel={buttonLabel}>
+      {longText}
+    </Paragraph>,
+  )
+
+  const button = screen.getByRole('button', { name: buttonLabel })
+  expect(button).toBeInTheDocument()
 
   // Initially the text is truncated and the button to expand is visible:
-  expect(paragraph.find('Text').text()).toBe(expectedTruncatedLongText)
-  expect(paragraph.find('Button').exists()).toBe(true)
+  expect(screen.getByText(expectedTruncatedLongText)).toBeInTheDocument()
 
   // Verify that truncated text is expanded after clicking the toggle
-  expandButton.simulate('click')
-  expect(paragraph.find('Text').text()).toBe(longText)
+  fireEvent.click(button)
+  expect(screen.getByText(longText)).toBeInTheDocument()
 
   // Verify button has been removed
-  expect(paragraph.find('Button').exists()).toBe(false)
+  expect(screen.queryByRole('button')).not.toBeInTheDocument()
 })

--- a/src/review/__snapshots__/Review.unit.tsx.snap
+++ b/src/review/__snapshots__/Review.unit.tsx.snap
@@ -42,68 +42,11 @@ Array [
 }
 
 .c4 {
-  margin: 0;
+  white-space: pre-line;
+  color: #708C91;
+  font-size: 16px;
   font-weight: 400;
-}
-
-.c4.kirk-text-button {
-  color: #054752;
-  font-size: 16px;
   line-height: 20px;
-}
-
-.c4.kirk-text-body,
-.c4.kirk-text-bodyStrong {
-  color: #708C91;
-  font-size: 16px;
-  line-height: 20px;
-}
-
-.c4.kirk-text-caption {
-  color: #708C91;
-  font-size: 13px;
-  line-height: 16px;
-}
-
-.c4.kirk-text-title,
-.c4.kirk-text-titleStrong {
-  color: #054752;
-  font-size: 18px;
-  line-height: 20px;
-}
-
-.c4.kirk-text-display2 {
-  color: #054752;
-  font-size: 82px;
-  line-height: 82px;
-  font-weight: 500;
-}
-
-.c4.kirk-text-display1 {
-  color: #054752;
-  font-size: 30px;
-  line-height: 1.06;
-  font-weight: 500;
-}
-
-.c4.kirk-text-subheader,
-.c4.kirk-text-subheaderStrong {
-  color: #054752;
-  font-size: 22px;
-  line-height: 24px;
-}
-
-.c4.kirk-text-title,
-.c4.kirk-text-titleStrong {
-  color: #054752;
-  font-size: 18px;
-  line-height: 20px;
-}
-
-.c4.kirk-text-bodyStrong,
-.c4.kirk-text-subheaderStrong,
-.c4.kirk-text-titleStrong {
-  font-weight: 500;
 }
 
 .c3 {
@@ -120,12 +63,6 @@ Array [
   padding-right: 24px !important;
   margin-left: 0;
   margin-right: 0;
-}
-
-.c3 .kirk-button {
-  -webkit-align-self: flex-end;
-  -ms-flex-item-align: end;
-  align-self: flex-end;
 }
 
 .c2 {
@@ -204,7 +141,7 @@ Array [
             role="presentation"
           >
             <p
-              className="kirk-text kirk-text-body c4"
+              className="c4"
               itemProp="reviewBody"
             >
               Review content
@@ -264,68 +201,11 @@ Array [
 }
 
 .c4 {
-  margin: 0;
+  white-space: pre-line;
+  color: #708C91;
+  font-size: 16px;
   font-weight: 400;
-}
-
-.c4.kirk-text-button {
-  color: #054752;
-  font-size: 16px;
   line-height: 20px;
-}
-
-.c4.kirk-text-body,
-.c4.kirk-text-bodyStrong {
-  color: #708C91;
-  font-size: 16px;
-  line-height: 20px;
-}
-
-.c4.kirk-text-caption {
-  color: #708C91;
-  font-size: 13px;
-  line-height: 16px;
-}
-
-.c4.kirk-text-title,
-.c4.kirk-text-titleStrong {
-  color: #054752;
-  font-size: 18px;
-  line-height: 20px;
-}
-
-.c4.kirk-text-display2 {
-  color: #054752;
-  font-size: 82px;
-  line-height: 82px;
-  font-weight: 500;
-}
-
-.c4.kirk-text-display1 {
-  color: #054752;
-  font-size: 30px;
-  line-height: 1.06;
-  font-weight: 500;
-}
-
-.c4.kirk-text-subheader,
-.c4.kirk-text-subheaderStrong {
-  color: #054752;
-  font-size: 22px;
-  line-height: 24px;
-}
-
-.c4.kirk-text-title,
-.c4.kirk-text-titleStrong {
-  color: #054752;
-  font-size: 18px;
-  line-height: 20px;
-}
-
-.c4.kirk-text-bodyStrong,
-.c4.kirk-text-subheaderStrong,
-.c4.kirk-text-titleStrong {
-  font-weight: 500;
 }
 
 .c3 {
@@ -342,12 +222,6 @@ Array [
   padding-right: 24px !important;
   margin-left: 0;
   margin-right: 0;
-}
-
-.c3 .kirk-button {
-  -webkit-align-self: flex-end;
-  -ms-flex-item-align: end;
-  align-self: flex-end;
 }
 
 .c2 {
@@ -422,7 +296,7 @@ Array [
             role="presentation"
           >
             <p
-              className="kirk-text kirk-text-body c4"
+              className="c4"
               itemProp="reviewBody"
             >
               Review content


### PR DESCRIPTION
> BBC-12765 

## Description

This PR update `Paragraph` to accept ReactNode, which is usefull to render a paragraph with link inside.

But! As the expandable feature of `Paragraph` (when `isExpandable` is `true` only) use `substring` on the children,
I keep the `children: string` typing when `isExpandable` is `true`.

3 commits in this PR:
- 1st and 2nd about refactoring the component to use hooks and testing-library
- 3rd about enabling `ReactNode` for simple `Paragraph`'s `children`

Out of scope:
- accessibility updates: see https://blablacar.atlassian.net/browse/BBC-12577


## TESTED
UT