### PR TITLE
Fix ModalFooter display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+
+- **[FIX]** Fix `ModalFooter` border top and border radius display
+- **[UPDATE]** Remove `forwardedRef` prop to `Modal`, `SuccessModal` and `ConfirmationModal`
 - [...]
 # v59.0.0 (31/03/2021)
 

--- a/src/confirmationModal/ConfirmationModal.tsx
+++ b/src/confirmationModal/ConfirmationModal.tsx
@@ -43,7 +43,6 @@ export class ConfirmationModal extends Component<ConfirmationModalProps> {
       closeButtonTitle,
       onConfirm,
       confirmLabel,
-      forwardedRef,
       confirmIsLoading,
     } = this.props
 
@@ -82,7 +81,6 @@ export class ConfirmationModal extends Component<ConfirmationModalProps> {
         isOpen={isOpen}
         displayCloseButton={false}
         displayDimmer={false}
-        forwardedRef={forwardedRef}
         modalContentClassName={classNames}
         {...a11yAttrs}
       >

--- a/src/modal/Modal.style.tsx
+++ b/src/modal/Modal.style.tsx
@@ -117,6 +117,8 @@ export const ModalBody = styled.div`
 export const ModalFooter = styled.div`
   position: -webkit-sticky;
   position: sticky;
+  border-bottom-right-radius: ${radius.m};
+  border-bottom-left-radius: ${radius.m};
   bottom: 0;
   background-color: ${color.white};
   flex-shrink: 0;

--- a/src/modal/Modal.tsx
+++ b/src/modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { Component, Ref } from 'react'
+import React, { Component } from 'react'
 import { createPortal } from 'react-dom'
 import TransitionGroup from 'react-transition-group/TransitionGroup'
 import cc from 'classcat'
@@ -34,7 +34,6 @@ export type ModalProps = A11yProps &
     size?: ModalSize
     displayDimmer?: boolean
     closeButtonTitle?: string
-    forwardedRef?: Ref<HTMLDivElement>
     noHorizontalSpacing?: boolean
     layoutModeEnabled?: boolean
     isLoading?: boolean
@@ -44,6 +43,7 @@ export class Modal extends Component<ModalProps> {
   private portalNode: HTMLElement
   private contentNode: HTMLElement
   private focusTrap: FocusTrap
+  private setModalRef: (elem: HTMLDivElement) => void
 
   static defaultProps: Partial<ModalProps> = {
     isOpen: false,
@@ -52,17 +52,23 @@ export class Modal extends Component<ModalProps> {
     displayCloseButton: true,
     size: ModalSize.MEDIUM,
     displayDimmer: true,
-    forwardedRef: null,
     isLoading: false,
   }
 
   state = {
-    showFooterBorder: true,
+    showFooterBorder: false,
   }
 
   constructor(props: ModalProps) {
     super(props)
     if (canUseDOM) {
+      this.setModalRef = element => {
+        // Trigger the onScroll function in case of scrollable content
+        // to update the showFooterBorder state
+        if (element) {
+          element.dispatchEvent(new CustomEvent('scroll'))
+        }
+      }
       this.portalNode = document.createElement('div')
       document.body.appendChild(this.portalNode)
       this.focusTrap = createFocusTrap(this.portalNode)
@@ -140,10 +146,6 @@ export class Modal extends Component<ModalProps> {
     }
   }
 
-  refContent = (contentNode: HTMLElement) => {
-    this.contentNode = contentNode
-  }
-
   onEntered = () => {
     this.focusTrap.activate()
   }
@@ -187,7 +189,7 @@ export class Modal extends Component<ModalProps> {
             <CustomTransition animationName={AnimationType.SLIDE_UP} onEntered={this.onEntered}>
               <div
                 className={contentClassNames}
-                ref={this.props.forwardedRef}
+                ref={this.setModalRef}
                 {...a11yAttrs}
                 role="dialog"
                 aria-modal="true"

--- a/src/modal/__snapshots__/Modal.unit.tsx.snap
+++ b/src/modal/__snapshots__/Modal.unit.tsx.snap
@@ -398,7 +398,7 @@ exports[`Modal should not have changed 1`] = `
           </svg>
         </button>
         <div
-          className="kirk-modal-body kirk-modal-modalFooterBorder"
+          className="kirk-modal-body"
         />
       </div>
     </div>

--- a/src/modal/storyUtils/ModalOpener.tsx
+++ b/src/modal/storyUtils/ModalOpener.tsx
@@ -1,4 +1,4 @@
-import React, { Component, createRef } from 'react'
+import React, { Component } from 'react'
 
 import { FilterBar } from '../../filterBar'
 import { Fog } from '../../fog'
@@ -30,8 +30,6 @@ export class ModalOpener extends Component<ModalProps> {
   closeModal2 = () => {
     this.setState({ modalOpen2: false })
   }
-
-  ref = createRef<HTMLDivElement>()
 
   render() {
     return (

--- a/src/successModal/SuccessModal.tsx
+++ b/src/successModal/SuccessModal.tsx
@@ -16,7 +16,6 @@ export const SuccessModal = (props: SuccessModalProps): JSX.Element => {
   const {
     isOpen = false,
     onClose = () => {},
-    forwardedRef = null,
     confirmLabel,
     illustration,
     children,
@@ -42,7 +41,6 @@ export const SuccessModal = (props: SuccessModalProps): JSX.Element => {
       closeOnEsc={false}
       displayCloseButton={false}
       displayDimmer={false}
-      forwardedRef={forwardedRef}
       className={className}
       modalContentClassName={baseClassName}
       aria-labelledby={successContentId}

--- a/src/successModal/SuccessModal.unit.tsx
+++ b/src/successModal/SuccessModal.unit.tsx
@@ -9,7 +9,6 @@ const defaultProps = {
   illustration: <img src="https://svgshare.com/i/AGz.svg" alt="Illustration description" />,
   closeOnEsc: true,
   onClose: () => {},
-  forwardedRef: null,
 }
 
 describe('<SuccessModal>', () => {


### PR DESCRIPTION
## Description

**This PR fixe:**
- Don't Display the ModalFooter border if no scrollable content
- Keep bottom border-radius on no fullscreen display (desktop)

**Previous issues:**
**Footer border display without scrollable content:**
<img width="327" alt="Screenshot 2021-04-01 at 10 52 30" src="https://user-images.githubusercontent.com/4067977/113300339-182ec980-92fe-11eb-927b-25c763ca31da.png">

**Missing border-radius:**
<img width="726" alt="Screenshot 2021-04-01 at 14 59 04" src="https://user-images.githubusercontent.com/4067977/113300536-4f04df80-92fe-11eb-8315-411ded22cab3.png">


## Demo
**Modal with scrollable content - Display footer border**
https://www.loom.com/share/fb2363423caa428081842f8091b923ac

**Modal without scrollable content - Don't display footer border**
https://www.loom.com/share/5b34abcb3eff4e87beb480eecb523fe3

## How it was tested

Local environment with ui-library + Canary release
