### PR TITLE
Release/v57.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
+- [...]
+# v57.0.0 (24/03/2021)
 
 - **[BREAKING CHANGE]** Add `title` and `tabIndex` props to `A11yProps` interface and `pickA11yProps` function
-- [...]
 
 # v56.0.0 (22/03/2021)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "56.0.0",
+  "version": "57.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blablacar/ui-library",
-      "version": "56.0.0",
+      "version": "57.0.0",
       "license": "MIT",
       "dependencies": {
         "country-telephone-data": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "56.0.0",
+  "version": "57.0.0",
   "description": "BlaBlaCar React UI component library",
   "homepage": "https://blablacar.github.io/ui-library",
   "repository": {


### PR DESCRIPTION
## Description

**v57.0.0 (24/03/2021)**
- **[BREAKING CHANGE]** Add `title` and `tabIndex` props to `A11yProps` interface and `pickA11yProps` function

## How it was tested

Local environment with canary release.
