### PR TITLE
Releases/53.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Unreleased
 
+[...]
+
+# v53.0.0 (05/03/2021)
+
 - **[BREAKING CHANGE]** Remove Microdata from `TripCard`
 - **[BREAKING CHANGE]** Use new `Itinerary` in `TripCard`
 - **[BREAKING CHANGE]** `Caption` is now private (the component, not the typography element)
 - **[FIX]** Fix broken docs for dividers
-[...]
 
 # v52.0.0 (03/03/2021)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "52.0.0",
+  "version": "53.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "52.0.0",
+  "version": "53.0.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
# v53.0.0 (05/03/2021)

- **[BREAKING CHANGE]** Remove Microdata from `TripCard`
- **[BREAKING CHANGE]** Use new `Itinerary` in `TripCard`
- **[BREAKING CHANGE]** `Caption` is now private (the component, not the typography element)
- **[FIX]** Fix broken docs for dividers