### PR TITLE
Moved ModalFog component as a generic component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- [...]
+- **[BREAKING CHANGE]** Replaced `ModalFog` by a new `Fog` component
 
 # v55.0.0 (18/03/2021)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "lodash.uniqueid": "4.0.1",
         "react-day-picker": "7.3.0",
         "react-transition-group": "4.4.1",
-        "uuid": "3.3.3"
+        "uuid": "3.3.3",
+        "wicg-inert": "3.1.1"
       },
       "devDependencies": {
         "@babel/cli": "7.12.1",
@@ -15370,8 +15371,7 @@
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
       "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-      "dev": true,
-      "hasInstallScript": true
+      "dev": true
     },
     "node_modules/babel-runtime/node_modules/regenerator-runtime": {
       "version": "0.11.1",
@@ -15553,10 +15553,7 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "optional": true
     },
     "node_modules/bindings": {
       "version": "1.5.0",
@@ -17061,8 +17058,7 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.7.0.tgz",
       "integrity": "sha512-NwS7fI5M5B85EwpWuIwJN4i/fbisQUwLwiSNUWeXlkAZ0sbBjLEvLvFLf1uzAUV66PcEPt4xCGCmOZSxVf3xzA==",
-      "dev": true,
-      "hasInstallScript": true
+      "dev": true
     },
     "node_modules/core-js-compat": {
       "version": "3.7.0",
@@ -17087,8 +17083,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.5.0.tgz",
       "integrity": "sha512-wB0QtKAofWigiISuT1Tej3hKgq932fB//Lf1VoPbiLpTYlHY0nIDhgF+q1na0DAKFHH5wGCirkAknOmDN8ijXA==",
-      "dev": true,
-      "hasInstallScript": true
+      "dev": true
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -22891,6 +22886,7 @@
         "ignore-walk",
         "inflight",
         "inherits",
+        "ini",
         "is-fullwidth-code-point",
         "isarray",
         "minimatch",
@@ -22931,8 +22927,7 @@
         "util-deprecate",
         "wide-align",
         "wrappy",
-        "yallist",
-        "ini"
+        "yallist"
       ],
       "dev": true,
       "hasInstallScript": true,
@@ -22951,30 +22946,34 @@
     },
     "node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -22982,15 +22981,17 @@
     },
     "node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -22998,66 +22999,75 @@
     },
     "node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/debug": {
       "version": "3.2.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -23067,24 +23077,27 @@
     },
     "node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.7",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^2.6.0"
       }
     },
     "node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -23098,9 +23111,10 @@
     },
     "node_modules/fsevents/node_modules/glob": {
       "version": "7.1.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -23118,15 +23132,17 @@
     },
     "node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -23136,18 +23152,20 @@
     },
     "node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minimatch": "^3.0.4"
       }
     },
     "node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -23155,24 +23173,27 @@
     },
     "node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -23182,15 +23203,17 @@
     },
     "node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -23200,15 +23223,17 @@
     },
     "node_modules/fsevents/node_modules/minimist": {
       "version": "0.0.8",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/minipass": {
       "version": "2.9.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -23216,18 +23241,20 @@
     },
     "node_modules/fsevents/node_modules/minizlib": {
       "version": "1.3.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minipass": "^2.9.0"
       }
     },
     "node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minimist": "0.0.8"
       },
@@ -23237,15 +23264,17 @@
     },
     "node_modules/fsevents/node_modules/ms": {
       "version": "2.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/needle": {
       "version": "2.4.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -23260,9 +23289,10 @@
     },
     "node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.14.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -23281,9 +23311,10 @@
     },
     "node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -23294,24 +23325,27 @@
     },
     "node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "node_modules/fsevents/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.7",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1"
@@ -23319,9 +23353,10 @@
     },
     "node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -23331,54 +23366,60 @@
     },
     "node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -23386,24 +23427,27 @@
     },
     "node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -23416,15 +23460,17 @@
     },
     "node_modules/fsevents/node_modules/rc/node_modules/minimist": {
       "version": "1.2.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -23437,9 +23483,10 @@
     },
     "node_modules/fsevents/node_modules/rimraf": {
       "version": "2.7.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -23449,57 +23496,65 @@
     },
     "node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/semver": {
       "version": "5.7.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -23511,9 +23566,10 @@
     },
     "node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -23523,18 +23579,20 @@
     },
     "node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/tar": {
       "version": "4.4.13",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -23550,30 +23608,34 @@
     },
     "node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
       }
     },
     "node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/yallist": {
       "version": "3.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -24705,7 +24767,6 @@
       "resolved": "https://registry.npmjs.org/husky/-/husky-1.3.1.tgz",
       "integrity": "sha512-86U6sVVVf4b5NYSZ0yvv88dRgBSSXXmHaiq5pP4KDj5JVzdwKgBjEtUPOm8hcoytezFwbU+7gotXNhpHdystlg==",
       "dev": true,
-      "hasInstallScript": true,
       "dependencies": {
         "cosmiconfig": "^5.0.7",
         "execa": "^1.0.0",
@@ -25384,9 +25445,6 @@
       "optional": true,
       "dependencies": {
         "binary-extensions": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-boolean-object": {
@@ -38471,9 +38529,6 @@
         "graceful-fs": "^4.1.11",
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/readline": {
@@ -40616,6 +40671,11 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -44370,7 +44430,6 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.3.2.tgz",
       "integrity": "sha512-NppHzIFavZ3TsIU3R1omtddJ0Bv1+j50AKh3ZWyXHuFvJq1I8qkQ5mZ7uQgD89Y8zJNx2qRo6RqAH1BmoVafHw==",
       "dev": true,
-      "hasInstallScript": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.0.0",
@@ -46065,11 +46124,7 @@
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
       "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=4",
-        "yarn": "*"
-      }
+      "optional": true
     },
     "node_modules/update-notifier": {
       "version": "2.5.0",
@@ -47114,6 +47169,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/wicg-inert": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.1.tgz",
+      "integrity": "sha512-PhBaNh8ur9Xm4Ggy4umelwNIP6pPP1bv3EaWaKqfb/QNme2rdLjm7wIInvV4WhxVHhzA4Spgw9qNSqWtB/ca2A=="
     },
     "node_modules/wide-align": {
       "version": "1.1.3",
@@ -67769,22 +67829,26 @@
         "abbrev": {
           "version": "1.1.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -67793,12 +67857,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -67807,32 +67873,38 @@
         "chownr": {
           "version": "1.1.3",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "debug": {
           "version": "3.2.6",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -67840,22 +67912,26 @@
         "deep-extend": {
           "version": "0.6.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "fs-minipass": {
           "version": "1.2.7",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.6.0"
           }
@@ -67863,12 +67939,14 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -67883,7 +67961,8 @@
         "glob": {
           "version": "7.1.6",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -67896,12 +67975,14 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -67909,7 +67990,8 @@
         "ignore-walk": {
           "version": "3.0.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
@@ -67917,7 +67999,8 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -67926,17 +68009,20 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -67944,12 +68030,14 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -67957,12 +68045,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -67971,7 +68061,8 @@
         "minizlib": {
           "version": "1.3.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.9.0"
           }
@@ -67979,7 +68070,8 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -67987,12 +68079,14 @@
         "ms": {
           "version": "2.1.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "needle": {
           "version": "2.4.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
@@ -68002,7 +68096,8 @@
         "node-pre-gyp": {
           "version": "0.14.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
@@ -68019,7 +68114,8 @@
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -68028,7 +68124,8 @@
         "npm-bundled": {
           "version": "1.1.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
@@ -68036,12 +68133,14 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.7",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1"
@@ -68050,7 +68149,8 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -68061,17 +68161,20 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -68079,17 +68182,20 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -68098,17 +68204,20 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -68119,14 +68228,16 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -68140,7 +68251,8 @@
         "rimraf": {
           "version": "2.7.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -68148,37 +68260,44 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "sax": {
           "version": "1.2.4",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.7.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -68186,7 +68305,8 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -68196,7 +68316,8 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -68204,12 +68325,14 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "tar": {
           "version": "4.4.13",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -68223,12 +68346,14 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
@@ -68236,12 +68361,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -87769,6 +87896,11 @@
           "dev": true
         }
       }
+    },
+    "wicg-inert": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/wicg-inert/-/wicg-inert-3.1.1.tgz",
+      "integrity": "sha512-PhBaNh8ur9Xm4Ggy4umelwNIP6pPP1bv3EaWaKqfb/QNme2rdLjm7wIInvV4WhxVHhzA4Spgw9qNSqWtB/ca2A=="
     },
     "wide-align": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,8 @@
     "lodash.uniqueid": "4.0.1",
     "react-day-picker": "7.3.0",
     "react-transition-group": "4.4.1",
-    "uuid": "3.3.3"
+    "uuid": "3.3.3",
+    "wicg-inert": "3.1.1"
   },
   "peerDependencies": {
     "classcat": "4.0.2",

--- a/src/fog/Fog.story.mdx
+++ b/src/fog/Fog.story.mdx
@@ -1,0 +1,51 @@
+import { Fragment } from 'react'
+import { action } from '@storybook/addon-actions'
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks'
+import { boolean } from '@storybook/addon-knobs'
+
+import { FocusVisibleProvider } from '../_utils/focusVisibleProvider'
+import { ItemChoice, ItemChoiceStatus } from '../itemChoice'
+import { Paragraph } from '../paragraph'
+import { TheVoice } from '../theVoice'
+import { Fog } from './index'
+
+<Meta title="Fog" />
+
+# **Fog**
+
+<Canvas>
+  <Story name="Default">
+    <FocusVisibleProvider>
+      <Fragment>
+        <ItemChoice
+          label="Outside of the Fog"
+          status={ItemChoiceStatus.DEFAULT}
+          onClick={action('click outside the fog')}
+        />
+        <Fog isLoading={boolean('isLoading', false)}>
+          <TheVoice>Fog Component</TheVoice>
+          <Paragraph>
+            When fog has isLoading set to true the Fog component will be displayed above its children
+            with semi-transparent background, making any interaction with the layer under impossible.
+            Check the isLoading checkbox for trying it out, and test the keyboard navigation.
+            It should be impossible to click on the ItemChoice inside the Fog is in isLoading mode
+          </Paragraph>
+          <ItemChoice
+            label="Inside the Fog"
+            status={ItemChoiceStatus.DEFAULT}
+            onClick={action('click inside the fog')}
+          />
+        </Fog>
+      </Fragment>
+    </FocusVisibleProvider>
+  </Story>
+</Canvas>
+
+## Usage
+
+```jsx
+import { Fog } from '@blablacar/ui-library/build/fog'
+<Fog />
+```
+
+<ArgsTable of={Fog} />

--- a/src/fog/Fog.style.tsx
+++ b/src/fog/Fog.style.tsx
@@ -1,0 +1,26 @@
+import styled from 'styled-components'
+
+import { color } from '../_utils/branding'
+
+export const StyledFogContainer = styled.div`
+  position: relative;
+`
+
+type FogProps = {
+  $isLoading?: boolean
+}
+
+const transitionDelay = '420ms'
+const transitionTimingFunction = 'ease-in-out'
+
+export const StyledFog = styled.div<FogProps>`
+  position: absolute;
+  background: ${color.white};
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+  opacity: ${props => (props.$isLoading ? 0.64 : 0)};
+  visibility: ${props => (props.$isLoading ? '' : 'hidden')};
+  transition: opacity ${transitionDelay} ${transitionTimingFunction},
+    visibility ${transitionDelay} ${transitionTimingFunction};
+`

--- a/src/fog/Fog.tsx
+++ b/src/fog/Fog.tsx
@@ -12,6 +12,8 @@ export type FogProps = Readonly<{
 export const Fog = ({ isLoading, children }: FogProps) => (
   <StyledFogContainer>
     <StyledFog $isLoading={isLoading} aria-hidden="true" />
-    <div ref={node => node && isLoading && node.setAttribute('inert', '')}>{children}</div>
+    <div ref={node => node && isLoading && node.setAttribute('inert', '')} aria-hidden={isLoading}>
+      {children}
+    </div>
   </StyledFogContainer>
 )

--- a/src/fog/Fog.tsx
+++ b/src/fog/Fog.tsx
@@ -12,7 +12,13 @@ export type FogProps = Readonly<{
 export const Fog = ({ isLoading, children }: FogProps) => (
   <StyledFogContainer>
     <StyledFog $isLoading={isLoading} aria-hidden="true" />
-    <div ref={node => node && isLoading && node.setAttribute('inert', '')} aria-hidden={isLoading}>
+    <div
+      ref={
+        node => node && (isLoading ? node.setAttribute('inert', '') : node.removeAttribute('inert'))
+        // eslint-disable-next-line react/jsx-curly-newline
+      }
+      aria-hidden={isLoading}
+    >
       {children}
     </div>
   </StyledFogContainer>

--- a/src/fog/Fog.tsx
+++ b/src/fog/Fog.tsx
@@ -1,0 +1,21 @@
+import React, { Fragment } from 'react'
+
+import 'wicg-inert'
+
+import { StyledFog, StyledFogContainer } from './Fog.style'
+
+export type FogProps = Readonly<{
+  isLoading?: boolean
+  children: React.ReactNode
+}>
+
+export const Fog = ({ isLoading, children }: FogProps) => (
+  <StyledFogContainer>
+    <Fragment>
+      <StyledFog $isLoading={isLoading} aria-hidden="true" />
+      <section ref={node => node && isLoading && node.setAttribute('inert', '')}>
+        {children}
+      </section>
+    </Fragment>
+  </StyledFogContainer>
+)

--- a/src/fog/Fog.tsx
+++ b/src/fog/Fog.tsx
@@ -13,9 +13,12 @@ export const Fog = ({ isLoading, children }: FogProps) => (
   <StyledFogContainer>
     <Fragment>
       <StyledFog $isLoading={isLoading} aria-hidden="true" />
-      <section ref={node => node && isLoading && node.setAttribute('inert', '')}>
+      <div
+        ref={node => node && isLoading && node.setAttribute('inert', '')}
+        aria-hidden={isLoading}
+      >
         {children}
-      </section>
+      </div>
     </Fragment>
   </StyledFogContainer>
 )

--- a/src/fog/Fog.tsx
+++ b/src/fog/Fog.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 
 import 'wicg-inert'
 
@@ -11,14 +11,7 @@ export type FogProps = Readonly<{
 
 export const Fog = ({ isLoading, children }: FogProps) => (
   <StyledFogContainer>
-    <Fragment>
-      <StyledFog $isLoading={isLoading} aria-hidden="true" />
-      <div
-        ref={node => node && isLoading && node.setAttribute('inert', '')}
-        aria-hidden={isLoading}
-      >
-        {children}
-      </div>
-    </Fragment>
+    <StyledFog $isLoading={isLoading} aria-hidden="true" />
+    <div ref={node => node && isLoading && node.setAttribute('inert', '')}>{children}</div>
   </StyledFogContainer>
 )

--- a/src/fog/Fog.unit.tsx
+++ b/src/fog/Fog.unit.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { Fog } from './Fog'
+
+describe('Fog', () => {
+  it('should be able to click on an interactive element', () => {
+    const onClick = jest.fn()
+    render(
+      <Fog>
+        <button onClick={onClick}>Button</button>
+      </Fog>,
+    )
+
+    const button = screen.getByRole('button')
+    fireEvent.click(button)
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  it('should not be able to click on an interactive element', () => {
+    const onClick = jest.fn()
+    render(
+      <Fog isLoading>
+        <button onClick={onClick}>Button</button>
+      </Fog>,
+    )
+
+    const button = screen.getByRole('button')
+    expect(onClick).not.toHaveBeenCalled()
+  })
+})

--- a/src/fog/Fog.unit.tsx
+++ b/src/fog/Fog.unit.tsx
@@ -26,7 +26,6 @@ describe('Fog', () => {
       </Fog>,
     )
 
-    const button = screen.getByRole('button')
-    expect(onClick).not.toHaveBeenCalled()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
 })

--- a/src/fog/index.tsx
+++ b/src/fog/index.tsx
@@ -1,0 +1,1 @@
+export { Fog, FogProps } from './Fog'

--- a/src/modal/Modal.style.tsx
+++ b/src/modal/Modal.style.tsx
@@ -126,22 +126,3 @@ export const ModalFooter = styled.div`
     border-top: 1px solid ${color.gray};
   }
 `
-
-type ModalFogProps = {
-  isLoading?: boolean
-}
-
-const transitionDelay = '420ms'
-const transitionTimingFunction = 'ease-in-out'
-
-export const ModalFog = styled.div<ModalFogProps>`
-  position: absolute;
-  background: ${color.white};
-  width: 100%;
-  height: 100%;
-  z-index: 1;
-  opacity: ${props => (props.isLoading ? 0.64 : 0)};
-  visibility: ${props => (props.isLoading ? '' : 'hidden')};
-  transition: opacity ${transitionDelay} ${transitionTimingFunction},
-    visibility ${transitionDelay} ${transitionTimingFunction};
-`

--- a/src/modal/index.tsx
+++ b/src/modal/index.tsx
@@ -1,2 +1,2 @@
 export { Modal, ModalSize, ModalProps } from './Modal'
-export { ModalBody, ModalFooter, ModalFog } from './Modal.style'
+export { ModalBody, ModalFooter } from './Modal.style'

--- a/src/modal/storyUtils/ModalOpener.tsx
+++ b/src/modal/storyUtils/ModalOpener.tsx
@@ -1,12 +1,13 @@
 import React, { Component, createRef } from 'react'
 
 import { FilterBar } from '../../filterBar'
+import { Fog } from '../../fog'
 import { CarpoolIcon } from '../../icon'
 import { ItemCheckbox } from '../../itemCheckbox'
 import { BaseSection as Section } from '../../layout/section/baseSection'
 import { SubHeader } from '../../subHeader/SubHeader'
 import { TheVoice } from '../../theVoice'
-import { Modal, ModalBody, ModalFog, ModalFooter, ModalProps } from '../index'
+import { Modal, ModalBody, ModalFooter, ModalProps } from '../index'
 
 export class ModalOpener extends Component<ModalProps> {
   state = {
@@ -53,25 +54,26 @@ export class ModalOpener extends Component<ModalProps> {
           layoutModeEnabled
         >
           <ModalBody>
-            <ModalFog aria-hidden="true" isLoading={this.props.isLoading} />
-            <TheVoice>Filters</TheVoice>
-            <Section>
-              <SubHeader>Amenities & Services</SubHeader>
-            </Section>
-            <Section noHorizontalSpacing>
-              <ItemCheckbox name="ladies" label="Ladies only" />
-              <ItemCheckbox name="automatic" label="Automatic Approval" />
-              <ItemCheckbox name="wifi" label="Wifi" />
-              <ItemCheckbox name="air" label="Air conditioning" />
-              <ItemCheckbox name="reclining" label="Reclining seats" />
-              <ItemCheckbox name="personal" label="Personal power outlets" />
-              <ItemCheckbox name="ladies" label="Ladies only" />
-              <ItemCheckbox name="automatic" label="Automatic Approval" />
-              <ItemCheckbox name="wifi" label="Wifi" />
-              <ItemCheckbox name="air" label="Air conditioning" />
-              <ItemCheckbox name="reclining" label="Reclining seats" />
-              <ItemCheckbox name="personal" label="Personal power outlets" />
-            </Section>
+            <Fog isLoading={this.props.isLoading}>
+              <TheVoice>Filters</TheVoice>
+              <Section>
+                <SubHeader>Amenities & Services</SubHeader>
+              </Section>
+              <Section noHorizontalSpacing>
+                <ItemCheckbox name="ladies" label="Ladies only" />
+                <ItemCheckbox name="automatic" label="Automatic Approval" />
+                <ItemCheckbox name="wifi" label="Wifi" />
+                <ItemCheckbox name="air" label="Air conditioning" />
+                <ItemCheckbox name="reclining" label="Reclining seats" />
+                <ItemCheckbox name="personal" label="Personal power outlets" />
+                <ItemCheckbox name="ladies" label="Ladies only" />
+                <ItemCheckbox name="automatic" label="Automatic Approval" />
+                <ItemCheckbox name="wifi" label="Wifi" />
+                <ItemCheckbox name="air" label="Air conditioning" />
+                <ItemCheckbox name="reclining" label="Reclining seats" />
+                <ItemCheckbox name="personal" label="Personal power outlets" />
+              </Section>
+            </Fog>
           </ModalBody>
           <ModalFooter>
             <FilterBar


### PR DESCRIPTION
## Description

Moved ModalFog component as a generic component so we can use it anywhere.

![Kapture 2021-03-18 at 17 16 46](https://user-images.githubusercontent.com/1606624/111660226-25cc5580-880e-11eb-8b1c-80b97750d27b.gif)

## What has been done

- Created `Fog`
- Unit tests to make sure we can't click on elements underneath `Fog` when it is in loading state 
 
## Things to consider

- Added a polyfill on `inert` attr for a11y since it's still an experimental feature in all browsers

## How it was tested

Storybook + Unit test
