### PR TITLE
Release/v54.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Unreleased
 
+[...]
+# v54.0.0 (09/03/2021)
+
 - **[UPDATE]** Update `TopBar/Menu` and `ItemsList` to support a single child item
 - **[BREAKING CHANGE]** Update `title` prop to `mainTitle` for `Hint`, `Profil`, `TripCard` and `QrCard`
-[...]
 
 # v53.0.0 (05/03/2021)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "53.0.0",
+  "version": "54.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "53.0.0",
+  "version": "54.0.0",
   "description": "BlaBlaCar React UI component library",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Description

# v54.0.0 (09/03/2021)

- **[UPDATE]** Update `TopBar/Menu` and `ItemsList` to support a single child item
- **[BREAKING CHANGE]** Update `title` prop to `mainTitle` for `Hint`, `Profil`, `TripCard` and `QrCard`
