### PR TITLE
Add title and tabIndex to A11yProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **[BREAKING CHANGE]** Add `title` and `tabIndex` props to `A11yProps` interface and `pickA11yProps` function
 - [...]
 
 # v56.0.0 (22/03/2021)

--- a/src/_utils/interfaces.ts
+++ b/src/_utils/interfaces.ts
@@ -11,6 +11,8 @@ export interface CommonFieldsProps {
 export interface A11yProps {
   id?: string
   role?: string
+  title?: string
+  tabIndex?: number
   'aria-label'?: string
   'aria-labelledby'?: string
   'aria-describedby'?: string
@@ -20,17 +22,23 @@ export interface A11yProps {
 type A11yKeys = keyof A11yProps
 
 export function pickA11yProps<T extends A11yProps>(source: T): Pick<T, A11yKeys> {
-  const returnValue = {} as Pick<T, A11yKeys>
+  const initialValue = {} as Pick<T, A11yKeys>
   const keys: A11yKeys[] = [
     'id',
     'role',
+    'title',
+    'tabIndex',
     'aria-label',
     'aria-labelledby',
     'aria-describedby',
     'aria-controls',
   ]
-  keys.forEach(k => {
-    returnValue[k] = source[k]
-  })
-  return returnValue
+
+  return keys.reduce(
+    (acc, key) => ({
+      ...acc,
+      [key]: source[key],
+    }),
+    initialValue,
+  )
 }

--- a/src/autoComplete/AutoComplete.story.mdx
+++ b/src/autoComplete/AutoComplete.story.mdx
@@ -91,7 +91,7 @@ Set a React element to the `inputAddon` props, here is an example with a button.
         <Button
           status={ButtonStatus.UNSTYLED}
           isBubble
-          tabIndex="-1"
+          tabIndex={-1}
           aria-hidden="true"
         >
           <SearchIcon size="18" />

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -24,7 +24,6 @@ export type ButtonProps = A11yProps &
     type?: string
     href?: string | JSX.Element
     className?: string
-    title?: string
     status?: ButtonStatus
     focus?: boolean
     isBubble?: boolean
@@ -37,7 +36,6 @@ export type ButtonProps = A11yProps &
     onTouchStart?: (event: React.TouchEvent<HTMLElement>) => void
     onTouchEnd?: (event: React.TouchEvent<HTMLElement>) => void
     onDoneAnimationEnd?: () => void
-    tabIndex?: string
     disabled?: boolean
     index?: string
     buttonRef?: (button: HTMLButtonElement) => void

--- a/src/itemChoice/ItemChoice.tsx
+++ b/src/itemChoice/ItemChoice.tsx
@@ -36,7 +36,6 @@ export type ItemChoiceProps = A11yProps &
     onFocus?: (event: React.FocusEventHandler<HTMLElement>) => void
     onMouseDown?: (event: React.MouseEvent<HTMLElement>) => void
     onDoneAnimationEnd?: () => void
-    tabIndex?: number
   }>
 
 export class ItemChoice extends PureComponent<ItemChoiceProps> {

--- a/src/phoneField/__snapshots__/PhoneField.unit.tsx.snap
+++ b/src/phoneField/__snapshots__/PhoneField.unit.tsx.snap
@@ -607,7 +607,7 @@ exports[`PhoneField should have the expected markup in the DOM with custom setti
             onMouseUp={[Function]}
             onTouchEnd={[Function]}
             onTouchStart={[Function]}
-            tabIndex="-1"
+            tabIndex={-1}
             type="button"
           >
             <svg

--- a/src/textField/TextField.tsx
+++ b/src/textField/TextField.tsx
@@ -313,7 +313,7 @@ export class TextField extends PureComponent<TextFieldProps, TextFieldState> {
               status={ButtonStatus.UNSTYLED}
               isBubble
               onClick={buttonOnClick}
-              tabIndex="-1"
+              tabIndex={-1}
               title={buttonTitle}
               aria-hidden={isEmpty(buttonTitle)}
               buttonRef={(elem: HTMLButtonElement) => {

--- a/src/textarea/Textarea.tsx
+++ b/src/textarea/Textarea.tsx
@@ -273,7 +273,7 @@ export class Textarea extends PureComponent<TextareaProps, TextAreaState> {
               status={ButtonStatus.UNSTYLED}
               isBubble
               onClick={onButtonClick}
-              tabIndex="0"
+              tabIndex={0}
               title={buttonTitle}
               buttonRef={(elem: HTMLButtonElement) => {
                 this.buttonRef = elem


### PR DESCRIPTION
## Description

Add title and tabIndex to A11yProps

## Demo

**If we add a `title` & `tabIndex` prop to the `Button` component:**
<img width="993" alt="Screenshot 2021-03-23 at 14 42 10" src="https://user-images.githubusercontent.com/4067977/112197720-ac1cd900-8c0c-11eb-89fe-8c2561b9d209.png">

## How it was tested

Unit tests + Storybook + Canary release
