### PR TITLE
Release/51.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Unreleased
 
 [...]
+
+# v51.0.0 (02/03/2021)
+
 - **[BREAKING CHANGE]** rename `HighlightSection` props
 - **[BREAKING CHANGE]** Removed `deprecatedExtraFooter` prop on `ColumnedContentSection`
 - **[UPDATE]** Refactor `ColumnedContentSection` following a compound component approach

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "50.0.0",
+  "version": "51.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "50.0.0",
+  "version": "51.0.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# v51.0.0 (02/03/2021)

- **[BREAKING CHANGE]** rename `HighlightSection` props
- **[BREAKING CHANGE]** Removed `deprecatedExtraFooter` prop on `ColumnedContentSection`
- **[UPDATE]** Refactor `ColumnedContentSection` following a compound component approach
- **[FIX]** Fix top link position on `ColumnedContentSection` and grouping it with the title
- **[NEW]** Add `FaqSection` component