### PR TITLE
add FaqSection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **[BREAKING CHANGE]** Removed `deprecatedExtraFooter` prop on `ColumnedContentSection`
 - **[UPDATE]** Refactor `ColumnedContentSection` following a compound component approach
 - **[FIX]** Fix top link position on `ColumnedContentSection` and grouping it with the title
+- **[NEW]** Add `FaqSection` component
 
 # v50.0.0 (02/03/2021)
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,7 @@ export * from './layout/section/illustratedSection'
 export * from './layout/section/mediaSection'
 export * from './layout/section/slideSection'
 export * from './layout/section/textFieldsSection'
+export * from './layout/section/faqSection'
 
 export * from './layout/pages/seaPage'
 

--- a/src/layout/section/faqSection/FaqSection.story.mdx
+++ b/src/layout/section/faqSection/FaqSection.story.mdx
@@ -1,0 +1,65 @@
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks'
+
+import { FaqSection } from './index'
+
+<Meta title="Sections/FaqSection" />
+
+# **FaqSection**
+
+<Canvas>
+  <Story name="Default">
+    <FaqSection
+      title="FAQ"
+      items={[
+        {
+          question: 'Question 1',
+          answer: `${'Answer to the question '.repeat(30)}`,
+        },
+        {
+          question: 'Question 2',
+          answer: 'A short answer.',
+        },
+        {
+          question: 'Question 3',
+          answer: `${'Answer to the question '.repeat(50)}`,
+        },
+        {
+          question: 'Question 4',
+          answer: `${'Another answer '.repeat(50)}`,
+        },
+      ]}
+      expandLabel="Read more"
+      buttonLabel="Link to complete FAQ"
+      buttonHref="https://www.blablacar.com"
+    />
+  </Story>
+</Canvas>
+
+## Specifications
+
+## Usage
+
+```jsx
+import { FaqSection } from '@blablacar/ui-library/build/layout/section/faqSection'
+
+<FaqSection
+  title="FAQ"
+  items={[
+    {
+      question: 'Question 1',
+      answer: 'Answer to the first question.',
+    },{
+      question: 'Question 2',
+      answer: 'Answer to the second question.',
+    },{
+      question: 'Question 3',
+      answer: 'Answer to the third question.',
+    },
+  ]}
+  expandLabel="Read more"
+  buttonLabel="Link to complete FAQ"
+  buttonHref="/"
+/>
+```
+
+<ArgsTable of={FaqSection} />

--- a/src/layout/section/faqSection/FaqSection.story.mdx
+++ b/src/layout/section/faqSection/FaqSection.story.mdx
@@ -9,7 +9,7 @@ import { FaqSection } from './index'
 <Canvas>
   <Story name="Default">
     <FaqSection
-      title="FAQ"
+      mainTitle="FAQ"
       items={[
         {
           question: 'Question 1',
@@ -43,7 +43,7 @@ import { FaqSection } from './index'
 import { FaqSection } from '@blablacar/ui-library/build/layout/section/faqSection'
 
 <FaqSection
-  title="FAQ"
+  mainTitle="FAQ"
   items={[
     {
       question: 'Question 1',

--- a/src/layout/section/faqSection/FaqSection.style.tsx
+++ b/src/layout/section/faqSection/FaqSection.style.tsx
@@ -11,9 +11,29 @@ const StyledSection = styled(BaseSection)`
   margin-bottom: ${space.xl};
 
   @media (${responsiveBreakpoints.isMediaLarge}) {
-  }
+    ul {
+      display: flex;
+      flex-wrap: wrap;
+    }
 
-  @media (${responsiveBreakpoints.isMediaSmall}) {
+    li {
+      min-width: 50%;
+      max-width: 50%;
+    }
+  }
+`
+
+const StyledList = styled.ul`
+  @media (${responsiveBreakpoints.isMediaLarge}) {
+    display: flex;
+    flex-wrap: wrap;
+  }
+`
+
+const StyledListItem = styled.li`
+  @media (${responsiveBreakpoints.isMediaLarge}) {
+    min-width: 50%;
+    max-width: 50%;
   }
 `
 
@@ -34,6 +54,8 @@ const StyledQuestion = styled(TextTitleStrong)`
 
 export const StyledFaqSection = {
   Section: StyledSection,
+  List: StyledList,
+  ListItem: StyledListItem,
   ButtonWrapper: StyledButtonWrapper,
   Title: StyledTitle,
   Question: StyledQuestion,

--- a/src/layout/section/faqSection/FaqSection.style.tsx
+++ b/src/layout/section/faqSection/FaqSection.style.tsx
@@ -1,0 +1,40 @@
+import styled from 'styled-components'
+
+import { responsiveBreakpoints, space } from '../../../_utils/branding'
+import { normalizeHorizontally } from '../../../layout/layoutNormalizer'
+import { BaseSection } from '../../../layout/section/baseSection'
+import { TextDisplay1 } from '../../../typography/display1'
+import { TextTitleStrong } from '../../../typography/titleStrong'
+
+const StyledSection = styled(BaseSection)`
+  margin-top: ${space.xl};
+  margin-bottom: ${space.xl};
+
+  @media (${responsiveBreakpoints.isMediaLarge}) {
+  }
+
+  @media (${responsiveBreakpoints.isMediaSmall}) {
+  }
+`
+
+const StyledButtonWrapper = styled.div`
+  margin: ${space.xl};
+  text-align: center;
+`
+
+const StyledTitle = styled(TextDisplay1)`
+  ${normalizeHorizontally};
+  margin-bottom: ${space.xxl};
+  text-align: center;
+`
+
+const StyledQuestion = styled(TextTitleStrong)`
+  ${normalizeHorizontally};
+`
+
+export const StyledFaqSection = {
+  Section: StyledSection,
+  ButtonWrapper: StyledButtonWrapper,
+  Title: StyledTitle,
+  Question: StyledQuestion,
+}

--- a/src/layout/section/faqSection/FaqSection.tsx
+++ b/src/layout/section/faqSection/FaqSection.tsx
@@ -1,0 +1,75 @@
+import React, { Fragment } from 'react'
+
+import { Button } from '../../../button'
+import { ContentDivider } from '../../../divider/contentDivider'
+import { SpacingDivider, SpacingDividerSize } from '../../../divider/spacingDivider'
+import { Column } from '../../../layout/column'
+import { Columns } from '../../../layout/columns'
+import { SectionContentSize } from '../../../layout/section/baseSection'
+import { Paragraph } from '../../../paragraph'
+import { StyledFaqSection } from './FaqSection.style'
+
+export type FaqItemProps = {
+  question: string
+  answer: string
+}
+
+export type FaqSectionProps = Readonly<{
+  className?: string
+  title?: string
+  items: Array<FaqItemProps> // max 6 FAQ items
+  expandLabel: string
+  buttonLabel?: string
+  buttonHref?: string | JSX.Element
+}>
+
+/**
+ * A specialized section with up to 6 expandable paragraphs with Questions & Answers.
+ *
+ * Note: use of Columns is not ideal as it creates a listitem for each column
+ * We would rather have one listitem by FAQ item instead
+ */
+export const FaqSection = (props: FaqSectionProps) => {
+  const { className, items, title, buttonLabel, buttonHref, expandLabel } = props
+
+  const renderFaqItem = ({ question, answer }: FaqItemProps): JSX.Element => (
+    <Fragment>
+      <StyledFaqSection.Question as="h3">{question}</StyledFaqSection.Question>
+      <Paragraph isExpandable expandLabel={expandLabel}>
+        {answer}
+      </Paragraph>
+      <ContentDivider />
+      <SpacingDivider size={SpacingDividerSize.SMALL} />
+    </Fragment>
+  )
+
+  return (
+    <StyledFaqSection.Section
+      contentSize={SectionContentSize.LARGE}
+      tagName="article"
+      noHorizontalSpacing
+      className={className}
+    >
+      {title && <StyledFaqSection.Title as="h2">{title}</StyledFaqSection.Title>}
+
+      <Columns>
+        <Column>
+          {renderFaqItem(items[0])}
+          {items[2] && renderFaqItem(items[2])}
+          {items[4] && renderFaqItem(items[4])}
+        </Column>
+        <Column>
+          {renderFaqItem(items[1])}
+          {items[3] && renderFaqItem(items[3])}
+          {items[5] && renderFaqItem(items[5])}
+        </Column>
+      </Columns>
+
+      {buttonLabel && buttonHref && (
+        <StyledFaqSection.ButtonWrapper>
+          <Button href={buttonHref}>{buttonLabel}</Button>
+        </StyledFaqSection.ButtonWrapper>
+      )}
+    </StyledFaqSection.Section>
+  )
+}

--- a/src/layout/section/faqSection/FaqSection.tsx
+++ b/src/layout/section/faqSection/FaqSection.tsx
@@ -15,7 +15,7 @@ export type FaqItemProps = {
 
 export type FaqSectionProps = Readonly<{
   className?: string
-  title?: string
+  mainTitle?: string
   items: Array<FaqItemProps>
   expandLabel: string
   buttonLabel?: string
@@ -26,7 +26,7 @@ export type FaqSectionProps = Readonly<{
  * A specialized section with multiple expandable paragraphs with Questions & Answers.
  */
 export const FaqSection = (props: FaqSectionProps) => {
-  const { className, items, title, buttonLabel, buttonHref, expandLabel } = props
+  const { className, items, mainTitle, buttonLabel, buttonHref, expandLabel } = props
 
   const renderFaqItem = ({ question, answer }: FaqItemProps): JSX.Element => {
     const id = uniqueId('faq-item-')
@@ -50,7 +50,7 @@ export const FaqSection = (props: FaqSectionProps) => {
       noHorizontalSpacing
       className={className}
     >
-      {title && <StyledFaqSection.Title as="h2">{title}</StyledFaqSection.Title>}
+      {mainTitle && <StyledFaqSection.Title as="h2">{mainTitle}</StyledFaqSection.Title>}
 
       <StyledFaqSection.List>{items.map(item => renderFaqItem(item))}</StyledFaqSection.List>
 

--- a/src/layout/section/faqSection/FaqSection.tsx
+++ b/src/layout/section/faqSection/FaqSection.tsx
@@ -1,10 +1,9 @@
-import React, { Fragment } from 'react'
+import React from 'react'
+import uniqueId from 'lodash.uniqueid'
 
 import { Button } from '../../../button'
 import { ContentDivider } from '../../../divider/contentDivider'
 import { SpacingDivider, SpacingDividerSize } from '../../../divider/spacingDivider'
-import { Column } from '../../../layout/column'
-import { Columns } from '../../../layout/columns'
 import { SectionContentSize } from '../../../layout/section/baseSection'
 import { Paragraph } from '../../../paragraph'
 import { StyledFaqSection } from './FaqSection.style'
@@ -17,31 +16,32 @@ export type FaqItemProps = {
 export type FaqSectionProps = Readonly<{
   className?: string
   title?: string
-  items: Array<FaqItemProps> // max 6 FAQ items
+  items: Array<FaqItemProps>
   expandLabel: string
   buttonLabel?: string
   buttonHref?: string | JSX.Element
 }>
 
 /**
- * A specialized section with up to 6 expandable paragraphs with Questions & Answers.
- *
- * Note: use of Columns is not ideal as it creates a listitem for each column
- * We would rather have one listitem by FAQ item instead
+ * A specialized section with multiple expandable paragraphs with Questions & Answers.
  */
 export const FaqSection = (props: FaqSectionProps) => {
   const { className, items, title, buttonLabel, buttonHref, expandLabel } = props
 
-  const renderFaqItem = ({ question, answer }: FaqItemProps): JSX.Element => (
-    <Fragment>
-      <StyledFaqSection.Question as="h3">{question}</StyledFaqSection.Question>
-      <Paragraph isExpandable expandLabel={expandLabel}>
-        {answer}
-      </Paragraph>
-      <ContentDivider />
-      <SpacingDivider size={SpacingDividerSize.SMALL} />
-    </Fragment>
-  )
+  const renderFaqItem = ({ question, answer }: FaqItemProps): JSX.Element => {
+    const id = uniqueId('faq-item-')
+
+    return (
+      <StyledFaqSection.ListItem key={id}>
+        <StyledFaqSection.Question as="h3">{question}</StyledFaqSection.Question>
+        <Paragraph isExpandable expandLabel={expandLabel}>
+          {answer}
+        </Paragraph>
+        <ContentDivider />
+        <SpacingDivider size={SpacingDividerSize.SMALL} />
+      </StyledFaqSection.ListItem>
+    )
+  }
 
   return (
     <StyledFaqSection.Section
@@ -52,18 +52,7 @@ export const FaqSection = (props: FaqSectionProps) => {
     >
       {title && <StyledFaqSection.Title as="h2">{title}</StyledFaqSection.Title>}
 
-      <Columns>
-        <Column>
-          {renderFaqItem(items[0])}
-          {items[2] && renderFaqItem(items[2])}
-          {items[4] && renderFaqItem(items[4])}
-        </Column>
-        <Column>
-          {renderFaqItem(items[1])}
-          {items[3] && renderFaqItem(items[3])}
-          {items[5] && renderFaqItem(items[5])}
-        </Column>
-      </Columns>
+      <StyledFaqSection.List>{items.map(item => renderFaqItem(item))}</StyledFaqSection.List>
 
       {buttonLabel && buttonHref && (
         <StyledFaqSection.ButtonWrapper>

--- a/src/layout/section/faqSection/FaqSection.unit.tsx
+++ b/src/layout/section/faqSection/FaqSection.unit.tsx
@@ -39,20 +39,20 @@ describe('FaqSection', () => {
   it('should render FaqSection section with minimal props', () => {
     render(<FaqSection {...minimalProps} />)
 
-    expect(screen.getByText('Question 1')).toBeInTheDocument()
-    expect(screen.getByText('Question 2')).toBeInTheDocument()
-    expect(screen.getByText('Question 3')).toBeInTheDocument()
-    expect(screen.getByText('Question 4')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Question 1' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Question 2' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Question 3' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Question 4' })).toBeInTheDocument()
     expect(screen.getAllByText('Read more')).toHaveLength(3)
 
-    expect(screen.queryByText('section title')).not.toBeInTheDocument()
-    expect(screen.queryByText('button label')).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'section title' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'button label' })).not.toBeInTheDocument()
   })
 
   it('should render FaqSection section with all props', () => {
     render(<FaqSection {...allProps} />)
 
-    expect(screen.getByText('section title')).toBeInTheDocument()
-    expect(screen.getByText('button label')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'section title' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'button label' })).toBeInTheDocument()
   })
 })

--- a/src/layout/section/faqSection/FaqSection.unit.tsx
+++ b/src/layout/section/faqSection/FaqSection.unit.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+
+import { render, screen } from '@testing-library/react'
+
+import { FaqItemProps, FaqSection, FaqSectionProps } from './index'
+
+const defaultItems: Array<FaqItemProps> = [
+  {
+    question: 'Question 1',
+    answer: `${'Answer to the question '.repeat(30)}`,
+  },
+  {
+    question: 'Question 2',
+    answer: 'A short answer.',
+  },
+  {
+    question: 'Question 3',
+    answer: `${'Answer to the question '.repeat(50)}`,
+  },
+  {
+    question: 'Question 4',
+    answer: `${'Another answer '.repeat(50)}`,
+  },
+]
+
+const minimalProps: FaqSectionProps = {
+  items: defaultItems,
+  expandLabel: 'Read more',
+}
+
+const allProps: FaqSectionProps = {
+  ...minimalProps,
+  title: 'section title',
+  buttonLabel: 'button label',
+  buttonHref: 'https://blablacar.com',
+}
+
+describe('FaqSection', () => {
+  it('should render FaqSection section with minimal props', () => {
+    render(<FaqSection {...minimalProps} />)
+
+    expect(screen.getByText('Question 1')).toBeInTheDocument()
+    expect(screen.getByText('Question 2')).toBeInTheDocument()
+    expect(screen.getByText('Question 3')).toBeInTheDocument()
+    expect(screen.getByText('Question 4')).toBeInTheDocument()
+    expect(screen.getAllByText('Read more')).toHaveLength(3)
+
+    expect(screen.queryByText('section title')).not.toBeInTheDocument()
+    expect(screen.queryByText('button label')).not.toBeInTheDocument()
+  })
+
+  it('should render FaqSection section with all props', () => {
+    render(<FaqSection {...allProps} />)
+
+    expect(screen.getByText('section title')).toBeInTheDocument()
+    expect(screen.getByText('button label')).toBeInTheDocument()
+  })
+})

--- a/src/layout/section/faqSection/FaqSection.unit.tsx
+++ b/src/layout/section/faqSection/FaqSection.unit.tsx
@@ -30,7 +30,7 @@ const minimalProps: FaqSectionProps = {
 
 const allProps: FaqSectionProps = {
   ...minimalProps,
-  title: 'section title',
+  mainTitle: 'section title',
   buttonLabel: 'button label',
   buttonHref: 'https://blablacar.com',
 }

--- a/src/layout/section/faqSection/index.tsx
+++ b/src/layout/section/faqSection/index.tsx
@@ -1,0 +1,1 @@
+export { FaqSection, FaqSectionProps, FaqItemProps } from './FaqSection'


### PR DESCRIPTION
Moved the FAQ block used on the Pro and Carpool home pages to ui-library, to better handle spacings.

## BEFORE
![Screen Shot 2021-03-01 at 19 46 59](https://user-images.githubusercontent.com/373381/109543701-eb9d4d00-7ac6-11eb-8421-fa68d8a38ef7.png)

## AFTER
![Screen Shot 2021-03-01 at 19 28 46](https://user-images.githubusercontent.com/373381/109543742-f6f07880-7ac6-11eb-8c95-dcfd2d23bdeb.png)


## How it was tested

Tested on Firefox MacOS with canary release (both /carpool and /pro pages)
