### PR TITLE
import TopBar style from main app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
+
 - [...]
+- **[BREAKING CHANGE]** Update `TopBar` and `Drawer` APIs and styles
+
 # v57.0.0 (24/03/2021)
 
 - **[BREAKING CHANGE]** Add `title` and `tabIndex` props to `A11yProps` interface and `pickA11yProps` function

--- a/src/_utils/branding.ts
+++ b/src/_utils/branding.ts
@@ -140,6 +140,14 @@ export const componentSizes = {
     small: '56px',
     large: '72px',
   },
+  headerWidth: {
+    small: '100%',
+    large: '1280px',
+  },
+  drawerWidth: {
+    small: '100%',
+    large: '350px',
+  },
 }
 
 export const modalSize = {

--- a/src/topBar/TopBar.example.tsx
+++ b/src/topBar/TopBar.example.tsx
@@ -57,6 +57,7 @@ const centerContent = (
 
 export const SimpleTopBar = (): JSX.Element => (
   <TopBar
+    zIndex={50}
     leftItem={boolean('With leftItem', true) && leftAction}
     centerItem={boolean('With centerItem', true) && centerContent}
     rightItem={boolean('With rightItem', true) && rightAction}
@@ -76,8 +77,8 @@ export const LoggedOutTopBar = (): JSX.Element => {
 
   return (
     <Fragment>
-      <TopBar leftItem={dropdownButton} />
-      <Drawer open={drawerOpened} onClose={(): void => setDrawerOpened(false)}>
+      <TopBar zIndex={50} leftItem={dropdownButton} />
+      <Drawer zIndex={40} open={drawerOpened} onClose={(): void => setDrawerOpened(false)}>
         <Menu>
           <ItemChoice label="Log in" />
           <ItemChoice label="Sign up" />
@@ -100,8 +101,8 @@ export const LoggedInTopBar = (): JSX.Element => {
 
   return (
     <Fragment>
-      <TopBar leftItem={dropdownButton} />
-      <Drawer open={drawerOpened} onClose={(): void => setDrawerOpened(false)}>
+      <TopBar zIndex={50} leftItem={dropdownButton} />
+      <Drawer zIndex={40} open={drawerOpened} onClose={(): void => setDrawerOpened(false)}>
         <Menu>
           <ItemChoice label="Dashboard" leftAddon={<HomeIcon />} />
           <ItemChoice label="Your rides" leftAddon={<MyRidesIcon />} />

--- a/src/topBar/TopBar.example.tsx
+++ b/src/topBar/TopBar.example.tsx
@@ -60,9 +60,6 @@ export const SimpleTopBar = (): JSX.Element => (
     leftItem={boolean('With leftItem', true) && leftAction}
     centerItem={boolean('With centerItem', true) && centerContent}
     rightItem={boolean('With rightItem', true) && rightAction}
-    fixed={false}
-    bgTransparent={false}
-    bgShadedTransparent={false}
   />
 )
 

--- a/src/topBar/TopBar.story.mdx
+++ b/src/topBar/TopBar.story.mdx
@@ -39,6 +39,7 @@ export const LoggedOutTopBar = (): JSX.Element => {
   return (
     <Fragment>
       <TopBar
+        zIndex={50}
         leftItem={(
           <DropdownButton onClick={(): void => setDrawerOpened(!drawerOpened)}>
             <Avatar
@@ -48,7 +49,10 @@ export const LoggedOutTopBar = (): JSX.Element => {
           </DropdownButton>
         )}
       />
-      <Drawer open={drawerOpened} onClose={(): void => setDrawerOpened(false)}>
+      <Drawer
+        zIndex={40}
+        open={drawerOpened}
+        onClose={(): void => setDrawerOpened(false)}>
         <Menu>
           <ItemChoice label="Log in"/>
           <ItemChoice label="Sign up"/>

--- a/src/topBar/TopBar.style.tsx
+++ b/src/topBar/TopBar.style.tsx
@@ -1,39 +1,35 @@
 import styled from 'styled-components'
 
-import { color } from '../_utils/branding'
+import { color, componentSizes, responsiveBreakpoints } from '../_utils/branding'
 
-export const StyledTopBar = styled.header`
-  & {
-    position: relative;
-    width: 100%;
-    background-color: ${color.white};
+export const StyledTopBar = styled.header<{ zIndex?: number }>`
+  position: fixed;
+  width: 100%;
+  background-color: ${color.white};
+  display: flex;
+  align-items: center;
+  top: 0;
+  height: ${componentSizes.headerHeight.small};
+  z-index: ${props => props.zIndex || 3}; /* z-index overridden in main application, above drawer */
+
+  .kirk-topBar-inner {
     display: flex;
-    align-items: center;
+    width: 100%;
+    margin: auto;
+    font-weight: 500;
   }
 
-  &.kirk-topBar--fixed {
-    position: fixed;
-  }
-
-  &.kirk-topBar--bgTransparent {
-    background-color: transparent;
-  }
-  &.kirk-topBar--bgShadedTransparent {
-    background-color: transparent;
-    background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0));
-  }
-
-  & .kirk-topBar-left,
-  & .kirk-topBar-right {
+  .kirk-topBar-left,
+  .kirk-topBar-right {
     flex: 1;
     display: flex;
   }
 
-  & .kirk-topBar-left {
+  .kirk-topBar-left {
     justify-content: flex-start;
   }
 
-  & .kirk-topBar-center {
+  .kirk-topBar-center {
     position: absolute;
     top: 50%;
     left: 50%;
@@ -41,7 +37,20 @@ export const StyledTopBar = styled.header`
     text-align: center;
   }
 
-  & .kirk-topBar-right {
+  .kirk-topBar-right {
     justify-content: flex-end;
+  }
+
+  @media (${responsiveBreakpoints.isMediaLarge}) {
+    height: ${componentSizes.headerHeight.large};
+
+    .kirk-topBar-inner {
+      width: 1280px;
+    }
+
+    .kirk-topBar-inner div:nth-child(3n) {
+      /* don't force the full text navigation links to grow on large media */
+      flex: none;
+    }
   }
 `

--- a/src/topBar/TopBar.style.tsx
+++ b/src/topBar/TopBar.style.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 import { color, componentSizes, responsiveBreakpoints } from '../_utils/branding'
 
-export const StyledTopBar = styled.header<{ zIndex?: number }>`
+export const StyledTopBar = styled.header<{ $zIndex: number }>`
   position: fixed;
   width: 100%;
   background-color: ${color.white};
@@ -10,7 +10,7 @@ export const StyledTopBar = styled.header<{ zIndex?: number }>`
   align-items: center;
   top: 0;
   height: ${componentSizes.headerHeight.small};
-  z-index: ${props => props.zIndex || 3}; /* z-index overridden in main application, above drawer */
+  z-index: ${props => props.$zIndex}; /* z-index defined in main application, above drawer */
 
   .kirk-topBar-inner {
     display: flex;

--- a/src/topBar/TopBar.style.tsx
+++ b/src/topBar/TopBar.style.tsx
@@ -1,16 +1,21 @@
 import styled from 'styled-components'
 
-import { color, componentSizes, responsiveBreakpoints } from '../_utils/branding'
+import { color, componentSizes, responsiveBreakpoints, space } from '../_utils/branding'
 
 export const StyledTopBar = styled.header<{ $zIndex: number }>`
   position: fixed;
   width: 100%;
+  height: ${componentSizes.headerHeight.small};
+  padding: 0 ${space.l};
   background-color: ${color.white};
   display: flex;
   align-items: center;
   top: 0;
-  height: ${componentSizes.headerHeight.small};
   z-index: ${props => props.$zIndex}; /* z-index defined in main application, above drawer */
+
+  &.kirk-topBar--scrolled {
+    border-bottom: 1px solid ${color.gray};
+  }
 
   .kirk-topBar-inner {
     display: flex;
@@ -43,6 +48,7 @@ export const StyledTopBar = styled.header<{ $zIndex: number }>`
 
   @media (${responsiveBreakpoints.isMediaLarge}) {
     height: ${componentSizes.headerHeight.large};
+    padding: 0 ${space.xl};
 
     .kirk-topBar-inner {
       width: 1280px;

--- a/src/topBar/TopBar.tsx
+++ b/src/topBar/TopBar.tsx
@@ -5,7 +5,7 @@ import { StyledTopBar } from './TopBar.style'
 
 export type TopBarProps = Readonly<{
   className?: string
-  zIndex?: number
+  zIndex: number
   leftItem?: ReactNode
   rightItem?: ReactNode
   centerItem?: ReactNode
@@ -35,7 +35,7 @@ export const TopBar = ({ className, leftItem, rightItem, centerItem, zIndex }: T
     )
   }
   return (
-    <StyledTopBar className={cc(['kirk-topBar', className])} zIndex={zIndex}>
+    <StyledTopBar className={cc(['kirk-topBar', className])} $zIndex={zIndex}>
       <div className="kirk-topBar-inner">{children}</div>
     </StyledTopBar>
   )

--- a/src/topBar/TopBar.tsx
+++ b/src/topBar/TopBar.tsx
@@ -1,34 +1,17 @@
-import React, { Fragment, ReactNode } from 'react'
+import React, { ReactNode } from 'react'
 import cc from 'classcat'
 
 import { StyledTopBar } from './TopBar.style'
 
 export type TopBarProps = Readonly<{
   className?: string
+  zIndex?: number
   leftItem?: ReactNode
   rightItem?: ReactNode
   centerItem?: ReactNode
-  fixed?: boolean
-  bgTransparent?: boolean
-  bgShadedTransparent?: boolean
-  innerWrapperClassName?: string
 }>
 
-export const TopBar = ({
-  className,
-  leftItem,
-  rightItem,
-  centerItem,
-  fixed = false,
-  bgShadedTransparent = false,
-  bgTransparent = false,
-  innerWrapperClassName = null,
-}: TopBarProps) => {
-  const Wrapper = innerWrapperClassName ? (
-    <div className={cc([innerWrapperClassName])} />
-  ) : (
-    <Fragment />
-  )
+export const TopBar = ({ className, leftItem, rightItem, centerItem, zIndex }: TopBarProps) => {
   const children = []
   if (leftItem) {
     children.push(
@@ -52,18 +35,8 @@ export const TopBar = ({
     )
   }
   return (
-    <StyledTopBar
-      className={cc([
-        'kirk-topBar',
-        {
-          'kirk-topBar--fixed': fixed,
-          'kirk-topBar--bgShadedTransparent': bgShadedTransparent,
-          'kirk-topBar--bgTransparent': bgTransparent,
-        },
-        className,
-      ])}
-    >
-      {React.cloneElement(Wrapper, {}, children)}
+    <StyledTopBar className={cc(['kirk-topBar', className])} zIndex={zIndex}>
+      <div className="kirk-topBar-inner">{children}</div>
     </StyledTopBar>
   )
 }

--- a/src/topBar/TopBar.tsx
+++ b/src/topBar/TopBar.tsx
@@ -9,9 +9,17 @@ export type TopBarProps = Readonly<{
   leftItem?: ReactNode
   rightItem?: ReactNode
   centerItem?: ReactNode
+  hasScrolled?: boolean
 }>
 
-export const TopBar = ({ className, leftItem, rightItem, centerItem, zIndex }: TopBarProps) => {
+export const TopBar = ({
+  className,
+  leftItem,
+  rightItem,
+  centerItem,
+  zIndex,
+  hasScrolled,
+}: TopBarProps) => {
   const children = []
   if (leftItem) {
     children.push(
@@ -35,7 +43,10 @@ export const TopBar = ({ className, leftItem, rightItem, centerItem, zIndex }: T
     )
   }
   return (
-    <StyledTopBar className={cc(['kirk-topBar', className])} $zIndex={zIndex}>
+    <StyledTopBar
+      className={cc(['kirk-topBar', { 'kirk-topBar--scrolled': hasScrolled }, className])}
+      $zIndex={zIndex}
+    >
       <div className="kirk-topBar-inner">{children}</div>
     </StyledTopBar>
   )

--- a/src/topBar/TopBar.unit.tsx
+++ b/src/topBar/TopBar.unit.tsx
@@ -13,26 +13,6 @@ describe('TopBar', () => {
     expect(topBar.hasClass('kirk-topBar--bgShadedTransparent')).toBe(false)
   })
 
-  it('should have the custom class on inner wrapper', () => {
-    const topBar = shallow(<TopBar innerWrapperClassName="test" />)
-    expect(topBar.find('.test').exists()).toBe(true)
-  })
-
-  it('should have the fixed modifier class', () => {
-    const topBar = shallow(<TopBar fixed />)
-    expect(topBar.hasClass('kirk-topBar--fixed')).toBe(true)
-  })
-
-  it('should have the bgTransparent modifier class', () => {
-    const topBar = shallow(<TopBar bgTransparent />)
-    expect(topBar.hasClass('kirk-topBar--bgTransparent')).toBe(true)
-  })
-
-  it('should have the bgShadedTransparent modifier class', () => {
-    const topBar = shallow(<TopBar bgShadedTransparent />)
-    expect(topBar.hasClass('kirk-topBar--bgShadedTransparent')).toBe(true)
-  })
-
   it('should have a clickable button ', () => {
     const onClick = jest.fn()
     const topBar = mount(<TopBar leftItem={<Button onClick={onClick} />} />)

--- a/src/topBar/TopBar.unit.tsx
+++ b/src/topBar/TopBar.unit.tsx
@@ -5,12 +5,14 @@ import { Button } from '../button'
 import { TopBar } from './TopBar'
 
 describe('TopBar', () => {
-  it('should not have any modifier classes', () => {
+  it('should not have the scrolled class if hasScrolled is false or null', () => {
     const topBar = shallow(<TopBar zIndex={50} />)
-    expect(topBar.hasClass('kirk-topBar--fixed')).toBe(false)
-    expect(topBar.hasClass('kirk-topBar--overlayed')).toBe(false)
-    expect(topBar.hasClass('kirk-topBar--bgTransparent')).toBe(false)
-    expect(topBar.hasClass('kirk-topBar--bgShadedTransparent')).toBe(false)
+    expect(topBar.hasClass('kirk-topBar--scrolled')).toBe(false)
+  })
+
+  it('should not have the scrolled class if hasScrolled is true', () => {
+    const topBar = shallow(<TopBar zIndex={50} hasScrolled />)
+    expect(topBar.hasClass('kirk-topBar--scrolled')).toBe(true)
   })
 
   it('should have a clickable button ', () => {

--- a/src/topBar/TopBar.unit.tsx
+++ b/src/topBar/TopBar.unit.tsx
@@ -6,7 +6,7 @@ import { TopBar } from './TopBar'
 
 describe('TopBar', () => {
   it('should not have any modifier classes', () => {
-    const topBar = shallow(<TopBar />)
+    const topBar = shallow(<TopBar zIndex={50} />)
     expect(topBar.hasClass('kirk-topBar--fixed')).toBe(false)
     expect(topBar.hasClass('kirk-topBar--overlayed')).toBe(false)
     expect(topBar.hasClass('kirk-topBar--bgTransparent')).toBe(false)
@@ -15,7 +15,7 @@ describe('TopBar', () => {
 
   it('should have a clickable button ', () => {
     const onClick = jest.fn()
-    const topBar = mount(<TopBar leftItem={<Button onClick={onClick} />} />)
+    const topBar = mount(<TopBar zIndex={50} leftItem={<Button onClick={onClick} />} />)
     expect(topBar.find('button')).toHaveLength(1)
     const button = topBar.find('button')
     button.simulate('click')
@@ -23,19 +23,19 @@ describe('TopBar', () => {
   })
 
   it('should have a left area with a button', () => {
-    const topBar = mount(<TopBar leftItem={<Button />} />)
+    const topBar = mount(<TopBar zIndex={50} leftItem={<Button />} />)
     const leftArea = topBar.find('.kirk-topBar-left')
     expect(leftArea.contains(<Button />)).toBe(true)
   })
 
   it('should have a right area with a span', () => {
-    const topBar = mount(<TopBar rightItem={<span>Test</span>} />)
+    const topBar = mount(<TopBar zIndex={50} rightItem={<span>Test</span>} />)
     const rightArea = topBar.find('.kirk-topBar-right')
     expect(rightArea.contains(<span>Test</span>)).toBe(true)
   })
 
   it('should have a center area', () => {
-    const topBar = mount(<TopBar centerItem={<span>Test</span>} />)
+    const topBar = mount(<TopBar zIndex={50} centerItem={<span>Test</span>} />)
     expect(topBar.find('.kirk-topBar-center')).toHaveLength(1)
   })
 })

--- a/src/topBar/drawer/Drawer.style.tsx
+++ b/src/topBar/drawer/Drawer.style.tsx
@@ -17,31 +17,10 @@ export const StyledDrawer = styled.aside<{ $zIndex?: number }>`
     transition-delay: 0;
   }
 
-  &::after {
-    content: '';
-    font-size: 0;
-  }
-
-  &.kirk-drawer--open::after {
-    content: none;
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
-    z-index: 2; /* z-index overridden in main application, above dimmer - below topBar */
-    background-color: rgba(0, 0, 0, 0.3);
-    transition: background-color ${transition.duration.base} linear;
-  }
-
   &.kirk-drawer--close {
     visibility: hidden; /* Hiding the drawer when closed, otherwise on mac/ios we can scroll top off screen and see it */
     transition-delay: 300ms;
     transition-property: visibility;
-  }
-
-  &.kirk-drawer--close::after {
-    background-color: rgba(0, 0, 0, 0);
   }
 
   & .kirk-drawer-scrollableContent {

--- a/src/topBar/drawer/Drawer.style.tsx
+++ b/src/topBar/drawer/Drawer.style.tsx
@@ -1,15 +1,20 @@
 import styled from 'styled-components'
 
-import { color, transition } from '../../_utils/branding'
+import { color, componentSizes, responsiveBreakpoints, transition } from '../../_utils/branding'
 
-export const StyledDrawer = styled.aside`
+export const StyledDrawer = styled.aside<{ zIndex?: number }>`
+  /* z-index handled in main application */
+
   &.kirk-drawer--open {
     position: fixed;
     top: 0;
     left: 0;
     bottom: 0;
     right: 0;
-    z-index: 1;
+    z-index: ${props =>
+      props.zIndex || 2}; /* z-index overridden in main application, above dimmer - below topBar */
+    visibility: visible;
+    transition-delay: 0;
   }
 
   &::after {
@@ -18,14 +23,21 @@ export const StyledDrawer = styled.aside`
   }
 
   &.kirk-drawer--open::after {
+    content: none;
     position: absolute;
     top: 0;
     left: 0;
     bottom: 0;
     right: 0;
-    z-index: 1;
+    z-index: 2; /* z-index overridden in main application, above dimmer - below topBar */
     background-color: rgba(0, 0, 0, 0.3);
     transition: background-color ${transition.duration.base} linear;
+  }
+
+  &.kirk-drawer--close {
+    visibility: hidden; /* Hiding the drawer when closed, otherwise on mac/ios we can scroll top off screen and see it */
+    transition-delay: 300ms;
+    transition-property: visibility;
   }
 
   &.kirk-drawer--close::after {
@@ -35,8 +47,9 @@ export const StyledDrawer = styled.aside`
   & .kirk-drawer-scrollableContent {
     position: absolute;
     z-index: 2;
-    top: 0;
     left: 0;
+    top: ${componentSizes.headerHeight.small};
+    bottom: 0;
     overflow-y: auto;
     background-color: ${color.white};
     transition: transform ${transition.duration.base} ease-in-out;
@@ -53,5 +66,49 @@ export const StyledDrawer = styled.aside`
 
   &.kirk-drawer--close .kirk-drawer-scrollableContent {
     transform: translateY(-100%);
+  }
+
+  @media (${responsiveBreakpoints.isMediaLarge}) {
+    && {
+      left: 50%;
+      right: auto;
+      top: 0;
+      bottom: 0;
+      width: 100%;
+      width: ${componentSizes.headerWidth.large};
+      position: fixed;
+      transform: translate(-50%, 0);
+    }
+
+    .kirk-drawer-scrollableContent {
+      top: ${componentSizes.headerHeight.large};
+      left: auto;
+      right: auto;
+      width: ${componentSizes.drawerWidth.large};
+      float: right;
+      position: relative;
+    }
+
+    &.kirk-drawer--close .kirk-drawer-scrollableContent {
+      transform: translateY(-100vh);
+    }
+  }
+`
+
+export const StyledDimmer = styled.div<{ zIndex?: number }>`
+  visibility: hidden;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #000;
+  opacity: 0;
+  transition: opacity 350ms cubic-bezier(0.455, 0.03, 0.515, 0.955);
+
+  &.kirk-drawer-dimmer--active {
+    visibility: visible;
+    opacity: 0.07;
+    z-index: ${props =>
+      props.zIndex || 1}; /* z-index overridden in main application, below drawer */
   }
 `

--- a/src/topBar/drawer/Drawer.style.tsx
+++ b/src/topBar/drawer/Drawer.style.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 import { color, componentSizes, responsiveBreakpoints, transition } from '../../_utils/branding'
 
-export const StyledDrawer = styled.aside<{ zIndex?: number }>`
+export const StyledDrawer = styled.aside<{ $zIndex?: number }>`
   /* z-index handled in main application */
 
   &.kirk-drawer--open {
@@ -12,7 +12,7 @@ export const StyledDrawer = styled.aside<{ zIndex?: number }>`
     bottom: 0;
     right: 0;
     z-index: ${props =>
-      props.zIndex || 2}; /* z-index overridden in main application, above dimmer - below topBar */
+      props.$zIndex}; /* z-index defined in main application, above dimmer - below topBar */
     visibility: visible;
     transition-delay: 0;
   }
@@ -95,7 +95,7 @@ export const StyledDrawer = styled.aside<{ zIndex?: number }>`
   }
 `
 
-export const StyledDimmer = styled.div<{ zIndex?: number }>`
+export const StyledDimmer = styled.div<{ $zIndex: number }>`
   visibility: hidden;
   position: fixed;
   top: 0;
@@ -108,7 +108,6 @@ export const StyledDimmer = styled.div<{ zIndex?: number }>`
   &.kirk-drawer-dimmer--active {
     visibility: visible;
     opacity: 0.07;
-    z-index: ${props =>
-      props.zIndex || 1}; /* z-index overridden in main application, below drawer */
+    z-index: ${props => props.$zIndex}; /* z-index defined in main application, below drawer */
   }
 `

--- a/src/topBar/drawer/Drawer.tsx
+++ b/src/topBar/drawer/Drawer.tsx
@@ -1,10 +1,10 @@
-import React, { PureComponent } from 'react'
+import React, { Fragment, PureComponent } from 'react'
 import cc from 'classcat'
 import { canUseDOM } from 'exenv'
 import { createGlobalStyle } from 'styled-components'
 
 import { KEYCODES } from '../../_utils/keycodes'
-import { StyledDrawer } from './Drawer.style'
+import { StyledDimmer, StyledDrawer } from './Drawer.style'
 
 const DrawerGlobalStyles = createGlobalStyle`
   .kirk-scroll-lock {
@@ -15,7 +15,7 @@ const DrawerGlobalStyles = createGlobalStyle`
 export type DrawerProps = Readonly<{
   children: string | JSX.Element
   className?: string
-  innerClassName?: string
+  zIndex?: number
   onOpen?: () => void
   onClose?: () => void
   onTransitionEnd?: (open: boolean) => void
@@ -27,6 +27,7 @@ export class Drawer extends PureComponent<DrawerProps> {
   private contentNode: HTMLDivElement
   static defaultProps: Partial<DrawerProps> = {
     width: '400px',
+    zIndex: 2,
     onOpen() {},
     onClose() {},
     onTransitionEnd() {},
@@ -92,28 +93,36 @@ export class Drawer extends PureComponent<DrawerProps> {
   }
 
   render() {
-    const { open, className, innerClassName, onTransitionEnd, children, width } = this.props
+    const { open, className, zIndex, onTransitionEnd, children, width } = this.props
     return (
-      <StyledDrawer
-        className={cc([
-          'kirk-drawer',
-          {
-            'kirk-drawer--open': open,
-            'kirk-drawer--close': !open,
-          },
-          className,
-        ])}
-      >
-        <div
-          ref={this.refContent}
-          className={cc(['kirk-drawer-scrollableContent', innerClassName])}
-          style={{ width }}
-          onTransitionEnd={() => onTransitionEnd(open)}
+      <Fragment>
+        <StyledDrawer
+          className={cc([
+            'kirk-drawer',
+            {
+              'kirk-drawer--open': open,
+              'kirk-drawer--close': !open,
+            },
+            className,
+          ])}
+          zIndex={zIndex}
         >
-          {children}
-        </div>
-        <DrawerGlobalStyles />
-      </StyledDrawer>
+          <div
+            ref={this.refContent}
+            className="kirk-drawer-scrollableContent"
+            style={{ width }}
+            onTransitionEnd={() => onTransitionEnd(open)}
+          >
+            {children}
+          </div>
+          <DrawerGlobalStyles />
+        </StyledDrawer>
+        <StyledDimmer
+          className={cc([['kirk-drawer-dimmer', { 'kirk-drawer-dimmer--active': open }]])}
+          zIndex={zIndex - 1}
+          aria-hidden="true"
+        />
+      </Fragment>
     )
   }
 }

--- a/src/topBar/drawer/Drawer.tsx
+++ b/src/topBar/drawer/Drawer.tsx
@@ -121,6 +121,7 @@ export class Drawer extends PureComponent<DrawerProps> {
           className={cc([['kirk-drawer-dimmer', { 'kirk-drawer-dimmer--active': open }]])}
           $zIndex={zIndex - 1}
           aria-hidden="true"
+          onClick={() => this.close()} // close Drawer when clicking outside the <aside> element too
         />
       </Fragment>
     )

--- a/src/topBar/drawer/Drawer.tsx
+++ b/src/topBar/drawer/Drawer.tsx
@@ -105,7 +105,7 @@ export class Drawer extends PureComponent<DrawerProps> {
             },
             className,
           ])}
-          zIndex={zIndex}
+          $zIndex={zIndex}
         >
           <div
             ref={this.refContent}
@@ -119,7 +119,7 @@ export class Drawer extends PureComponent<DrawerProps> {
         </StyledDrawer>
         <StyledDimmer
           className={cc([['kirk-drawer-dimmer', { 'kirk-drawer-dimmer--active': open }]])}
-          zIndex={zIndex - 1}
+          $zIndex={zIndex - 1}
           aria-hidden="true"
         />
       </Fragment>

--- a/src/topBar/drawer/Drawer.unit.tsx
+++ b/src/topBar/drawer/Drawer.unit.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
+import { render, screen } from '@testing-library/react'
+
 import { Drawer } from './index'
 
 const defaultProps = {
@@ -10,12 +12,10 @@ const defaultProps = {
 describe('Drawer', () => {
   it('Renders with a custom className', () => {
     const customClassName = 'custom-drawer'
-    const wrapper = shallow(
-      <Drawer {...defaultProps} className={customClassName}>
-        body
-      </Drawer>,
-    )
-    expect(wrapper.hasClass(customClassName)).toBe(true)
+    render(<Drawer {...defaultProps} className={customClassName} />)
+    // getByRole('complementary') should match <aside>, but it doesn't...
+    const items = screen.getAllByText('')
+    expect(items[2]).toHaveClass(customClassName)
   })
 
   it('Should call `onOpen` and `scrollLock` after open', () => {


### PR DESCRIPTION
The current TopBar has lots of style rules in the main app that should come from the ui-library component.
With that PR, only 2 rules remain, waiting for a more important refactoring of the component itself.

Also removed unnecessary style and added close() to the dimmer which is now included along with the drawer.

Tested locally on Firefox MacOS, with canary release