### PR TITLE
Releases/55.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Unreleased
+
 - [...]
-- **[BREAKING CHANGE]** Remove root exports 
+
+# v55.0.0 (18/03/2021)
+
+- **[BREAKING CHANGE]** Remove root exports
+- **[UPDATE]** Allow newer node/npm version
 
 # v54.0.1 (12/03/2021)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "54.0.1",
+  "version": "55.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blablacar/ui-library",
-      "version": "54.0.1",
+      "version": "55.0.0",
       "license": "MIT",
       "dependencies": {
         "country-telephone-data": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "54.0.1",
+  "version": "55.0.0",
   "description": "BlaBlaCar React UI component library",
   "homepage": "https://blablacar.github.io/ui-library",
   "repository": {


### PR DESCRIPTION
# v55.0.0 (18/03/2021)

- **[BREAKING CHANGE]** Remove root exports
- **[UPDATE]** Allow newer node/npm version