### PR TITLE
Releases/50.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+[...]
+
+# v50.0.0 (02/03/2021)
+
 - **[BREAKING CHANGE]** Move `Drawer`, `DropdownButton`, `HamburgerButton` and `Menu` to `TopBar`
 - **[BREAKING CHANGE]** Move `Proximity` to `newItinerary`
 - **[BREAKING CHANGE]** Removed `small` prop on `TimePicker`
@@ -10,7 +14,6 @@
 - **[UPDATE]** Normalize `TimePicker` component
 - **[UPDATE]** Normalize `PushInfo`
 - **[FIX]** Fix `Why` overflow
-[...]
 
 # v49.1.0 (01/03/2021)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "49.1.0",
+  "version": "50.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "49.1.0",
+  "version": "50.0.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# v50.0.0 (02/03/2021)

- **[BREAKING CHANGE]** Move `Drawer`, `DropdownButton`, `HamburgerButton` and `Menu` to `TopBar`
- **[BREAKING CHANGE]** Move `Proximity` to `newItinerary`
- **[BREAKING CHANGE]** Removed `small` prop on `TimePicker`
- **[BREAKING CHANGE]** `Stars` and `Rating` components are now private
- **[BREAKING CHANGE]** Rename `Why` to `TheWhy`
- **[UPDATE]** Normalize `Why`
- **[UPDATE]** Normalize `DatePicker`
- **[UPDATE]** Normalize `TimePicker` component
- **[UPDATE]** Normalize `PushInfo`
- **[FIX]** Fix `Why` overflow