### PR TITLE
Release/56.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Unreleased
 
+- [...]
+
+# v56.0.0 (22/03/2021)
+
 - **[BREAKING CHANGE]** Replaced `ModalFog` by a new `Fog` component
 - **[NEW]** New `CardsStackSection`
 - **[UPDATE]** Allow polymorphism with `as` prop for `SubHeader`
 - **[UPDATE]** Allow polymorphism with `as` prop for `TheVoice`
-- [...]
 
 # v55.0.0 (18/03/2021)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "55.0.0",
+  "version": "56.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blablacar/ui-library",
-      "version": "55.0.0",
+      "version": "56.0.0",
       "license": "MIT",
       "dependencies": {
         "country-telephone-data": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "55.0.0",
+  "version": "56.0.0",
   "description": "BlaBlaCar React UI component library",
   "homepage": "https://blablacar.github.io/ui-library",
   "repository": {


### PR DESCRIPTION
## Description

- **[BREAKING CHANGE]** Replaced `ModalFog` by a new `Fog` component
- **[NEW]** New `CardsStackSection`
- **[UPDATE]** Allow polymorphism with `as` prop for `SubHeader`
- **[UPDATE]** Allow polymorphism with `as` prop for `TheVoice`
