### PR TITLE
prevent itinerary from shrinking with long names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Unreleased
 
+- [...]
 - **[UPDATE]** Add `background` prop to `CheckShieldIcon`
 - **[NEW]** New `ScamsEducationIllustration`
-- [...]
+- **[FIX]** Prevent `NewItinerary` from visually breaking with long names
 
 # v58.0.0 (25/03/2021)
 

--- a/src/newItinerary/Itinerary.style.tsx
+++ b/src/newItinerary/Itinerary.style.tsx
@@ -18,6 +18,7 @@ export const StyledItinerary = styled.ul<ItineraryProps>`
     width: ${ITINERARY_TIME_WIDTH};
     padding-top: ${space.m};
     display: ${({ small }) => (small ? 'none' : 'initial')};
+    flex-shrink: 0;
   }
 
   // Remove line/icons left margin if small display

--- a/src/newItinerary/internals/Line.style.tsx
+++ b/src/newItinerary/internals/Line.style.tsx
@@ -15,6 +15,7 @@ export const StyledLineWrapper = styled.div`
   min-height: ${ITINERARY_ITEM_BASE_HEIGHT}px;
   margin: 0 ${space.m};
   width: ${space.m};
+  flex-shrink: 0;
 `
 
 // Using background-image to display the dashed line for connection


### PR DESCRIPTION
Video with problem & fix

https://user-images.githubusercontent.com/373381/113024550-2ad2c280-9187-11eb-8f28-a1088bc510fe.mp4

When a city name was too long and could not be naturally wrapped, it would take all the space, shrinking the time and line items. These 2 should not shrink.