### PR TITLE
Release/v59.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Unreleased
+- [...]
+# v59.0.0 (31/03/2021)
 
 - **[UPDATE]** Add `background` prop to `CheckShieldIcon`
 - **[NEW]** New `ScamsEducationIllustration`
 - **[FIX]** Prevent `NewItinerary` from visually breaking with long names
 - **[BREAKING CHANGE]** Remove `useInfoIcon` prop and add `icon` prop to `Disclamer`
-- [...]
 
 # v58.0.0 (25/03/2021)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blablacar/ui-library",
-      "version": "58.0.0",
+      "version": "59.0.0",
       "license": "MIT",
       "dependencies": {
         "country-telephone-data": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blablacar/ui-library",
-  "version": "58.0.0",
+  "version": "59.0.0",
   "description": "BlaBlaCar React UI component library",
   "homepage": "https://blablacar.github.io/ui-library",
   "repository": {


### PR DESCRIPTION
## Description

**v59.0.0 (31/03/2021)**
- **[UPDATE]** Add `background` prop to `CheckShieldIcon`
- **[NEW]** New `ScamsEducationIllustration`
- **[FIX]** Prevent `NewItinerary` from visually breaking with long names
- **[BREAKING CHANGE]** Remove `useInfoIcon` prop and add `icon` prop to `Disclamer`

